### PR TITLE
Snowflake: support of views column comment

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -992,6 +992,7 @@ impl fmt::Display for ColumnDef {
 /// ```sql
 /// name
 /// age OPTIONS(description = "age column", tag = "prod")
+/// amount COMMENT 'The total amount for the order line'
 /// created_at DateTime64
 /// ```
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1000,7 +1001,7 @@ impl fmt::Display for ColumnDef {
 pub struct ViewColumnDef {
     pub name: Ident,
     pub data_type: Option<DataType>,
-    pub options: Option<Vec<SqlOption>>,
+    pub options: Option<Vec<ColumnOption>>,
 }
 
 impl fmt::Display for ViewColumnDef {
@@ -1010,11 +1011,7 @@ impl fmt::Display for ViewColumnDef {
             write!(f, " {}", data_type)?;
         }
         if let Some(options) = self.options.as_ref() {
-            write!(
-                f,
-                " OPTIONS({})",
-                display_comma_separated(options.as_slice())
-            )?;
+            write!(f, " {}", display_comma_separated(options.as_slice()))?;
         }
         Ok(())
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3831,18 +3831,18 @@ impl fmt::Display for Statement {
                         .map(|to| format!(" TO {to}"))
                         .unwrap_or_default()
                 )?;
+                if !columns.is_empty() {
+                    write!(f, " ({})", display_comma_separated(columns))?;
+                }
+                if matches!(options, CreateTableOptions::With(_)) {
+                    write!(f, " {options}")?;
+                }
                 if let Some(comment) = comment {
                     write!(
                         f,
                         " COMMENT = '{}'",
                         value::escape_single_quote_string(comment)
                     )?;
-                }
-                if matches!(options, CreateTableOptions::With(_)) {
-                    write!(f, " {options}")?;
-                }
-                if !columns.is_empty() {
-                    write!(f, " ({})", display_comma_separated(columns))?;
                 }
                 if !cluster_by.is_empty() {
                     write!(f, " CLUSTER BY ({})", display_comma_separated(cluster_by))?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8193,16 +8193,10 @@ impl<'a> Parser<'a> {
     fn parse_view_column(&mut self) -> Result<ViewColumnDef, ParserError> {
         let name = self.parse_identifier(false)?;
         let mut options = vec![];
-        if dialect_of!(self is BigQueryDialect | GenericDialect)
-            && self.parse_keyword(Keyword::OPTIONS)
-        {
-            self.prev_token();
-            if let Some(option) = self.parse_optional_column_option()? {
-                options.push(option);
-            }
-        };
-        if dialect_of!(self is SnowflakeDialect | GenericDialect)
-            && self.parse_keyword(Keyword::COMMENT)
+        if (dialect_of!(self is BigQueryDialect | GenericDialect)
+            && self.parse_keyword(Keyword::OPTIONS))
+            || (dialect_of!(self is SnowflakeDialect | GenericDialect)
+                && self.parse_keyword(Keyword::COMMENT))
         {
             self.prev_token();
             if let Some(option) = self.parse_optional_column_option()? {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8197,26 +8197,25 @@ impl<'a> Parser<'a> {
             && self.parse_keyword(Keyword::OPTIONS)
         {
             self.prev_token();
-            let option = ColumnOption::Options(self.parse_options(Keyword::OPTIONS)?);
-            options.push(option);
+            if let Some(option) = self.parse_optional_column_option()? {
+                options.push(option);
+            }
         };
         if dialect_of!(self is SnowflakeDialect | GenericDialect)
             && self.parse_keyword(Keyword::COMMENT)
         {
-            let next_token = self.next_token();
-            let option = match next_token.token {
-                Token::SingleQuotedString(str) => ColumnOption::Comment(str),
-                _ => self.expected("string literal", next_token)?,
-            };
-            options.push(option);
-        };
-        let data_type = if dialect_of!(self is ClickHouseDialect) {
-            Some(self.parse_data_type()?)
-        } else {
-            None
+            self.prev_token();
+            if let Some(option) = self.parse_optional_column_option()? {
+                options.push(option);
+            }
         };
         let options = if !options.is_empty() {
             Some(options)
+        } else {
+            None
+        };
+        let data_type = if dialect_of!(self is ClickHouseDialect) {
+            Some(self.parse_data_type()?)
         } else {
             None
         };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8192,19 +8192,14 @@ impl<'a> Parser<'a> {
     /// Parses a column definition within a view.
     fn parse_view_column(&mut self) -> Result<ViewColumnDef, ParserError> {
         let name = self.parse_identifier(false)?;
-        let mut options = vec![];
-        if (dialect_of!(self is BigQueryDialect | GenericDialect)
+        let options = if (dialect_of!(self is BigQueryDialect | GenericDialect)
             && self.parse_keyword(Keyword::OPTIONS))
             || (dialect_of!(self is SnowflakeDialect | GenericDialect)
                 && self.parse_keyword(Keyword::COMMENT))
         {
             self.prev_token();
-            if let Some(option) = self.parse_optional_column_option()? {
-                options.push(option);
-            }
-        };
-        let options = if !options.is_empty() {
-            Some(options)
+            self.parse_optional_column_option()?
+                .map(|option| vec![option])
         } else {
             None
         };

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -267,10 +267,10 @@ fn parse_create_view_with_options() {
                     ViewColumnDef {
                         name: Ident::new("age"),
                         data_type: None,
-                        options: Some(vec![SqlOption::KeyValue {
+                        options: Some(vec![ColumnOption::Options(vec![SqlOption::KeyValue {
                             key: Ident::new("description"),
                             value: Expr::Value(Value::DoubleQuotedString("field age".to_string())),
-                        }])
+                        }])]),
                     },
                 ],
                 columns

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2406,6 +2406,7 @@ fn view_comment_option_should_be_after_column_list() {
     for sql in [
         "CREATE OR REPLACE VIEW v (a) COMMENT = 'Comment' AS SELECT a FROM t",
         "CREATE OR REPLACE VIEW v (a COMMENT 'a comment', b, c COMMENT 'c comment') COMMENT = 'Comment' AS SELECT a FROM t",
+        "CREATE OR REPLACE VIEW v (a COMMENT 'a comment', b, c COMMENT 'c comment') WITH (foo = bar) COMMENT = 'Comment' AS SELECT a FROM t",
     ] {
         snowflake_and_generic()
             .verified_stmt(sql);

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2400,3 +2400,29 @@ fn parse_use() {
         );
     }
 }
+
+#[test]
+fn parse_view_column_descriptions() {
+    let sql = "CREATE OR REPLACE VIEW v (a COMMENT 'Comment of field') COMMENT = 'Comment of view' AS SELECT a FROM table1 AS o";
+
+    match snowflake_and_generic().verified_stmt(sql) {
+        Statement::CreateView {
+            name,
+            columns,
+            comment,
+            ..
+        } => {
+            assert_eq!(name.to_string(), "v");
+            assert_eq!(comment, Some("Comment of view".to_string()));
+            assert_eq!(
+                columns,
+                vec![ViewColumnDef {
+                    name: Ident::new("a"),
+                    data_type: None,
+                    options: Some(vec![ColumnOption::Comment("Comment of field".to_string())]),
+                },]
+            );
+        }
+        _ => unreachable!(),
+    };
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2403,8 +2403,13 @@ fn parse_use() {
 
 #[test]
 fn view_comment_option_should_be_after_column_list() {
-    snowflake_and_generic()
-        .verified_stmt("CREATE OR REPLACE VIEW v (a) COMMENT = 'Comment' AS SELECT a FROM t");
+    for sql in [
+        "CREATE OR REPLACE VIEW v (a) COMMENT = 'Comment' AS SELECT a FROM t",
+        "CREATE OR REPLACE VIEW v (a COMMENT 'a comment', b, c COMMENT 'c comment') COMMENT = 'Comment' AS SELECT a FROM t",
+    ] {
+        snowflake_and_generic()
+            .verified_stmt(sql);
+    }
 }
 
 #[test]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2402,25 +2402,33 @@ fn parse_use() {
 }
 
 #[test]
+fn view_comment_option_should_be_after_column_list() {
+    snowflake_and_generic()
+        .verified_stmt("CREATE OR REPLACE VIEW v (a) COMMENT = 'Comment' AS SELECT a FROM t");
+}
+
+#[test]
 fn parse_view_column_descriptions() {
-    let sql = "CREATE OR REPLACE VIEW v (a COMMENT 'Comment of field') COMMENT = 'Comment of view' AS SELECT a FROM table1 AS o";
+    let sql =
+        "CREATE OR REPLACE VIEW v (a COMMENT 'Comment', b) AS SELECT a, b FROM table1";
 
     match snowflake_and_generic().verified_stmt(sql) {
-        Statement::CreateView {
-            name,
-            columns,
-            comment,
-            ..
-        } => {
+        Statement::CreateView { name, columns, .. } => {
             assert_eq!(name.to_string(), "v");
-            assert_eq!(comment, Some("Comment of view".to_string()));
             assert_eq!(
                 columns,
-                vec![ViewColumnDef {
-                    name: Ident::new("a"),
-                    data_type: None,
-                    options: Some(vec![ColumnOption::Comment("Comment of field".to_string())]),
-                },]
+                vec![
+                    ViewColumnDef {
+                        name: Ident::new("a"),
+                        data_type: None,
+                        options: Some(vec![ColumnOption::Comment("Comment".to_string())]),
+                    },
+                    ViewColumnDef {
+                        name: Ident::new("b"),
+                        data_type: None,
+                        options: None,
+                    }
+                ]
             );
         }
         _ => unreachable!(),

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2409,8 +2409,7 @@ fn view_comment_option_should_be_after_column_list() {
 
 #[test]
 fn parse_view_column_descriptions() {
-    let sql =
-        "CREATE OR REPLACE VIEW v (a COMMENT 'Comment', b) AS SELECT a, b FROM table1";
+    let sql = "CREATE OR REPLACE VIEW v (a COMMENT 'Comment', b) AS SELECT a, b FROM table1";
 
     match snowflake_and_generic().verified_stmt(sql) {
         Statement::CreateView { name, columns, .. } => {


### PR DESCRIPTION
[Snowflake supports](https://docs.snowflake.com/en/sql-reference/sql/create-view) adding comments to fields within a view:

```sql
CREATE OR REPLACE VIEW v (a COMMENT 'Comment of field') AS SELECT a FROM table1
```

This MR introduces support for this feature.

Additionally, I noticed that the view's comment was not in the correct order—this issue surfaced while testing with a large query from a Snowflake production environment. The comment for the view should appear after the column list. I've included this minor fix in this MR as well. Please let me know if you think it would be better to address this in a separate MR.