### PR TITLE
Add "DROP TYPE" support.

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -5713,6 +5713,7 @@ pub enum ObjectType {
     Role,
     Sequence,
     Stage,
+    Type,
 }
 
 impl fmt::Display for ObjectType {
@@ -5726,6 +5727,7 @@ impl fmt::Display for ObjectType {
             ObjectType::Role => "ROLE",
             ObjectType::Sequence => "SEQUENCE",
             ObjectType::Stage => "STAGE",
+            ObjectType::Type => "TYPE",
         })
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4887,6 +4887,8 @@ impl<'a> Parser<'a> {
             ObjectType::Sequence
         } else if self.parse_keyword(Keyword::STAGE) {
             ObjectType::Stage
+        } else if self.parse_keyword(Keyword::TYPE) {
+            ObjectType::Type
         } else if self.parse_keyword(Keyword::FUNCTION) {
             return self.parse_drop_function();
         } else if self.parse_keyword(Keyword::POLICY) {
@@ -4899,7 +4901,7 @@ impl<'a> Parser<'a> {
             return self.parse_drop_trigger();
         } else {
             return self.expected(
-                "TABLE, VIEW, INDEX, ROLE, SCHEMA, DATABASE, FUNCTION, PROCEDURE, STAGE, TRIGGER, SECRET or SEQUENCE after DROP",
+                "TABLE, VIEW, INDEX, ROLE, SCHEMA, DATABASE, FUNCTION, PROCEDURE, STAGE, TRIGGER, SECRET, SEQUENCE, or TYPE after DROP",
                 self.peek_token(),
             );
         };

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -9649,6 +9649,60 @@ fn parse_create_type() {
 }
 
 #[test]
+fn parse_drop_type() {
+    let sql = "DROP TYPE abc";
+    match verified_stmt(sql) {
+        Statement::Drop {
+            names,
+            object_type,
+            if_exists,
+            cascade,
+            ..
+        } => {
+            assert_eq_vec(&["abc"], &names);
+            assert_eq!(ObjectType::Type, object_type);
+            assert!(!if_exists);
+            assert!(!cascade);
+        }
+        _ => unreachable!(),
+    };
+
+    let sql = "DROP TYPE IF EXISTS def, magician, quaternion";
+    match verified_stmt(sql) {
+        Statement::Drop {
+            names,
+            object_type,
+            if_exists,
+            cascade,
+            ..
+        } => {
+            assert_eq_vec(&["def", "magician", "quaternion"], &names);
+            assert_eq!(ObjectType::Type, object_type);
+            assert!(if_exists);
+            assert!(!cascade);
+        }
+        _ => unreachable!(),
+    }
+
+    let sql = "DROP TYPE IF EXISTS my_type CASCADE";
+    match verified_stmt(sql) {
+        Statement::Drop {
+            names,
+            object_type,
+            if_exists,
+            cascade,
+            ..
+        } => {
+            assert_eq_vec(&["my_type"], &names);
+            assert_eq!(ObjectType::Type, object_type);
+            assert!(if_exists);
+            assert!(cascade);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_call() {
     all_dialects().verified_stmt("CALL my_procedure()");
     all_dialects().verified_stmt("CALL my_procedure(1, 'a')");


### PR DESCRIPTION
See: https://www.postgresql.org/docs/current/sql-droptype.html
     https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-type-transact-sql?view=sql-server-ver16
     https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/DROP-TYPE.html

According to the postgresql docs (above), their implementation is from ansi with only the `IF EXISTS` being an extension. mssql supports the `IF EXISTS` extension as well though it looks like Oracle doesn't.

I implemented this as a new `ObjectType::Type` which lets the existing `Statement::Drop` handle it generically.