### PR TITLE
fix: add stacker and maybe_grow on recursion guard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ path = "src/lib.rs"
 
 [features]
 default = ["std"]
-std = []
+std = ["stacker"]
 # Enable JSON output in the `cli` example:
 json_example = ["serde_json", "serde"]
 visitor = ["sqlparser_derive"]
@@ -48,10 +48,11 @@ bigdecimal = { version = "0.4.1", features = ["serde"], optional = true }
 log = "0.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
 # serde_json is only used in examples/cli, but we have to put it outside
-# of dev-dependencies because of
+# dev-dependencies because of
 # https://github.com/rust-lang/cargo/issues/1596
 serde_json = { version = "1.0", optional = true }
 sqlparser_derive = { version = "0.2.0", path = "derive", optional = true }
+stacker = { version = "0.1.17", optional = true }
 
 [dev-dependencies]
 simple_logger = "5.0"


### PR DESCRIPTION
## Changed

under `#[cfg(feature="std")]`, `stacker::maybe_grow` was called in `RecursionCounter::try_decrease` to prevent stack overflow

I also tested on Windows(stack size 1MB), it seems fine.

### reproducible code from original issue
```rust
use datafusion::prelude::{ParquetReadOptions, SessionContext};

#[tokio::main(flavor = "current_thread")]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let ctx = SessionContext::new();
    ctx.register_parquet(
        "parquet_table",
        "batches.parquet",
        ParquetReadOptions::default(),
    )
    .await?;

    let sql_query = "
    SELECT seq
    FROM (
      SELECT seq,
        LEAD(seq) OVER (ORDER BY seq) AS next_seq
        FROM parquet_table
    ) AS subquery
    WHERE next_seq - seq > 1";

    let df = ctx.sql(sql_query).await?;

    df.show().await?;
    Ok(())
}
```

## Missing
- [ ] Return error when growing stack fail:
growing stack on unsupported target seems to be no-op on stacker side, so I am unable to detect it.
- [ ] Test: which part should be tested?
- [ ] Observe performance impact