### PR TITLE
Add SQLite "ON CONFLICT" column option in CREATE TABLE statements

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -33,6 +33,7 @@ use crate::ast::{
     display_comma_separated, display_separated, DataType, Expr, Ident, MySQLColumnPosition,
     ObjectName, OrderByExpr, ProjectionSelect, SequenceOptions, SqlOption, Value,
 };
+use crate::keywords::Keyword;
 use crate::tokenizer::Token;
 
 /// An `ALTER TABLE` (`Statement::AlterTable`) operation
@@ -1146,6 +1147,9 @@ pub enum ColumnOption {
     /// ```
     /// [MS SQL Server]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property
     Identity(Option<IdentityProperty>),
+    /// Sqlite specific: ON CONFLICT option on column definition
+    /// https://www.sqlite.org/lang_conflict.html
+    OnConflict(Keyword),
 }
 
 impl fmt::Display for ColumnOption {
@@ -1252,6 +1256,10 @@ impl fmt::Display for ColumnOption {
                 if let Some(parameters) = parameters {
                     write!(f, "({parameters})")?;
                 }
+                Ok(())
+            }
+            OnConflict(keyword) => {
+                write!(f, "ON CONFLICT {:?}", keyword)?;
                 Ok(())
             }
         }

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1147,8 +1147,8 @@ pub enum ColumnOption {
     /// ```
     /// [MS SQL Server]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property
     Identity(Option<IdentityProperty>),
-    /// Sqlite specific: ON CONFLICT option on column definition
-    /// https://www.sqlite.org/lang_conflict.html
+    /// SQLite specific: ON CONFLICT option on column definition
+    /// <https://www.sqlite.org/lang_conflict.html>
     OnConflict(Keyword),
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6096,10 +6096,7 @@ impl<'a> Parser<'a> {
             ]);
             match on_confl {
                 Some(keyword) => Ok(Some(ColumnOption::OnConflict(keyword))),
-                _ => self.expected(
-                    "one of ROLLBACK, ABORT, FAIL, IGNORE or REPLACE",
-                    self.peek_token(),
-                ),
+                _ => unreachable!()
             }
         } else {
             Ok(None)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6083,6 +6083,24 @@ impl<'a> Parser<'a> {
                 None
             };
             Ok(Some(ColumnOption::Identity(property)))
+        } else if dialect_of!(self is SQLiteDialect)
+            && self.parse_keywords(&[Keyword::ON, Keyword::CONFLICT])
+        {
+            // Support ON CONFLICT for SQLite
+            let on_confl = self.parse_one_of_keywords(&[
+                Keyword::ROLLBACK,
+                Keyword::ABORT,
+                Keyword::FAIL,
+                Keyword::IGNORE,
+                Keyword::REPLACE,
+            ]);
+            match on_confl {
+                Some(keyword) => Ok(Some(ColumnOption::OnConflict(keyword))),
+                _ => self.expected(
+                    "one of ROLLBACK, ABORT, FAIL, IGNORE or REPLACE",
+                    self.peek_token(),
+                ),
+            }
         } else {
             Ok(None)
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6083,7 +6083,7 @@ impl<'a> Parser<'a> {
                 None
             };
             Ok(Some(ColumnOption::Identity(property)))
-        } else if dialect_of!(self is SQLiteDialect)
+        } else if dialect_of!(self is SQLiteDialect | GenericDialect)
             && self.parse_keywords(&[Keyword::ON, Keyword::CONFLICT])
         {
             // Support ON CONFLICT for SQLite

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6087,16 +6087,16 @@ impl<'a> Parser<'a> {
             && self.parse_keywords(&[Keyword::ON, Keyword::CONFLICT])
         {
             // Support ON CONFLICT for SQLite
-            let on_confl = self.parse_one_of_keywords(&[
+            let on_conflict = self.parse_one_of_keywords(&[
                 Keyword::ROLLBACK,
                 Keyword::ABORT,
                 Keyword::FAIL,
                 Keyword::IGNORE,
                 Keyword::REPLACE,
             ]);
-            match on_confl {
+            match on_conflict {
                 Some(keyword) => Ok(Some(ColumnOption::OnConflict(keyword))),
-                _ => unreachable!()
+                _ => unreachable!(),
             }
         } else {
             Ok(None)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6087,17 +6087,15 @@ impl<'a> Parser<'a> {
             && self.parse_keywords(&[Keyword::ON, Keyword::CONFLICT])
         {
             // Support ON CONFLICT for SQLite
-            let on_conflict = self.parse_one_of_keywords(&[
-                Keyword::ROLLBACK,
-                Keyword::ABORT,
-                Keyword::FAIL,
-                Keyword::IGNORE,
-                Keyword::REPLACE,
-            ]);
-            match on_conflict {
-                Some(keyword) => Ok(Some(ColumnOption::OnConflict(keyword))),
-                _ => unreachable!(),
-            }
+            Ok(Some(ColumnOption::OnConflict(
+                self.expect_one_of_keywords(&[
+                    Keyword::ROLLBACK,
+                    Keyword::ABORT,
+                    Keyword::FAIL,
+                    Keyword::IGNORE,
+                    Keyword::REPLACE,
+                ])?,
+            )))
         } else {
             Ok(None)
         }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -308,10 +308,18 @@ fn parse_create_table_on_conflict_col() {
 }
 
 #[test]
-#[should_panic]
 fn test_parse_create_table_on_conflict_col_err() {
     let sql_err = "CREATE TABLE t1 (a INT, b INT ON CONFLICT BOH)";
-    let _ = sqlite().parse_sql_statements(sql_err);
+    let err = sqlite_and_generic()
+        .parse_sql_statements(sql_err)
+        .unwrap_err();
+    assert_eq!(
+        err,
+        ParserError::ParserError(
+            "Expected: one of ROLLBACK or ABORT or FAIL or IGNORE or REPLACE, found: BOH"
+                .to_string()
+        )
+    );
 }
 
 #[test]

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -282,6 +282,104 @@ fn parse_create_table_gencol() {
 }
 
 #[test]
+fn parse_create_table_on_conflict_col() {
+    let sql_rollback = "CREATE TABLE t1 (a INT, b INT ON CONFLICT ROLLBACK)";
+    match sqlite().verified_stmt(sql_rollback) {
+        Statement::CreateTable(CreateTable { name, columns, .. }) => {
+            assert_eq!(name.to_string(), "t1");
+            assert_eq!(
+                vec![
+                    ColumnDef {
+                        name: Ident::new("a"),
+                        data_type: DataType::Int(None),
+                        collation: None,
+                        options: vec![],
+                    },
+                    ColumnDef {
+                        name: Ident::new("b"), //::with_quote('[', "BINDEX"),
+                        data_type: DataType::Int(None),
+                        collation: None,
+                        options: vec![ColumnOptionDef {
+                            name: None,
+                            option: ColumnOption::OnConflict(
+                                sqlparser::keywords::Keyword::ROLLBACK
+                            ),
+                        }],
+                    },
+                ],
+                columns
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    let sql_abort = "CREATE TABLE t1 (a INT, b INT ON CONFLICT ABORT)";
+    match sqlite().verified_stmt(sql_abort) {
+        Statement::CreateTable(CreateTable { columns, .. }) => {
+            assert_eq!(
+                vec![ColumnOptionDef {
+                    name: None,
+                    option: ColumnOption::OnConflict(sqlparser::keywords::Keyword::ABORT),
+                }],
+                columns[1].options
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    let sql_fail = "CREATE TABLE t1 (a INT, b INT ON CONFLICT FAIL)";
+    match sqlite().verified_stmt(sql_fail) {
+        Statement::CreateTable(CreateTable { columns, .. }) => {
+            assert_eq!(
+                vec![ColumnOptionDef {
+                    name: None,
+                    option: ColumnOption::OnConflict(sqlparser::keywords::Keyword::FAIL),
+                }],
+                columns[1].options
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    let sql_ignore = "CREATE TABLE t1 (a INT, b INT ON CONFLICT IGNORE)";
+    match sqlite().verified_stmt(sql_ignore) {
+        Statement::CreateTable(CreateTable { columns, .. }) => {
+            assert_eq!(
+                vec![ColumnOptionDef {
+                    name: None,
+                    option: ColumnOption::OnConflict(sqlparser::keywords::Keyword::IGNORE),
+                }],
+                columns[1].options
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    let sql_replace = "CREATE TABLE t1 (a INT, b INT ON CONFLICT REPLACE)";
+    match sqlite().verified_stmt(sql_replace) {
+        Statement::CreateTable(CreateTable { columns, .. }) => {
+            assert_eq!(
+                vec![ColumnOptionDef {
+                    name: None,
+                    option: ColumnOption::OnConflict(sqlparser::keywords::Keyword::REPLACE),
+                }],
+                columns[1].options
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    let sql_err = "CREATE TABLE t1 (a INT, b INT ON CONFLICT BOH)";
+    assert_eq!(
+        "sql parser error: Expected: one of ROLLBACK, ABORT, FAIL, IGNORE or REPLACE, found: BOH",
+        sqlite()
+            .parse_sql_statements(sql_err)
+            .unwrap_err()
+            .to_string()
+    );
+}
+
+#[test]
 fn parse_create_table_untyped() {
     sqlite().verified_stmt("CREATE TABLE t1 (a, b AS (a * 2), c NOT NULL)");
 }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -292,7 +292,7 @@ fn parse_create_table_on_conflict_col() {
         Keyword::REPLACE,
     ] {
         let sql = format!("CREATE TABLE t1 (a INT, b INT ON CONFLICT {:?})", keyword);
-        match sqlite().verified_stmt(&sql) {
+        match sqlite_and_generic().verified_stmt(&sql) {
             Statement::CreateTable(CreateTable { columns, .. }) => {
                 assert_eq!(
                     vec![ColumnOptionDef {


### PR DESCRIPTION
Thank you for all the work done on the parser, I hope this can be of any utility.

### Original issue

I was parsing `CREATE TABLE` statements when I discovered that SQLite allows for a non-standard `ON CONFLICT` option related to columns:

https://www.sqlite.org/lang_conflict.html

Considering an example from https://database.guide/how-on-conflict-works-in-sqlite/ the following sql statement could not be parsed:

```sql
CREATE TABLE Products( 
    ProductId INTEGER PRIMARY KEY, 
    ProductName NOT NULL ON CONFLICT IGNORE, 
    Price
);
```

resulting in the following error

```
ParserError("Expected: ',' or ')' after column definition ...
```

### Description of the syntax

Basically there is a column option that allows to specify how to handle conflicts in case of specific columns. The syntax seemed to me very clear in the plot at https://www.sqlite.org/syntax/conflict-clause.html, in which th keywords `ON CONFLICT` are followed by one of the keywords `[ROLLBACK, ABORT, FAIL, IGNORE, REPLACE]`

### My implementation

I noticed that the error originated in function `parse_columns` at

https://github.com/sqlparser-rs/sqlparser-rs/blob/affe8b549884a351ead4f35aa8bdf4cae8c93e4b/src/parser/mod.rs#L5874-L5879

when the parser did not recognize the option, still didn't find a comma.

So I added a column option parsing in function `parse_optional_column_option`:

https://github.com/nucccc/sqlparser-rs/blob/6154f66dc3bad88c87c40750ee882a23fb894a56/src/parser/mod.rs#L6086-L6103

in which if the dialect is SQLite (only SQL syntax I know that allows for this option) and the keywords `ON` and `CONFLICT` follow, it then checks if any of `[ROLLBACK, ABORT, FAIL, IGNORE, REPLACE]` is then present. In case none of them are found, a parser error is returned.

I added a dedicated column option `OnConflict(Keyword)`. I thought to make it accept a keyword, since the option is characterized by one of the 5 possible subsequent keywords.

I don't know if an `Expr` would have been a more appropriate choice instead of the `Keyword` enum. Most of the other column options accept an `Expr`, no one was accepting a `Keyword` from what I noticed.

I admit my limited knowledge of this codebase (maybe the `Keyword` concept does not need to exist at the ddl level). In case there is a better way to represent this column option I would kindly accept any suggestion.

I did my best in implementing an appropriate unit test.

### Caveats

From what I read on https://www.sqlite.org/lang_conflict.html "The ON CONFLICT clause applies to UNIQUE, NOT NULL, CHECK, and PRIMARY KEY constraints." In my implementation the presence of these constraints on the column is not taken into account, but it seemed to me (from the repo's readme) that this library concerns syntax, not semantics. So I thought maybe it's an upper level problem to verify that the `ON CONFLICT` clause is applied on a column with one of the above mentioned constraints.