### PR TITLE
Fix typo in `Dialect::supports_eq_alias_assigment`

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -582,7 +582,7 @@ pub trait Dialect: Debug + Any {
     ///  SELECT col_alias = col FROM tbl;
     ///  SELECT col_alias AS col FROM tbl;
     /// ```
-    fn supports_eq_alias_assigment(&self) -> bool {
+    fn supports_eq_alias_assignment(&self) -> bool {
         false
     }
 

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -50,7 +50,7 @@ impl Dialect for MsSqlDialect {
         true
     }
 
-    fn supports_eq_alias_assigment(&self) -> bool {
+    fn supports_eq_alias_assignment(&self) -> bool {
         true
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11209,7 +11209,7 @@ impl<'a> Parser<'a> {
                 left,
                 op: BinaryOperator::Eq,
                 right,
-            } if self.dialect.supports_eq_alias_assigment()
+            } if self.dialect.supports_eq_alias_assignment()
                 && matches!(left.as_ref(), Expr::Identifier(_)) =>
             {
                 let Expr::Identifier(alias) = *left else {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11435,7 +11435,7 @@ fn test_any_some_all_comparison() {
 
 #[test]
 fn test_alias_equal_expr() {
-    let dialects = all_dialects_where(|d| d.supports_eq_alias_assigment());
+    let dialects = all_dialects_where(|d| d.supports_eq_alias_assignment());
     let sql = r#"SELECT some_alias = some_column FROM some_table"#;
     let expected = r#"SELECT some_column AS some_alias FROM some_table"#;
     let _ = dialects.one_statement_parses_to(sql, expected);
@@ -11444,7 +11444,7 @@ fn test_alias_equal_expr() {
     let expected = r#"SELECT (a * b) AS some_alias FROM some_table"#;
     let _ = dialects.one_statement_parses_to(sql, expected);
 
-    let dialects = all_dialects_where(|d| !d.supports_eq_alias_assigment());
+    let dialects = all_dialects_where(|d| !d.supports_eq_alias_assignment());
     let sql = r#"SELECT x = (a * b) FROM some_table"#;
     let expected = r#"SELECT x = (a * b) FROM some_table"#;
     let _ = dialects.one_statement_parses_to(sql, expected);


### PR DESCRIPTION
I noticed this while reviewing other PRs. I think it is a small typo introduced in #1467

FYI @yoavcloud