### PR TITLE
ClickHouse: support `alter table update ...`

### DIFF
--- a/src/dialect/clickhouse.rs
+++ b/src/dialect/clickhouse.rs
@@ -31,6 +31,11 @@ impl Dialect for ClickHouseDialect {
         self.is_identifier_start(ch) || ch.is_ascii_digit()
     }
 
+    // See https://clickhouse.com/docs/en/sql-reference/statements/alter/update
+    fn supports_alter_table_update(&self) -> bool {
+        true
+    }
+
     fn supports_string_literal_backslash_escape(&self) -> bool {
         true
     }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -40,6 +40,10 @@ impl Dialect for GenericDialect {
             || ch == '_'
     }
 
+    fn supports_alter_table_update(&self) -> bool {
+        true
+    }
+
     fn supports_unicode_string_literal(&self) -> bool {
         true
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -60,7 +60,7 @@ use alloc::boxed::Box;
 
 /// Convenience check if a [`Parser`] uses a certain dialect.
 ///
-/// Note: when possible please the new style, adding a method to the [`Dialect`]
+/// Note: when possible please use the new style, adding a method to the [`Dialect`]
 /// trait rather than using this macro.
 ///
 /// The benefits of adding a method on `Dialect` over this macro are:
@@ -146,6 +146,11 @@ pub trait Dialect: Debug + Any {
 
     /// Most dialects do not have custom operators. Override this method to provide custom operators.
     fn is_custom_operator_part(&self, _ch: char) -> bool {
+        false
+    }
+
+    /// Determine if the dialect supports `ALTER TABLE ... UPDATE ...` statements.
+    fn supports_alter_table_update(&self) -> bool {
         false
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11432,3 +11432,24 @@ fn test_any_some_all_comparison() {
     verified_stmt("SELECT c1 FROM tbl WHERE c1 <> SOME(SELECT c2 FROM tbl)");
     verified_stmt("SELECT 1 = ANY(WITH x AS (SELECT 1) SELECT * FROM x)");
 }
+
+#[test]
+fn test_parse_alter_table_update() {
+    let dialects = all_dialects_where(|d| d.supports_alter_table_update());
+    let cases = [
+        (
+            "ALTER TABLE t UPDATE col1 = 1, col2 = col3 + col4 WHERE cod4 = 1",
+            true,
+        ),
+        ("ALTER TABLE t UPDATE c = 0 IN PARTITION abc", true),
+        ("ALTER TABLE t UPDATE", false),
+        ("ALTER TABLE t UPDATE c WHERE 1 = 1", false),
+    ];
+    for (sql, is_valid) in cases {
+        if is_valid {
+            dialects.verified_stmt(sql);
+        } else {
+            assert!(dialects.parse_sql_statements(sql).is_err());
+        }
+    }
+}


### PR DESCRIPTION
It's to support `ALTER TABLE [<database>.]<table> UPDATE <column> = <expression> WHERE <filter_expr>`. 