### PR TITLE
fix: Guard against stack overflow in parse_table_and_joins

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9334,6 +9334,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_table_and_joins(&mut self) -> Result<TableWithJoins, ParserError> {
+        let _guard = self.recursion_counter.try_decrease()?;
         let relation = self.parse_table_factor()?;
         // Note that for keywords to be properly handled here, they need to be
         // added to `RESERVED_FOR_TABLE_ALIAS`, otherwise they may be parsed as

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8839,6 +8839,13 @@ fn parse_deeply_nested_subquery_expr_hits_recursion_limits() {
 }
 
 #[test]
+fn parse_deeply_nested_update_hits_recursion_limits() {
+    let sql = format!("UPDATE {}", "(".repeat(1000));
+    let res = parse_sql_statements(&sql);
+    assert_eq!(ParserError::RecursionLimitExceeded, res.unwrap_err());
+}
+
+#[test]
 fn parse_with_recursion_limit() {
     let dialect = GenericDialect {};
 


### PR DESCRIPTION
It possible to hit a stack overflow due to `parse_table_and_joins`
calling `parse_table_factor` which then calls `parse_table_and_joins`.

This fixes the issue by adding a recurssion guard in
`parse_table_and_joins`.

Found by running the fuzzer.
