### PR TITLE
Fix always uses CommentDef::WithoutEq while parsing the inline comment

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -22,9 +22,7 @@ use crate::ast::helpers::stmt_data_loading::{
     DataLoadingOption, DataLoadingOptionType, DataLoadingOptions, StageLoadSelectItem,
     StageParamsObject,
 };
-use crate::ast::{
-    CommentDef, Ident, ObjectName, RowAccessPolicy, Statement, Tag, WrappedCollection,
-};
+use crate::ast::{Ident, ObjectName, RowAccessPolicy, Statement, Tag, WrappedCollection};
 use crate::dialect::{Dialect, Precedence};
 use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
@@ -210,13 +208,9 @@ pub fn parse_create_table(
                     builder = builder.copy_grants(true);
                 }
                 Keyword::COMMENT => {
-                    parser.expect_token(&Token::Eq)?;
-                    let next_token = parser.next_token();
-                    let comment = match next_token.token {
-                        Token::SingleQuotedString(str) => Some(CommentDef::WithEq(str)),
-                        _ => parser.expected("comment", next_token)?,
-                    };
-                    builder = builder.comment(comment);
+                    // Rewind the COMMENT keyword
+                    parser.prev_token();
+                    builder = builder.comment(parser.parse_optional_inline_comment()?);
                 }
                 Keyword::AS => {
                     let query = parser.parse_boxed_query()?;

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -713,11 +713,11 @@ fn parse_create_table_primary_and_unique_key_characteristic_test() {
 
 #[test]
 fn parse_create_table_comment() {
-    let canonical = "CREATE TABLE foo (bar INT) COMMENT 'baz'";
+    let without_equal = "CREATE TABLE foo (bar INT) COMMENT 'baz'";
     let with_equal = "CREATE TABLE foo (bar INT) COMMENT = 'baz'";
 
-    for sql in [canonical, with_equal] {
-        match mysql().one_statement_parses_to(sql, canonical) {
+    for sql in [without_equal, with_equal] {
+        match mysql().verified_stmt(sql) {
             Statement::CreateTable(CreateTable { name, comment, .. }) => {
                 assert_eq!(name.to_string(), "foo");
                 assert_eq!(comment.expect("Should exist").to_string(), "baz");


### PR DESCRIPTION
This closes #1452.