### PR TITLE
Add support for the LIKE ANY and ILIKE ANY pattern-matching condition

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -613,6 +613,7 @@ pub enum Expr {
     /// `[NOT] LIKE <pattern> [ESCAPE <escape_character>]`
     Like {
         negated: bool,
+        any: bool,
         expr: Box<Expr>,
         pattern: Box<Expr>,
         escape_char: Option<String>,
@@ -620,6 +621,7 @@ pub enum Expr {
     /// `ILIKE` (case-insensitive `LIKE`)
     ILike {
         negated: bool,
+        any: bool,
         expr: Box<Expr>,
         pattern: Box<Expr>,
         escape_char: Option<String>,
@@ -1242,20 +1244,23 @@ impl fmt::Display for Expr {
                 expr,
                 pattern,
                 escape_char,
+                any,
             } => match escape_char {
                 Some(ch) => write!(
                     f,
-                    "{} {}LIKE {} ESCAPE '{}'",
+                    "{} {}LIKE {}{} ESCAPE '{}'",
                     expr,
                     if *negated { "NOT " } else { "" },
+                    if *any { "ANY " } else { "" },
                     pattern,
                     ch
                 ),
                 _ => write!(
                     f,
-                    "{} {}LIKE {}",
+                    "{} {}LIKE {}{}",
                     expr,
                     if *negated { "NOT " } else { "" },
+                    if *any { "ANY " } else { "" },
                     pattern
                 ),
             },
@@ -1264,20 +1269,23 @@ impl fmt::Display for Expr {
                 expr,
                 pattern,
                 escape_char,
+                any,
             } => match escape_char {
                 Some(ch) => write!(
                     f,
-                    "{} {}ILIKE {} ESCAPE '{}'",
+                    "{} {}ILIKE {}{} ESCAPE '{}'",
                     expr,
                     if *negated { "NOT " } else { "" },
+                    if *any { "ANY" } else { "" },
                     pattern,
                     ch
                 ),
                 _ => write!(
                     f,
-                    "{} {}ILIKE {}",
+                    "{} {}ILIKE {}{}",
                     expr,
                     if *negated { "NOT " } else { "" },
+                    if *any { "ANY " } else { "" },
                     pattern
                 ),
             },

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -613,6 +613,8 @@ pub enum Expr {
     /// `[NOT] LIKE <pattern> [ESCAPE <escape_character>]`
     Like {
         negated: bool,
+        // Snowflake supports the ANY keyword to match against a list of patterns
+        // https://docs.snowflake.com/en/sql-reference/functions/like_any
         any: bool,
         expr: Box<Expr>,
         pattern: Box<Expr>,
@@ -621,6 +623,8 @@ pub enum Expr {
     /// `ILIKE` (case-insensitive `LIKE`)
     ILike {
         negated: bool,
+        // Snowflake supports the ANY keyword to match against a list of patterns
+        // https://docs.snowflake.com/en/sql-reference/functions/like_any
         any: bool,
         expr: Box<Expr>,
         pattern: Box<Expr>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2734,10 +2734,6 @@ impl<'a> Parser<'a> {
                     let regexp = self.parse_keyword(Keyword::REGEXP);
                     let rlike = self.parse_keyword(Keyword::RLIKE);
                     if regexp || rlike {
-                        if self.parse_keyword(Keyword::ANY) {
-                            self.prev_token();
-                            return self.expected("pattern after RLIKE or REGEXP", self.peek_token());
-                        }
                         Ok(Expr::RLike {
                             negated,
                             expr: Box::new(expr),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2734,6 +2734,10 @@ impl<'a> Parser<'a> {
                     let regexp = self.parse_keyword(Keyword::REGEXP);
                     let rlike = self.parse_keyword(Keyword::RLIKE);
                     if regexp || rlike {
+                        if self.parse_keyword(Keyword::ANY) {
+                            self.prev_token();
+                            return self.expected("pattern after RLIKE or REGEXP", self.peek_token());
+                        }
                         Ok(Expr::RLike {
                             negated,
                             expr: Box::new(expr),
@@ -2749,6 +2753,7 @@ impl<'a> Parser<'a> {
                     } else if self.parse_keyword(Keyword::LIKE) {
                         Ok(Expr::Like {
                             negated,
+                            any: self.parse_keyword(Keyword::ANY),
                             expr: Box::new(expr),
                             pattern: Box::new(
                                 self.parse_subexpr(self.dialect.prec_value(Precedence::Like))?,
@@ -2758,6 +2763,7 @@ impl<'a> Parser<'a> {
                     } else if self.parse_keyword(Keyword::ILIKE) {
                         Ok(Expr::ILike {
                             negated,
+                            any: self.parse_keyword(Keyword::ANY),
                             expr: Box::new(expr),
                             pattern: Box::new(
                                 self.parse_subexpr(self.dialect.prec_value(Precedence::Like))?,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1549,6 +1549,7 @@ fn parse_not_precedence() {
                 negated: true,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("b".into()))),
                 escape_char: None,
+                any: false,
             }),
         },
     );
@@ -1579,6 +1580,7 @@ fn parse_null_like() {
         SelectItem::ExprWithAlias {
             expr: Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("column1"))),
+                any: false,
                 negated: false,
                 pattern: Box::new(Expr::Value(Value::Null)),
                 escape_char: None,
@@ -1594,6 +1596,7 @@ fn parse_null_like() {
         SelectItem::ExprWithAlias {
             expr: Expr::Like {
                 expr: Box::new(Expr::Value(Value::Null)),
+                any: false,
                 negated: false,
                 pattern: Box::new(Expr::Identifier(Ident::new("column1"))),
                 escape_char: None,
@@ -1621,6 +1624,7 @@ fn parse_ilike() {
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
+                any: false,
             },
             select.selection.unwrap()
         );
@@ -1637,6 +1641,7 @@ fn parse_ilike() {
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('^'.to_string()),
+                any: false,
             },
             select.selection.unwrap()
         );
@@ -1654,6 +1659,7 @@ fn parse_ilike() {
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
+                any: false,
             })),
             select.selection.unwrap()
         );
@@ -1676,6 +1682,7 @@ fn parse_like() {
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
+                any: false,
             },
             select.selection.unwrap()
         );
@@ -1692,6 +1699,7 @@ fn parse_like() {
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: Some('^'.to_string()),
+                any: false,
             },
             select.selection.unwrap()
         );
@@ -1709,6 +1717,7 @@ fn parse_like() {
                 negated,
                 pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
                 escape_char: None,
+                any: false,
             })),
             select.selection.unwrap()
         );
@@ -10098,6 +10107,7 @@ fn test_selective_aggregation() {
                         expr: Box::new(Expr::Identifier(Ident::new("name"))),
                         pattern: Box::new(Expr::Value(Value::SingleQuotedString("a%".to_owned()))),
                         escape_char: None,
+                        any: false,
                     })),
                     null_treatment: None,
                     over: None,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11269,3 +11269,11 @@ fn test_alter_policy() {
         "sql parser error: Expected: (, found: EOF"
     );
 }
+
+#[test]
+fn test_select_where_with_like_or_ilike_any() {
+    verified_stmt(r#"SELECT * FROM x WHERE a ILIKE ANY '%abc%'"#);
+    verified_stmt(r#"SELECT * FROM x WHERE a LIKE ANY '%abc%'"#);
+    verified_stmt(r#"SELECT * FROM x WHERE a ILIKE ANY ('%Jo%oe%', 'T%e')"#);
+    verified_stmt(r#"SELECT * FROM x WHERE a LIKE ANY ('%Jo%oe%', 'T%e')"#);
+}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2163,19 +2163,6 @@ fn test_select_wildcard_with_ilike_replace() {
 }
 
 #[test]
-fn test_select_where_with_like_or_ilike_any() {
-    snowflake().verified_stmt(r#"SELECT * FROM x WHERE a ILIKE ANY '%abc%'"#);
-    snowflake().verified_stmt(r#"SELECT * FROM x WHERE a LIKE ANY '%abc%'"#);
-    snowflake().verified_stmt(r#"SELECT * FROM x WHERE a ILIKE ANY ('%Jo%oe%', 'T%e')"#);
-    snowflake().verified_stmt(r#"SELECT * FROM x WHERE a LIKE ANY ('%Jo%oe%', 'T%e')"#);
-    let res = snowflake().parse_sql_statements(r#"SELECT * FROM x WHERE a RLIKE ANY '%abc%'"#);
-    assert_eq!(
-        res.unwrap_err().to_string(),
-        "sql parser error: Expected: pattern after RLIKE or REGEXP, found: ANY"
-    );
-}
-
-#[test]
 fn first_value_ignore_nulls() {
     snowflake().verified_only_select(concat!(
         "SELECT FIRST_VALUE(column2 IGNORE NULLS) ",

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2163,6 +2163,19 @@ fn test_select_wildcard_with_ilike_replace() {
 }
 
 #[test]
+fn test_select_where_with_like_or_ilike_any() {
+    snowflake().verified_stmt(r#"SELECT * FROM x WHERE a ILIKE ANY '%abc%'"#);
+    snowflake().verified_stmt(r#"SELECT * FROM x WHERE a LIKE ANY '%abc%'"#);
+    snowflake().verified_stmt(r#"SELECT * FROM x WHERE a ILIKE ANY ('%Jo%oe%', 'T%e')"#);
+    snowflake().verified_stmt(r#"SELECT * FROM x WHERE a LIKE ANY ('%Jo%oe%', 'T%e')"#);
+    let res = snowflake().parse_sql_statements(r#"SELECT * FROM x WHERE a RLIKE ANY '%abc%'"#);
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "sql parser error: Expected: pattern after RLIKE or REGEXP, found: ANY"
+    );
+}
+
+#[test]
 fn first_value_ignore_nulls() {
     snowflake().verified_only_select(concat!(
         "SELECT FIRST_VALUE(column2 IGNORE NULLS) ",


### PR DESCRIPTION
Snowflake supports pattern matching over a list of patterns with the use of the case-sensitive LIKE ANY and case-insensitive ILIKE ANY functions. Added support for the ANY option in the Expr::Like and Expr::ILike variants.