### PR TITLE
improve support for T-SQL EXECUTE statements

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3095,10 +3095,14 @@ pub enum Statement {
     /// EXECUTE name [ ( parameter [, ...] ) ] [USING <expr>]
     /// ```
     ///
-    /// Note: this is a PostgreSQL-specific statement.
+    /// Note: this statement is supported by Postgres and MSSQL, with slight differences in syntax.
+    ///
+    /// Postgres: <https://www.postgresql.org/docs/current/sql-execute.html>
+    /// MSSQL: <https://learn.microsoft.com/en-us/sql/relational-databases/stored-procedures/execute-a-stored-procedure>
     Execute {
-        name: Ident,
+        name: ObjectName,
         parameters: Vec<Expr>,
+        has_parentheses: bool,
         using: Vec<Expr>,
     },
     /// ```sql
@@ -4510,12 +4514,19 @@ impl fmt::Display for Statement {
             Statement::Execute {
                 name,
                 parameters,
+                has_parentheses,
                 using,
             } => {
-                write!(f, "EXECUTE {name}")?;
-                if !parameters.is_empty() {
-                    write!(f, "({})", display_comma_separated(parameters))?;
-                }
+                let (open, close) = if *has_parentheses {
+                    ("(", ")")
+                } else {
+                    (if parameters.is_empty() { "" } else { " " }, "")
+                };
+                write!(
+                    f,
+                    "EXECUTE {name}{open}{}{close}",
+                    display_comma_separated(parameters),
+                )?;
                 if !using.is_empty() {
                     write!(f, " USING {}", display_comma_separated(using))?;
                 };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -529,7 +529,7 @@ impl<'a> Parser<'a> {
                 // `PREPARE`, `EXECUTE` and `DEALLOCATE` are Postgres-specific
                 // syntaxes. They are used for Postgres prepared statement.
                 Keyword::DEALLOCATE => self.parse_deallocate(),
-                Keyword::EXECUTE => self.parse_execute(),
+                Keyword::EXECUTE | Keyword::EXEC => self.parse_execute(),
                 Keyword::PREPARE => self.parse_prepare(),
                 Keyword::MERGE => self.parse_merge(),
                 // `PRAGMA` is sqlite specific https://www.sqlite.org/pragma.html
@@ -11726,11 +11726,20 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_execute(&mut self) -> Result<Statement, ParserError> {
-        let name = self.parse_identifier(false)?;
+        let name = self.parse_object_name(false)?;
 
-        let mut parameters = vec![];
-        if self.consume_token(&Token::LParen) {
-            parameters = self.parse_comma_separated(Parser::parse_expr)?;
+        let has_parentheses = self.consume_token(&Token::LParen);
+
+        let end_token = match (has_parentheses, self.peek_token().token) {
+            (true, _) => Token::RParen,
+            (false, Token::EOF) => Token::EOF,
+            (false, Token::Word(w)) if w.keyword == Keyword::USING => Token::Word(w),
+            (false, _) => Token::SemiColon,
+        };
+
+        let parameters = self.parse_comma_separated0(Parser::parse_expr, end_token)?;
+
+        if has_parentheses {
             self.expect_token(&Token::RParen)?;
         }
 
@@ -11746,6 +11755,7 @@ impl<'a> Parser<'a> {
         Ok(Statement::Execute {
             name,
             parameters,
+            has_parentheses,
             using,
         })
     }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -571,41 +571,6 @@ fn parse_substring_in_select() {
 }
 
 #[test]
-fn parse_mssql_execute_stored_procedure() {
-    let expected = Statement::Execute {
-        name: ObjectName(vec![
-            Ident {
-                value: "my_schema".to_string(),
-                quote_style: None,
-            },
-            Ident {
-                value: "my_stored_procedure".to_string(),
-                quote_style: None,
-            },
-        ]),
-        parameters: vec![
-            Expr::Value(Value::NationalStringLiteral("param1".to_string())),
-            Expr::Value(Value::NationalStringLiteral("param2".to_string())),
-        ],
-        has_parentheses: false,
-        using: vec![],
-    };
-    assert_eq!(
-        ms().verified_stmt("EXECUTE my_schema.my_stored_procedure N'param1', N'param2'"),
-        expected
-    );
-    assert_eq!(
-        Parser::parse_sql(
-            &MsSqlDialect {},
-            "EXEC my_schema.my_stored_procedure N'param1', N'param2';"
-        )
-        .unwrap()[0],
-        expected,
-        "EXEC should be parsed the same as EXECUTE"
-    );
-}
-
-#[test]
 fn parse_mssql_declare() {
     let sql = "DECLARE @foo CURSOR, @bar INT, @baz AS TEXT = 'foobar';";
     let ast = Parser::parse_sql(&MsSqlDialect {}, sql).unwrap();

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1538,8 +1538,9 @@ fn parse_execute() {
     assert_eq!(
         stmt,
         Statement::Execute {
-            name: "a".into(),
+            name: ObjectName(vec!["a".into()]),
             parameters: vec![],
+            has_parentheses: false,
             using: vec![]
         }
     );
@@ -1548,11 +1549,12 @@ fn parse_execute() {
     assert_eq!(
         stmt,
         Statement::Execute {
-            name: "a".into(),
+            name: ObjectName(vec!["a".into()]),
             parameters: vec![
                 Expr::Value(number("1")),
                 Expr::Value(Value::SingleQuotedString("t".to_string()))
             ],
+            has_parentheses: true,
             using: vec![]
         }
     );
@@ -1562,8 +1564,9 @@ fn parse_execute() {
     assert_eq!(
         stmt,
         Statement::Execute {
-            name: "a".into(),
+            name: ObjectName(vec!["a".into()]),
             parameters: vec![],
+            has_parentheses: false,
             using: vec![
                 Expr::Cast {
                     kind: CastKind::Cast,


### PR DESCRIPTION
This adds the following features from the Microsoft SQL Server EXECUTE statement:

Support EXEC as an alias to EXECUTE
fixes #1275

Support schema qualified stored procedures
fixes #1276

support unnamed parameters in mssql EXECUTE stored procedure calls
fixes #1489

@alamb, I would love if we could get this merge, since this is blocking for https://github.com/sqlpage/SQLPage/discussions/655