### PR TITLE
Fix complex blocks warning when running clippy

### DIFF
--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -230,14 +230,16 @@ pub fn parse_comment(parser: &mut Parser) -> Result<Statement, ParserError> {
 }
 
 pub fn parse_create(parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
-    match parser.maybe_parse(|parser| -> Result<ObjectName, ParserError> {
+    let name = parser.maybe_parse(|parser| -> Result<ObjectName, ParserError> {
         parser.expect_keyword(Keyword::CREATE)?;
         parser.expect_keyword(Keyword::TYPE)?;
         let name = parser.parse_object_name(false)?;
         parser.expect_keyword(Keyword::AS)?;
         parser.expect_keyword(Keyword::ENUM)?;
         Ok(name)
-    }) {
+    });
+
+    match name {
         Ok(name) => name.map(|name| parse_create_type_as_enum(parser, name)),
         Err(e) => Some(Err(e)),
     }


### PR DESCRIPTION
```shell
warning: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
   --> src/dialect/postgresql.rs:233:74
    |
233 |       match parser.maybe_parse(|parser| -> Result<ObjectName, ParserError> {
    |  __________________________________________________________________________^
234 | |         parser.expect_keyword(Keyword::CREATE)?;
235 | |         parser.expect_keyword(Keyword::TYPE)?;
236 | |         let name = parser.parse_object_name(false)?;
...   |
239 | |         Ok(name)
240 | |     }) {
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_conditions
    = note: `#[warn(clippy::blocks_in_conditions)]` on by default
```