### PR TITLE
Fix the parsing error in MSSQL for multiple statements that include `DECLARE` statements

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -434,16 +434,6 @@ impl<'a> Parser<'a> {
             let statement = self.parse_statement()?;
             stmts.push(statement);
             expecting_statement_delimiter = true;
-            if self.peek_token().token != Token::SemiColon {
-                // If the next valid character is not a semicolon,
-                // check whether the previous valid character is a semicolon.
-                // If it is, revert to the previous valid character (i.e., the semicolon);
-                // otherwise, do nothing.
-                self.prev_token();
-                if self.peek_token().token != Token::SemiColon {
-                    self.next_token();
-                }
-            };
         }
         Ok(stmts)
     }
@@ -5364,7 +5354,7 @@ impl<'a> Parser<'a> {
                 for_query: None,
             });
 
-            if self.next_token() != Token::Comma {
+            if self.peek_token().token == Token::SemiColon || self.next_token() != Token::Comma {
                 break;
             }
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -434,6 +434,16 @@ impl<'a> Parser<'a> {
             let statement = self.parse_statement()?;
             stmts.push(statement);
             expecting_statement_delimiter = true;
+            if self.peek_token().token != Token::SemiColon {
+                // If the next valid character is not a semicolon,
+                // check whether the previous valid character is a semicolon.
+                // If it is, revert to the previous valid character (i.e., the semicolon);
+                // otherwise, do nothing.
+                self.prev_token();
+                if self.peek_token().token != Token::SemiColon {
+                    self.next_token();
+                }
+            };
         }
         Ok(stmts)
     }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -669,6 +669,7 @@ fn parse_mssql_declare() {
                 body: Box::new(SetExpr::Select(Box::new(Select {
                     distinct: None,
                     top: None,
+                    top_before_distinct: false,
                     projection: vec![SelectItem::UnnamedExpr(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("@bar"))),
                         op: BinaryOperator::Multiply,

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -29,7 +29,7 @@ use sqlparser::ast::DeclareAssignment::MsSqlAssignment;
 use sqlparser::ast::Value::SingleQuotedString;
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, MsSqlDialect};
-use sqlparser::parser::{Parser, ParserError};
+use sqlparser::parser::ParserError;
 
 #[test]
 fn parse_mssql_identifiers() {
@@ -575,7 +575,7 @@ fn parse_substring_in_select() {
 #[test]
 fn parse_mssql_declare() {
     let sql = "DECLARE @foo CURSOR, @bar INT, @baz AS TEXT = 'foobar';";
-    let ast = Parser::parse_sql(&MsSqlDialect {}, sql).unwrap();
+    let ast = ms().parse_sql_statements(sql).unwrap();
 
     assert_eq!(
         vec![Statement::Declare {
@@ -630,7 +630,7 @@ fn parse_mssql_declare() {
     );
 
     let sql = "DECLARE @bar INT;SET @bar = 2;SELECT @bar * 4";
-    let ast = Parser::parse_sql(&MsSqlDialect {}, sql).unwrap();
+    let ast = ms().parse_sql_statements(sql).unwrap();
     assert_eq!(
         vec![
             Statement::Declare {

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -628,6 +628,72 @@ fn parse_mssql_declare() {
         }],
         ast
     );
+
+    let sql = "DECLARE @bar INT;SET @bar = 2;SELECT @bar * 4";
+    let ast = Parser::parse_sql(&MsSqlDialect {}, sql).unwrap();
+    assert_eq!(
+        vec![
+            Statement::Declare {
+                stmts: vec![Declare {
+                    names: vec![Ident {
+                        value: "@bar".to_string(),
+                        quote_style: None
+                    }],
+                    data_type: Some(Int(None)),
+                    assignment: None,
+                    declare_type: None,
+                    binary: None,
+                    sensitive: None,
+                    scroll: None,
+                    hold: None,
+                    for_query: None
+                }]
+            },
+            Statement::SetVariable {
+                local: false,
+                hivevar: false,
+                variables: OneOrManyWithParens::One(ObjectName(vec![Ident::new("@bar")])),
+                value: vec![Expr::Value(Value::Number("2".parse().unwrap(), false))],
+            },
+            Statement::Query(Box::new(Query {
+                with: None,
+                limit: None,
+                limit_by: vec![],
+                offset: None,
+                fetch: None,
+                locks: vec![],
+                for_clause: None,
+                order_by: None,
+                settings: None,
+                format_clause: None,
+                body: Box::new(SetExpr::Select(Box::new(Select {
+                    distinct: None,
+                    top: None,
+                    projection: vec![SelectItem::UnnamedExpr(Expr::BinaryOp {
+                        left: Box::new(Expr::Identifier(Ident::new("@bar"))),
+                        op: BinaryOperator::Multiply,
+                        right: Box::new(Expr::Value(Value::Number("4".parse().unwrap(), false))),
+                    })],
+                    into: None,
+                    from: vec![],
+                    lateral_views: vec![],
+                    prewhere: None,
+                    selection: None,
+                    group_by: GroupByExpr::Expressions(vec![], vec![]),
+                    cluster_by: vec![],
+                    distribute_by: vec![],
+                    sort_by: vec![],
+                    having: None,
+                    named_window: vec![],
+                    window_before_qualify: false,
+                    qualify: None,
+                    value_table_mode: None,
+                    connect_by: None,
+                })))
+            }))
+        ],
+        ast
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR resolves an error in MSSQL that occurs when parsing multiple SQL statements containing `DECLARE` statements.

before
parse sql in mssql
```
declare @a int;
set @a = 2;
select @a * 4;
```
raise error
```
Error during parsing: ParserError("Expected: end of statement, found: set at Line: 2, Column: 1")
```

This resolves issue https://github.com/apache/datafusion-sqlparser-rs/issues/1450