### PR TITLE
Add PostgreSQL specfic "CREATE TYPE t AS ENUM (...)" support.

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1479,6 +1479,8 @@ pub enum UserDefinedTypeRepresentation {
     Composite {
         attributes: Vec<UserDefinedTypeCompositeAttributeDef>,
     },
+    /// Note: this is PostgreSQL-specific. See <https://www.postgresql.org/docs/current/sql-createtype.html>
+    Enum { labels: Vec<Ident> },
 }
 
 impl fmt::Display for UserDefinedTypeRepresentation {
@@ -1486,6 +1488,9 @@ impl fmt::Display for UserDefinedTypeRepresentation {
         match self {
             UserDefinedTypeRepresentation::Composite { attributes } => {
                 write!(f, "({})", display_comma_separated(attributes))
+            }
+            UserDefinedTypeRepresentation::Enum { labels } => {
+                write!(f, "ENUM ({})", display_comma_separated(labels))
             }
         }
     }

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -28,7 +28,7 @@
 // limitations under the License.
 use log::debug;
 
-use crate::ast::{CommentObject, Statement};
+use crate::ast::{CommentObject, ObjectName, Statement, UserDefinedTypeRepresentation};
 use crate::dialect::{Dialect, Precedence};
 use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
@@ -138,6 +138,9 @@ impl Dialect for PostgreSqlDialect {
     fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
         if parser.parse_keyword(Keyword::COMMENT) {
             Some(parse_comment(parser))
+        } else if parser.parse_keyword(Keyword::CREATE) {
+            parser.prev_token(); // unconsume the CREATE in case we don't end up parsing anything
+            parse_create(parser)
         } else {
             None
         }
@@ -219,5 +222,35 @@ pub fn parse_comment(parser: &mut Parser) -> Result<Statement, ParserError> {
         object_name,
         comment,
         if_exists,
+    })
+}
+
+pub fn parse_create(parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+    let name = parser.maybe_parse(|parser| -> Result<ObjectName, ParserError> {
+        parser.expect_keyword(Keyword::CREATE)?;
+        parser.expect_keyword(Keyword::TYPE)?;
+        let name = parser.parse_object_name(false)?;
+        parser.expect_keyword(Keyword::AS)?;
+        parser.expect_keyword(Keyword::ENUM)?;
+        Ok(name)
+    });
+    name.map(|name| parse_create_type_as_enum(parser, name))
+}
+
+// https://www.postgresql.org/docs/current/sql-createtype.html
+pub fn parse_create_type_as_enum(
+    parser: &mut Parser,
+    name: ObjectName,
+) -> Result<Statement, ParserError> {
+    if !parser.consume_token(&Token::LParen) {
+        return parser.expected("'(' after CREATE TYPE AS ENUM", parser.peek_token());
+    }
+
+    let labels = parser.parse_comma_separated0(|p| p.parse_identifier(false), Token::RParen)?;
+    parser.expect_token(&Token::RParen)?;
+
+    Ok(Statement::CreateType {
+        name,
+        representation: UserDefinedTypeRepresentation::Enum { labels },
     })
 }


### PR DESCRIPTION
See: https://www.postgresql.org/docs/current/sql-createtype.html

I implemented this as a separate `Statement::CreateTypeAsEnum { name, labels }` so it wouldn't be as invasive to the existing `Statement::CreateType` (which I would imagine helps forwards/backwards compatibility for the crate's users).

I used the `PostgreSqlDialect`'s comment as a blueprint but that means that the generic dialect doesn't get this feature (unless I'm missing something). I didn't see `parse_statement()` implemented in `GenericDialect` though I suppose it could be (and call out to other dialects' `parse_statement()`s). I didn't want to set that precedent without asking.