### PR TITLE
Add support of `EXPLAIN QUERY PLAN` syntax for SQLite dialect

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3316,18 +3316,17 @@ impl fmt::Display for Statement {
 
                 if *query_plan {
                     write!(f, "QUERY PLAN ")?;
-                } else {
-                    if *analyze {
-                        write!(f, "ANALYZE ")?;
-                    }
+                }
+                if *analyze {
+                    write!(f, "ANALYZE ")?;
+                }
 
-                    if *verbose {
-                        write!(f, "VERBOSE ")?;
-                    }
+                if *verbose {
+                    write!(f, "VERBOSE ")?;
+                }
 
-                    if let Some(format) = format {
-                        write!(f, "FORMAT {format} ")?;
-                    }
+                if let Some(format) = format {
+                    write!(f, "FORMAT {format} ")?;
                 }
 
                 if let Some(options) = options {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3111,6 +3111,11 @@ pub enum Statement {
         analyze: bool,
         // Display additional information regarding the plan.
         verbose: bool,
+        /// `EXPLAIN QUERY PLAN`
+        /// Display the query plan without running the query.
+        ///
+        /// [SQLite](https://sqlite.org/lang_explain.html)
+        query_plan: bool,
         /// A SQL query that specifies what to explain
         statement: Box<Statement>,
         /// Optional output format of explain
@@ -3302,22 +3307,27 @@ impl fmt::Display for Statement {
                 describe_alias,
                 verbose,
                 analyze,
+                query_plan,
                 statement,
                 format,
                 options,
             } => {
                 write!(f, "{describe_alias} ")?;
 
-                if *analyze {
-                    write!(f, "ANALYZE ")?;
-                }
+                if *query_plan {
+                    write!(f, "QUERY PLAN ")?;
+                } else {
+                    if *analyze {
+                        write!(f, "ANALYZE ")?;
+                    }
 
-                if *verbose {
-                    write!(f, "VERBOSE ")?;
-                }
+                    if *verbose {
+                        write!(f, "VERBOSE ")?;
+                    }
 
-                if let Some(format) = format {
-                    write!(f, "FORMAT {format} ")?;
+                    if let Some(format) = format {
+                        write!(f, "FORMAT {format} ")?;
+                    }
                 }
 
                 if let Some(options) = options {

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -572,6 +572,7 @@ define_keywords!(
     PERSISTENT,
     PIVOT,
     PLACING,
+    PLAN,
     PLANS,
     POLICY,
     PORTION,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8632,6 +8632,7 @@ impl<'a> Parser<'a> {
     ) -> Result<Statement, ParserError> {
         let mut analyze = false;
         let mut verbose = false;
+        let mut query_plan = false;
         let mut format = None;
         let mut options = None;
 
@@ -8642,6 +8643,8 @@ impl<'a> Parser<'a> {
             && self.peek_token().token == Token::LParen
         {
             options = Some(self.parse_utility_options()?)
+        } else if self.parse_keywords(&[Keyword::QUERY, Keyword::PLAN]) {
+            query_plan = true;
         } else {
             analyze = self.parse_keyword(Keyword::ANALYZE);
             verbose = self.parse_keyword(Keyword::VERBOSE);
@@ -8658,6 +8661,7 @@ impl<'a> Parser<'a> {
                 describe_alias,
                 analyze,
                 verbose,
+                query_plan,
                 statement: Box::new(statement),
                 format,
                 options,


### PR DESCRIPTION
This closes #1455 and introduces one keyword: `PLAN`.

For the syntax documentation, please refer to:

https://sqlite.org/lang_explain.html