### PR TITLE
Add support for Hive's `LOAD DATA` expr

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3329,6 +3329,22 @@ pub enum Statement {
         channel: Ident,
         payload: Option<String>,
     },
+    /// ```sql
+    /// LOAD DATA [LOCAL] INPATH 'filepath' [OVERWRITE] INTO TABLE tablename
+    /// [PARTITION (partcol1=val1, partcol2=val2 ...)]
+    /// [INPUTFORMAT 'inputformat' SERDE 'serde']
+    /// ```
+    /// Loading files into tables
+    ///
+    /// See Hive <https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27362036#LanguageManualDML-Loadingfilesintotables>
+    LoadData {
+        local: bool,
+        inpath: String,
+        overwrite: bool,
+        table_name: ObjectName,
+        partitioned: Option<Vec<Expr>>,
+        table_format: Option<HiveLoadDataOption>,
+    },
 }
 
 impl fmt::Display for Statement {
@@ -3931,6 +3947,36 @@ impl fmt::Display for Statement {
                 Ok(())
             }
             Statement::CreateTable(create_table) => create_table.fmt(f),
+            Statement::LoadData {
+                local,
+                inpath,
+                overwrite,
+                table_name,
+                partitioned,
+                table_format,
+            } => {
+                write!(
+                    f,
+                    "LOAD DATA {local}INPATH '{inpath}' {overwrite}INTO TABLE {table_name}",
+                    local = if *local { "LOCAL " } else { "" },
+                    inpath = inpath,
+                    overwrite = if *overwrite { "OVERWRITE " } else { "" },
+                    table_name = table_name,
+                )?;
+                if let Some(ref parts) = &partitioned {
+                    if !parts.is_empty() {
+                        write!(f, " PARTITION ({})", display_comma_separated(parts))?;
+                    }
+                }
+                if let Some(HiveLoadDataOption {
+                    serde,
+                    input_format,
+                }) = &table_format
+                {
+                    write!(f, " INPUTFORMAT {input_format} SERDE {serde}")?;
+                }
+                Ok(())
+            }
             Statement::CreateVirtualTable {
                 name,
                 if_not_exists,
@@ -5814,6 +5860,14 @@ pub enum HiveDistributionStyle {
 pub enum HiveRowFormat {
     SERDE { class: String },
     DELIMITED { delimiters: Vec<HiveRowDelimiter> },
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct HiveLoadDataOption {
+    pub serde: Expr,
+    pub input_format: Expr,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3343,7 +3343,7 @@ pub enum Statement {
         overwrite: bool,
         table_name: ObjectName,
         partitioned: Option<Vec<Expr>>,
-        table_format: Option<HiveLoadDataOption>,
+        table_format: Option<HiveLoadDataFormat>,
     },
 }
 
@@ -3968,7 +3968,7 @@ impl fmt::Display for Statement {
                         write!(f, " PARTITION ({})", display_comma_separated(parts))?;
                     }
                 }
-                if let Some(HiveLoadDataOption {
+                if let Some(HiveLoadDataFormat {
                     serde,
                     input_format,
                 }) = &table_format
@@ -5865,7 +5865,7 @@ pub enum HiveRowFormat {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
-pub struct HiveLoadDataOption {
+pub struct HiveLoadDataFormat {
     pub serde: Expr,
     pub input_format: Expr,
 }

--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -66,4 +66,9 @@ impl Dialect for DuckDbDialect {
     fn supports_explain_with_utility_options(&self) -> bool {
         true
     }
+
+    /// See DuckDB <https://duckdb.org/docs/sql/statements/load_and_install.html#load>
+    fn supports_load_extension(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -115,4 +115,8 @@ impl Dialect for GenericDialect {
     fn supports_comment_on(&self) -> bool {
         true
     }
+
+    fn supports_load_extension(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/hive.rs
+++ b/src/dialect/hive.rs
@@ -56,4 +56,9 @@ impl Dialect for HiveDialect {
     fn supports_bang_not_operator(&self) -> bool {
         true
     }
+
+    /// See Hive <https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27362036#LanguageManualDML-Loadingfilesintotables>
+    fn supports_load_data(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -611,6 +611,16 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports the `LOAD DATA` statement
+    fn supports_load_data(&self) -> bool {
+        false
+    }
+
+    /// Returns true if the dialect supports the `LOAD extension` statement
+    fn supports_load_extension(&self) -> bool {
+        false
+    }
+
     /// Returns true if this dialect expects the `TOP` option
     /// before the `ALL`/`DISTINCT` options in a `SELECT` statement.
     fn supports_top_before_distinct(&self) -> bool {

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -389,6 +389,7 @@ define_keywords!(
     INITIALLY,
     INNER,
     INOUT,
+    INPATH,
     INPUT,
     INPUTFORMAT,
     INSENSITIVE,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12218,7 +12218,7 @@ impl<'a> Parser<'a> {
             })
         } else {
             self.expected(
-                "dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements",
+                " DATA` or an extension name after `LOAD`",
                 self.peek_token(),
             )
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11177,12 +11177,12 @@ impl<'a> Parser<'a> {
 
     pub fn parse_load_data_table_format(
         &mut self,
-    ) -> Result<Option<HiveLoadDataOption>, ParserError> {
+    ) -> Result<Option<HiveLoadDataFormat>, ParserError> {
         if self.parse_keyword(Keyword::INPUTFORMAT) {
             let input_format = self.parse_expr()?;
             self.expect_keyword(Keyword::SERDE)?;
             let serde = self.parse_expr()?;
-            Ok(Some(HiveLoadDataOption {
+            Ok(Some(HiveLoadDataFormat {
                 input_format,
                 serde,
             }))
@@ -12218,7 +12218,7 @@ impl<'a> Parser<'a> {
             })
         } else {
             self.expected(
-                "Expected: dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements",
+                "dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements",
                 self.peek_token(),
             )
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12218,7 +12218,7 @@ impl<'a> Parser<'a> {
             })
         } else {
             self.expected(
-                " DATA` or an extension name after `LOAD`",
+                "`DATA` or an extension name after `LOAD`",
                 self.peek_token(),
             )
         }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11503,10 +11503,6 @@ fn parse_notify_channel() {
             dialects.parse_sql_statements(sql).unwrap_err(),
             ParserError::ParserError("Expected: an SQL statement, found: NOTIFY".to_string())
         );
-        assert_eq!(
-            dialects.parse_sql_statements(sql).unwrap_err(),
-            ParserError::ParserError("Expected: an SQL statement, found: NOTIFY".to_string())
-        );
     }
 }
 
@@ -11626,10 +11622,20 @@ fn parse_load_data() {
                         op: BinaryOperator::Eq,
                         right:  Box::new(Expr::Value(Value::Number("11".parse().unwrap(), false))),
                     }]), partitioned);
-                assert_eq!(Some(HiveLoadDataOption {serde: Expr::Value(Value::SingleQuotedString("org.apache.hadoop.hive.serde2.OpenCSVSerde".to_string())), input_format: Expr::Value(Value::SingleQuotedString("org.apache.hadoop.mapred.TextInputFormat".to_string()))}), table_format);
+                assert_eq!(Some(HiveLoadDataFormat {serde: Expr::Value(Value::SingleQuotedString("org.apache.hadoop.hive.serde2.OpenCSVSerde".to_string())), input_format: Expr::Value(Value::SingleQuotedString("org.apache.hadoop.mapred.TextInputFormat".to_string()))}), table_format);
             }
             _ => unreachable!(),
         };
+
+    // negative test case
+    assert_eq!(
+            dialects
+                .parse_sql_statements(
+                    "LOAD DATA2 LOCAL INPATH '/local/path/to/data.txt' INTO TABLE test.my_table"
+                )
+                .unwrap_err(),
+            ParserError::ParserError("Expected: dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements, found: DATA2".to_string())
+        );
 
     let dialects = all_dialects_where(|d| !d.supports_load_data() && d.supports_load_extension());
 
@@ -11655,12 +11661,12 @@ fn parse_load_data() {
 
     assert_eq!(
         dialects.parse_sql_statements("LOAD DATA LOCAL INPATH '/local/path/to/data.txt' INTO TABLE test.my_table").unwrap_err(),
-        ParserError::ParserError("Expected: Expected: dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements, found: LOCAL".to_string())
+        ParserError::ParserError("Expected: dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements, found: LOCAL".to_string())
     );
 
     assert_eq!(
         dialects.parse_sql_statements("LOAD DATA INPATH '/local/path/to/data.txt' INTO TABLE test.my_table").unwrap_err(),
-        ParserError::ParserError("Expected: Expected: dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements, found: INPATH".to_string())
+        ParserError::ParserError("Expected: dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements, found: INPATH".to_string())
     );
 }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11564,8 +11564,13 @@ fn parse_load_data() {
             .unwrap_err(),
         ParserError::ParserError("Expected: end of statement, found: INPATH".to_string())
     );
-    assert_eq!( not_supports_load_dialects.parse_sql_statements(sql).unwrap_err(),
-        ParserError::ParserError("Expected: dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements, found: INPATH".to_string())
+    assert_eq!(
+        not_supports_load_dialects
+            .parse_sql_statements(sql)
+            .unwrap_err(),
+        ParserError::ParserError(
+            "Expected: `DATA` or an extension name after `LOAD`, found: INPATH".to_string()
+        )
     );
 
     // with LOCAL keyword
@@ -11599,8 +11604,12 @@ fn parse_load_data() {
         ParserError::ParserError("Expected: end of statement, found: LOCAL".to_string())
     );
     assert_eq!(
-        not_supports_load_dialects.parse_sql_statements(sql).unwrap_err(),
-        ParserError::ParserError("Expected: dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements, found: LOCAL".to_string())
+        not_supports_load_dialects
+            .parse_sql_statements(sql)
+            .unwrap_err(),
+        ParserError::ParserError(
+            "Expected: `DATA` or an extension name after `LOAD`, found: LOCAL".to_string()
+        )
     );
 
     // with PARTITION  clause
@@ -11689,11 +11698,11 @@ fn parse_load_data() {
     // negative test case
     let sql = "LOAD DATA2 LOCAL INPATH '/local/path/to/data.txt' INTO TABLE test.my_table";
     assert_eq!(
-            dialects
-                .parse_sql_statements(sql)
-                .unwrap_err(),
-            ParserError::ParserError("Expected: dialect supports `LOAD DATA` or `LOAD extension` to parse `LOAD` statements, found: DATA2".to_string())
-        );
+        dialects.parse_sql_statements(sql).unwrap_err(),
+        ParserError::ParserError(
+            "Expected: `DATA` or an extension name after `LOAD`, found: DATA2".to_string()
+        )
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR supports `LOAD DATA` clause for hive dialect,. For more information, please refer to:
https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27362036#LanguageManualDML-Loadingfilesintotables

It also introduces the following keywords:
- INPATH

