### PR TITLE
chore: Add asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file controls the settings of this repository
+#
+# See more details at
+# https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+
+notifications:
+  commits: commits@datafusion.apache.org
+  issues: github@datafusion.apache.org
+  pullrequests: github@datafusion.apache.org
+  jira_options: link label worklog
+github:
+  description: "Extensible SQL Lexer and Parser for Rust"
+  labels:
+    - big-data
+    - rust
+    - sql
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: false
+  features:
+    issues: true
+  protected_branches:
+    main:
+      required_pull_request_reviews:
+        required_approving_review_count: 1

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,7 +24,6 @@ notifications:
   commits: commits@datafusion.apache.org
   issues: github@datafusion.apache.org
   pullrequests: github@datafusion.apache.org
-  jira_options: link label worklog
 github:
   description: "Extensible SQL Lexer and Parser for Rust"
   labels:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,7 +36,3 @@ github:
     rebase: false
   features:
     issues: true
-  protected_branches:
-    main:
-      required_pull_request_reviews:
-        required_approving_review_count: 1


### PR DESCRIPTION
This PR adds `asf.yaml` which mainly copied from https://github.com/apache/datafusion/blob/main/.asf.yaml

After this change, we can avoid sending too many traffic to dev@d.a.o.