### PR TITLE
Add support for ASC and DESC in CREATE TABLE column constraints for SQLite.

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -103,4 +103,8 @@ impl Dialect for GenericDialect {
     fn supports_limit_comma(&self) -> bool {
         true
     }
+
+    fn supports_asc_desc_in_column_definition(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -557,6 +557,10 @@ pub trait Dialect: Debug + Any {
     fn supports_explain_with_utility_options(&self) -> bool {
         false
     }
+
+    fn supports_asc_desc_in_column_definition(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -77,4 +77,8 @@ impl Dialect for SQLiteDialect {
     fn supports_limit_comma(&self) -> bool {
         true
     }
+
+    fn supports_asc_desc_in_column_definition(&self) -> bool {
+        true
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6175,6 +6175,20 @@ impl<'a> Parser<'a> {
             Ok(Some(ColumnOption::DialectSpecific(vec![
                 Token::make_keyword("AUTOINCREMENT"),
             ])))
+        } else if self.parse_keyword(Keyword::ASC)
+            && self.dialect.supports_asc_desc_in_column_definition()
+        {
+            // Support ASC for SQLite
+            Ok(Some(ColumnOption::DialectSpecific(vec![
+                Token::make_keyword("ASC"),
+            ])))
+        } else if self.parse_keyword(Keyword::DESC)
+            && self.dialect.supports_asc_desc_in_column_definition()
+        {
+            // Support DESC for SQLite
+            Ok(Some(ColumnOption::DialectSpecific(vec![
+                Token::make_keyword("DESC"),
+            ])))
         } else if self.parse_keywords(&[Keyword::ON, Keyword::UPDATE])
             && dialect_of!(self is MySqlDialect | GenericDialect)
         {

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -238,6 +238,43 @@ fn parse_create_table_auto_increment() {
 }
 
 #[test]
+fn parse_create_table_primary_key_asc_desc() {
+    let expected_column_def = |kind| ColumnDef {
+        name: "bar".into(),
+        data_type: DataType::Int(None),
+        collation: None,
+        options: vec![
+            ColumnOptionDef {
+                name: None,
+                option: ColumnOption::Unique {
+                    is_primary: true,
+                    characteristics: None,
+                },
+            },
+            ColumnOptionDef {
+                name: None,
+                option: ColumnOption::DialectSpecific(vec![Token::make_keyword(kind)]),
+            },
+        ],
+    };
+
+    let sql = "CREATE TABLE foo (bar INT PRIMARY KEY ASC)";
+    match sqlite_and_generic().verified_stmt(sql) {
+        Statement::CreateTable(CreateTable { columns, .. }) => {
+            assert_eq!(vec![expected_column_def("ASC")], columns);
+        }
+        _ => unreachable!(),
+    }
+    let sql = "CREATE TABLE foo (bar INT PRIMARY KEY DESC)";
+    match sqlite_and_generic().verified_stmt(sql) {
+        Statement::CreateTable(CreateTable { columns, .. }) => {
+            assert_eq!(vec![expected_column_def("DESC")], columns);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_create_sqlite_quote() {
     let sql = "CREATE TABLE `PRIMARY` (\"KEY\" INT, [INDEX] INT)";
     match sqlite().verified_stmt(sql) {


### PR DESCRIPTION
See: https://sqlite.org/lang_createtable.html

I didn't directly copy the `AUTOINCREMENT` code right above the diff because I happened to read #1430 the other day. Instead I created a new function in Dialect and enabled it in `SQLiteDialect` and `GenericDialect`—I hope this is ok.

I'm also a little disappointed that I couldn't deduplicate the ASC and DESC handling in src/parser/mod.rs. Maybe if/when [`if let` chains](https://github.com/rust-lang/rust/issues/53667) are stabilized they could be consolidated cleanly…