### PR TITLE
Expand handling of `LIMIT 1, 2` handling to include sqlite

### DIFF
--- a/src/dialect/clickhouse.rs
+++ b/src/dialect/clickhouse.rs
@@ -46,4 +46,8 @@ impl Dialect for ClickHouseDialect {
     fn require_interval_qualifier(&self) -> bool {
         true
     }
+
+    fn supports_limit_comma(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -99,4 +99,8 @@ impl Dialect for GenericDialect {
     fn supports_explain_with_utility_options(&self) -> bool {
         true
     }
+
+    fn supports_limit_comma(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -60,7 +60,7 @@ use alloc::boxed::Box;
 
 /// Convenience check if a [`Parser`] uses a certain dialect.
 ///
-/// `dialect_of!(parser Is SQLiteDialect |  GenericDialect)` evaluates
+/// `dialect_of!(parser is SQLiteDialect |  GenericDialect)` evaluates
 /// to `true` if `parser.dialect` is one of the [`Dialect`]s specified.
 macro_rules! dialect_of {
     ( $parsed_dialect: ident is $($dialect_type: ty)|+ ) => {

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -316,6 +316,11 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Does the dialect support parsing `LIMIT 1, 2` as `LIMIT 2 OFFSET 1`?
+    fn supports_limit_comma(&self) -> bool {
+        false
+    }
+
     /// Does the dialect support trailing commas in the projection list?
     fn supports_projection_trailing_commas(&self) -> bool {
         self.supports_trailing_commas()

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -93,6 +93,10 @@ impl Dialect for MySqlDialect {
     fn require_interval_qualifier(&self) -> bool {
         true
     }
+
+    fn supports_limit_comma(&self) -> bool {
+        true
+    }
 }
 
 /// `LOCK TABLES`

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -73,4 +73,8 @@ impl Dialect for SQLiteDialect {
     fn supports_in_empty_list(&self) -> bool {
         true
     }
+
+    fn supports_limit_comma(&self) -> bool {
+        true
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8715,7 +8715,7 @@ impl<'a> Parser<'a> {
                     offset = Some(self.parse_offset()?)
                 }
 
-                if dialect_of!(self is GenericDialect | MySqlDialect | ClickHouseDialect)
+                if dialect_of!(self is GenericDialect | MySqlDialect | ClickHouseDialect | SQLiteDialect)
                     && limit.is_some()
                     && offset.is_none()
                     && self.consume_token(&Token::Comma)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8715,7 +8715,7 @@ impl<'a> Parser<'a> {
                     offset = Some(self.parse_offset()?)
                 }
 
-                if dialect_of!(self is GenericDialect | MySqlDialect | ClickHouseDialect | SQLiteDialect)
+                if self.dialect.supports_limit_comma()
                     && limit.is_some()
                     && offset.is_none()
                     && self.consume_token(&Token::Comma)

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -211,22 +211,27 @@ impl TestedDialects {
 
 /// Returns all available dialects.
 pub fn all_dialects() -> TestedDialects {
-    let all_dialects = vec![
-        Box::new(GenericDialect {}) as Box<dyn Dialect>,
-        Box::new(PostgreSqlDialect {}) as Box<dyn Dialect>,
-        Box::new(MsSqlDialect {}) as Box<dyn Dialect>,
-        Box::new(AnsiDialect {}) as Box<dyn Dialect>,
-        Box::new(SnowflakeDialect {}) as Box<dyn Dialect>,
-        Box::new(HiveDialect {}) as Box<dyn Dialect>,
-        Box::new(RedshiftSqlDialect {}) as Box<dyn Dialect>,
-        Box::new(MySqlDialect {}) as Box<dyn Dialect>,
-        Box::new(BigQueryDialect {}) as Box<dyn Dialect>,
-        Box::new(SQLiteDialect {}) as Box<dyn Dialect>,
-        Box::new(DuckDbDialect {}) as Box<dyn Dialect>,
-        Box::new(DatabricksDialect {}) as Box<dyn Dialect>,
-    ];
+    specific_dialects(vec![
+        Box::new(GenericDialect {}),
+        Box::new(PostgreSqlDialect {}),
+        Box::new(MsSqlDialect {}),
+        Box::new(AnsiDialect {}),
+        Box::new(SnowflakeDialect {}),
+        Box::new(HiveDialect {}),
+        Box::new(RedshiftSqlDialect {}),
+        Box::new(MySqlDialect {}),
+        Box::new(BigQueryDialect {}),
+        Box::new(SQLiteDialect {}),
+        Box::new(DuckDbDialect {}),
+        Box::new(DatabricksDialect {}),
+        Box::new(ClickHouseDialect {}),
+    ])
+}
+
+/// Returns a specific set of dialects.
+pub fn specific_dialects(dialects: Vec<Box<dyn Dialect>>) -> TestedDialects {
     TestedDialects {
-        dialects: all_dialects,
+        dialects,
         options: None,
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -47,6 +47,14 @@ pub struct TestedDialects {
 }
 
 impl TestedDialects {
+    /// Create a TestedDialects with default options and the given dialects.
+    pub fn new(dialects: Vec<Box<dyn Dialect>>) -> Self {
+        Self {
+            dialects,
+            options: None,
+        }
+    }
+
     fn new_parser<'a>(&self, dialect: &'a dyn Dialect) -> Parser<'a> {
         let parser = Parser::new(dialect);
         if let Some(options) = &self.options {
@@ -211,7 +219,7 @@ impl TestedDialects {
 
 /// Returns all available dialects.
 pub fn all_dialects() -> TestedDialects {
-    specific_dialects(vec![
+    TestedDialects::new(vec![
         Box::new(GenericDialect {}),
         Box::new(PostgreSqlDialect {}),
         Box::new(MsSqlDialect {}),
@@ -226,14 +234,6 @@ pub fn all_dialects() -> TestedDialects {
         Box::new(DatabricksDialect {}),
         Box::new(ClickHouseDialect {}),
     ])
-}
-
-/// Returns a specific set of dialects.
-pub fn specific_dialects(dialects: Vec<Box<dyn Dialect>>) -> TestedDialects {
-    TestedDialects {
-        dialects,
-        options: None,
-    }
 }
 
 /// Returns all dialects matching the given predicate.

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -39,7 +39,7 @@ use sqlparser::parser::{Parser, ParserError, ParserOptions};
 use sqlparser::tokenizer::Tokenizer;
 use test_utils::{
     all_dialects, all_dialects_where, alter_table_op, assert_eq_vec, call, expr_from_projection,
-    join, number, only, specific_dialects, table, table_alias, TestedDialects,
+    join, number, only, table, table_alias, TestedDialects,
 };
 
 #[macro_use]
@@ -6795,7 +6795,8 @@ fn parse_create_view_with_options() {
 #[test]
 fn parse_create_view_with_columns() {
     let sql = "CREATE VIEW v (has, cols) AS SELECT 1, 2";
-    // TODO: why does this fail for ClickHouseDialect?
+    // TODO: why does this fail for ClickHouseDialect? (#1449)
+    // match all_dialects().verified_stmt(sql) {
     match all_dialects_except(|d| d.is::<ClickHouseDialect>()).verified_stmt(sql) {
         Statement::CreateView {
             name,
@@ -8601,7 +8602,7 @@ fn parse_offset_and_limit() {
     one_statement_parses_to("SELECT foo FROM bar OFFSET 2 LIMIT 1", sql);
 
     // mysql syntax is ok for some dialects
-    specific_dialects(vec![
+    TestedDialects::new(vec![
         Box::new(GenericDialect {}),
         Box::new(MySqlDialect {}),
         Box::new(SQLiteDialect {}),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -39,7 +39,7 @@ use sqlparser::parser::{Parser, ParserError, ParserOptions};
 use sqlparser::tokenizer::Tokenizer;
 use test_utils::{
     all_dialects, all_dialects_where, alter_table_op, assert_eq_vec, call, expr_from_projection,
-    join, number, only, table, table_alias, TestedDialects,
+    join, number, only, specific_dialects, table, table_alias, TestedDialects,
 };
 
 #[macro_use]
@@ -6795,7 +6795,8 @@ fn parse_create_view_with_options() {
 #[test]
 fn parse_create_view_with_columns() {
     let sql = "CREATE VIEW v (has, cols) AS SELECT 1, 2";
-    match verified_stmt(sql) {
+    // TODO: why does this fail for ClickHouseDialect?
+    match all_dialects_except(|d| d.is::<ClickHouseDialect>()).verified_stmt(sql) {
         Statement::CreateView {
             name,
             columns,
@@ -8587,17 +8588,26 @@ fn verified_expr(query: &str) -> Expr {
 
 #[test]
 fn parse_offset_and_limit() {
-    let sql = "SELECT foo FROM bar LIMIT 2 OFFSET 2";
+    let sql = "SELECT foo FROM bar LIMIT 1 OFFSET 2";
     let expect = Some(Offset {
         value: Expr::Value(number("2")),
         rows: OffsetRows::None,
     });
     let ast = verified_query(sql);
     assert_eq!(ast.offset, expect);
-    assert_eq!(ast.limit, Some(Expr::Value(number("2"))));
+    assert_eq!(ast.limit, Some(Expr::Value(number("1"))));
 
     // different order is OK
-    one_statement_parses_to("SELECT foo FROM bar OFFSET 2 LIMIT 2", sql);
+    one_statement_parses_to("SELECT foo FROM bar OFFSET 2 LIMIT 1", sql);
+
+    // mysql syntax is ok for some dialects
+    specific_dialects(vec![
+        Box::new(GenericDialect {}),
+        Box::new(MySqlDialect {}),
+        Box::new(SQLiteDialect {}),
+        Box::new(ClickHouseDialect {}),
+    ])
+    .one_statement_parses_to("SELECT foo FROM bar LIMIT 2, 1", sql);
 
     // expressions are allowed
     let sql = "SELECT foo FROM bar LIMIT 1 + 2 OFFSET 3 * 4";


### PR DESCRIPTION
Sqlite itself parses this syntax, so this parser should parse it when operating in sqlite mode.

Tangential fixups:
* I also noticed that ClickhouseDialect was missing from `all_dialects()`, so I rectified that. This required excluding ClickhouseDialect from one existing test, but it works everywhere else.
* Added `TestedDialects::new(...)` function to more cleanly be able to specify exactly the dialects this LIMIT comma syntax works for, in tests
* Added a test for `LIMIT 1, 2`
* (very minor) fix capitalization of `is` in doc comment for `dialect_of!` macro
