### PR TITLE
feat: handle different placing of type names

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3476,12 +3476,13 @@ impl<'a> Parser<'a> {
         }
         Ok(values)
     }
-    /// Parse a comma-separated list of 1+ items accepted by `F`
+    /// Parse a comma-separated list of 1+ items accepted by `F` with possibility to skip [`Keyword`] and consume [`Keyword`].
+    /// Extended behavior to [`Self::parse_comma_separated`]
     pub fn parse_comma_separated_with_skip_and_consume<T, F>(
         &mut self,
-        mut f: F,
         skip: &[Keyword],
         consume: &[Keyword],
+        mut f: F,
     ) -> Result<Vec<T>, ParserError>
     where
         F: FnMut(&mut Parser<'a>) -> Result<T, ParserError>,
@@ -8471,9 +8472,9 @@ impl<'a> Parser<'a> {
                 Ok(vec![])
             } else {
                 let cols = self.parse_comma_separated_with_skip_and_consume(
+                    &[Keyword::DESC, Keyword::ASC],
+                    &[Keyword::DESC, Keyword::ASC],
                     |p| p.parse_identifier(false),
-                    &[Keyword::DESC, Keyword::ASC],
-                    &[Keyword::DESC, Keyword::ASC],
                 )?;
                 self.expect_token(&Token::RParen)?;
                 Ok(cols)

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -2521,6 +2521,26 @@ fn parse_create_table_with_index_definition() {
     );
 
     mysql_and_generic().one_statement_parses_to(
+        "CREATE TABLE tb (id INT, KEY (id) USING HASH)",
+        "CREATE TABLE tb (id INT, KEY USING HASH (id))",
+    );
+
+    mysql_and_generic().one_statement_parses_to(
+        "CREATE TABLE tb (id INT, KEY (id, id2) USING HASH)",
+        "CREATE TABLE tb (id INT, KEY USING HASH (id, id2))",
+    );
+
+    mysql_and_generic().one_statement_parses_to(
+        "CREATE TABLE tb (id INT, KEY (id DESC) USING HASH)",
+        "CREATE TABLE tb (id INT, KEY USING HASH (id))",
+    );
+
+    mysql_and_generic().one_statement_parses_to(
+        "CREATE TABLE tb (id INT, KEY (id ASC) USING HASH)",
+        "CREATE TABLE tb (id INT, KEY USING HASH (id))",
+    );
+
+    mysql_and_generic().one_statement_parses_to(
         "CREATE TABLE tb (id INT, key index (id))",
         "CREATE TABLE tb (id INT, KEY index (id))",
     );


### PR DESCRIPTION
Hey, 

First of all I just want to thank for all the awesome work on this library!

I've came across something that didn't work as expected a couple of months ago and created a fix for myself but now took the time to bring it here also. I'm sure there are some things left to do so I would appreciate some rubber-🦆 

The issue is when trying to parse create a create statement


```
// Working
CREATE TABLE tb (id INT, KEY USING HASH (id))
```
```
// Not working
CREATE TABLE tb (id INT, KEY (id) USING HASH)
```

There was also an issue using order on the keys, such as this
```
CREATE TABLE tb (id INT, KEY USING HASH (id ASC))
```
which I'm not entirely sure how you'd like to handle, from my side I just did what was the appropriate solution (not using it) but I'd imagine from your end that would not be ideal solution. 