### PR TITLE
added ability to parse extension to parse_comment inside postgres dialect

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1843,6 +1843,7 @@ impl fmt::Display for ShowCreateObject {
 pub enum CommentObject {
     Column,
     Table,
+    Extension,
 }
 
 impl fmt::Display for CommentObject {
@@ -1850,6 +1851,7 @@ impl fmt::Display for CommentObject {
         match self {
             CommentObject::Column => f.write_str("COLUMN"),
             CommentObject::Table => f.write_str("TABLE"),
+            CommentObject::Extension => f.write_str("EXTENSION"),
         }
     }
 }

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -205,6 +205,10 @@ pub fn parse_comment(parser: &mut Parser) -> Result<Statement, ParserError> {
             let object_name = parser.parse_object_name(false)?;
             (CommentObject::Table, object_name)
         }
+        Token::Word(w) if w.keyword == Keyword::EXTENSION => {
+            let object_name = parser.parse_object_name(false)?;
+            (CommentObject::Extension, object_name)
+        }
         _ => parser.expected("comment object_type", token)?,
     };
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2902,6 +2902,21 @@ fn parse_comments() {
         _ => unreachable!(),
     }
 
+    match pg().verified_stmt("COMMENT ON EXTENSION plpgsql IS 'comment'") {
+        Statement::Comment {
+            object_type,
+            object_name,
+            comment: Some(comment),
+            if_exists,
+        } => {
+            assert_eq!("comment", comment);
+            assert_eq!("plpgsql", object_name.to_string());
+            assert_eq!(CommentObject::Extension, object_type);
+            assert!(!if_exists);
+        }
+        _ => unreachable!(),
+    }
+
     match pg().verified_stmt("COMMENT ON TABLE public.tab IS 'comment'") {
         Statement::Comment {
             object_type,


### PR DESCRIPTION
Hi guys, 
First of all i'd say that i'm new to contributing to open source so if I've made a mistake i'm deeply sorry.
Also I made sure to write the relevant tests and I ran `cargo test`, `cargo fmt` and `cargo clippy` and it said in the README.
I added the ability to parse COMMENT ON EXTENSION statements to postgres dialect,
I've been using this crate for a while now and I saw that I get a parser error when I have these kind of statements.