### PR TITLE
Add support for parsing MsSql alias with equals

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -562,7 +562,13 @@ pub trait Dialect: Debug + Any {
         false
     }
 
-    /// For example: SELECT col_alias = col FROM tbl
+    /// Returns true if this dialect supports treating the equals operator `=` within a [`SelectItem`]
+    /// as an alias assignment operator, rather than a boolean expression.
+    /// For example: the following statements are equivalent for such a dialect:
+    /// ```sql
+    ///  SELECT col_alias = col FROM tbl;
+    ///  SELECT col_alias AS col FROM tbl;
+    /// ```
     fn supports_eq_alias_assigment(&self) -> bool {
         false
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -562,7 +562,7 @@ pub trait Dialect: Debug + Any {
         false
     }
 
-    /// Returns true if this dialect supports treating the equals operator `=` within a [`SelectItem`]
+    /// Returns true if this dialect supports treating the equals operator `=` within a `SelectItem`
     /// as an alias assignment operator, rather than a boolean expression.
     /// For example: the following statements are equivalent for such a dialect:
     /// ```sql

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -561,6 +561,11 @@ pub trait Dialect: Debug + Any {
     fn supports_asc_desc_in_column_definition(&self) -> bool {
         false
     }
+
+    /// For example: SELECT col_alias = col FROM tbl
+    fn supports_eq_alias_assigment(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -49,4 +49,8 @@ impl Dialect for MsSqlDialect {
     fn supports_connect_by(&self) -> bool {
         true
     }
+
+    fn supports_eq_alias_assigment(&self) -> bool {
+        true
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11182,11 +11182,29 @@ impl<'a> Parser<'a> {
                 )
             }
             expr => {
-                if dialect_of!(self is MsSqlDialect) {
-                    if let Some(select_item) = self.parse_mssql_alias_with_equal(&expr) {
-                        return Ok(select_item);
+                // Parse a [`SelectItem`] based on an [MsSql] syntax that uses the equal sign
+                // to denote an alias, for example: SELECT col_alias = col FROM tbl
+                // [MsSql]: https://learn.microsoft.com/en-us/sql/t-sql/queries/select-examples-transact-sql?view=sql-server-ver16#b-use-select-with-column-headings-and-calculations
+                let expr = if self.dialect.supports_eq_alias_assigment() {
+                    if let Expr::BinaryOp {
+                        ref left,
+                        op: BinaryOperator::Eq,
+                        ref right,
+                    } = expr
+                    {
+                        if let Expr::Identifier(alias) = left.as_ref() {
+                            return Ok(SelectItem::ExprWithAlias {
+                                expr: *right.clone(),
+                                alias: alias.clone(),
+                            });
+                        }
                     }
-                }
+                    expr
+                } else {
+                    expr
+                };
+
+                // Parse the common AS keyword for aliasing a column
                 self.parse_optional_alias(keywords::RESERVED_FOR_COLUMN_ALIAS)
                     .map(|alias| match alias {
                         Some(alias) => SelectItem::ExprWithAlias { expr, alias },
@@ -11194,27 +11212,6 @@ impl<'a> Parser<'a> {
                     })
             }
         }
-    }
-
-    /// Parse a [`SelectItem`] based on an MsSql syntax that uses the equal sign
-    /// to denote an alias, for example: SELECT col_alias = col FROM tbl
-    /// <https://learn.microsoft.com/en-us/sql/t-sql/queries/select-examples-transact-sql?view=sql-server-ver16#b-use-select-with-column-headings-and-calculations>    
-    fn parse_mssql_alias_with_equal(&mut self, expr: &Expr) -> Option<SelectItem> {
-        if let Expr::BinaryOp {
-            left, op, right, ..
-        } = expr
-        {
-            if op == &BinaryOperator::Eq {
-                if let Expr::Identifier(ref alias) = **left {
-                    return Some(SelectItem::ExprWithAlias {
-                        expr: *right.clone(),
-                        alias: alias.clone(),
-                    });
-                }
-            }
-        }
-
-        None
     }
 
     /// Parse an [`WildcardAdditionalOptions`] information for wildcard select items.

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11432,3 +11432,15 @@ fn test_any_some_all_comparison() {
     verified_stmt("SELECT c1 FROM tbl WHERE c1 <> SOME(SELECT c2 FROM tbl)");
     verified_stmt("SELECT 1 = ANY(WITH x AS (SELECT 1) SELECT * FROM x)");
 }
+
+#[test]
+fn test_alias_equal_expr() {
+    let dialects = all_dialects_where(|d| d.supports_eq_alias_assigment());
+    let sql = r#"SELECT some_alias = some_column FROM some_table"#;
+    let expected = r#"SELECT some_column AS some_alias FROM some_table"#;
+    let _ = dialects.one_statement_parses_to(sql, expected);
+
+    let sql = r#"SELECT some_alias = (a*b) FROM some_table"#;
+    let expected = r#"SELECT (a * b) AS some_alias FROM some_table"#;
+    let _ = dialects.one_statement_parses_to(sql, expected);
+}

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11443,4 +11443,9 @@ fn test_alias_equal_expr() {
     let sql = r#"SELECT some_alias = (a*b) FROM some_table"#;
     let expected = r#"SELECT (a * b) AS some_alias FROM some_table"#;
     let _ = dialects.one_statement_parses_to(sql, expected);
+
+    let dialects = all_dialects_where(|d| !d.supports_eq_alias_assigment());
+    let sql = r#"SELECT x = (a * b) FROM some_table"#;
+    let expected = r#"SELECT x = (a * b) FROM some_table"#;
+    let _ = dialects.one_statement_parses_to(sql, expected);
 }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1024,6 +1024,17 @@ fn parse_create_table_with_identity_column() {
     }
 }
 
+#[test]
+fn test_alias_equal_expr() {
+    let sql = r#"SELECT some_alias = some_column FROM some_table"#;
+    let expected = r#"SELECT some_column AS some_alias FROM some_table"#;
+    let _ = ms().one_statement_parses_to(sql, expected);
+
+    let sql = r#"SELECT some_alias = (a*b) FROM some_table"#;
+    let expected = r#"SELECT (a * b) AS some_alias FROM some_table"#;
+    let _ = ms().one_statement_parses_to(sql, expected);
+}
+
 fn ms() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(MsSqlDialect {})],

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1024,17 +1024,6 @@ fn parse_create_table_with_identity_column() {
     }
 }
 
-#[test]
-fn test_alias_equal_expr() {
-    let sql = r#"SELECT some_alias = some_column FROM some_table"#;
-    let expected = r#"SELECT some_column AS some_alias FROM some_table"#;
-    let _ = ms().one_statement_parses_to(sql, expected);
-
-    let sql = r#"SELECT some_alias = (a*b) FROM some_table"#;
-    let expected = r#"SELECT (a * b) AS some_alias FROM some_table"#;
-    let _ = ms().one_statement_parses_to(sql, expected);
-}
-
 fn ms() -> TestedDialects {
     TestedDialects {
         dialects: vec![Box::new(MsSqlDialect {})],


### PR DESCRIPTION
This PR addresses the MsSql syntax for select item alias using the `=` operator, for example:
```
SELECT col_alias = col FROM tbl
```
