### PR TITLE
Add support for PostgreSQL `UNLISTEN` syntax and Add support for Postgres `LOAD extension` expr

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3340,6 +3340,13 @@ pub enum Statement {
     /// See Postgres <https://www.postgresql.org/docs/current/sql-listen.html>
     LISTEN { channel: Ident },
     /// ```sql
+    /// UNLISTEN
+    /// ```
+    /// stop listening for a notification
+    ///
+    /// See Postgres <https://www.postgresql.org/docs/current/sql-unlisten.html>
+    UNLISTEN { channel: Ident },
+    /// ```sql
     /// NOTIFY channel [ , payload ]
     /// ```
     /// send a notification event together with an optional “payload” string to channel
@@ -4946,6 +4953,10 @@ impl fmt::Display for Statement {
             }
             Statement::LISTEN { channel } => {
                 write!(f, "LISTEN {channel}")?;
+                Ok(())
+            }
+            Statement::UNLISTEN { channel } => {
+                write!(f, "UNLISTEN {channel}")?;
                 Ok(())
             }
             Statement::NOTIFY { channel, payload } => {

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -633,18 +633,8 @@ pub trait Dialect: Debug + Any {
         false
     }
 
-    /// Returns true if the dialect supports the `LISTEN` statement
-    fn supports_listen(&self) -> bool {
-        false
-    }
-
-    /// Returns true if the dialect supports the `UNLISTEN` statement
-    fn supports_unlisten(&self) -> bool {
-        false
-    }
-
-    /// Returns true if the dialect supports the `NOTIFY` statement
-    fn supports_notify(&self) -> bool {
+    /// Returns true if the dialect supports the `LISTEN`, `UNLISTEN` and `NOTIFY` statements
+    fn supports_listen_notify(&self) -> bool {
         false
     }
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -638,6 +638,11 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports the `UNLISTEN` statement
+    fn supports_unlisten(&self) -> bool {
+        false
+    }
+
     /// Returns true if the dialect supports the `NOTIFY` statement
     fn supports_notify(&self) -> bool {
         false

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -191,17 +191,9 @@ impl Dialect for PostgreSqlDialect {
     }
 
     /// see <https://www.postgresql.org/docs/current/sql-listen.html>
-    fn supports_listen(&self) -> bool {
-        true
-    }
-
     /// see <https://www.postgresql.org/docs/current/sql-unlisten.html>
-    fn supports_unlisten(&self) -> bool {
-        true
-    }
-
     /// see <https://www.postgresql.org/docs/current/sql-notify.html>
-    fn supports_notify(&self) -> bool {
+    fn supports_listen_notify(&self) -> bool {
         true
     }
 

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -195,6 +195,11 @@ impl Dialect for PostgreSqlDialect {
         true
     }
 
+    /// see <https://www.postgresql.org/docs/current/sql-unlisten.html>
+    fn supports_unlisten(&self) -> bool {
+        true
+    }
+
     /// see <https://www.postgresql.org/docs/current/sql-notify.html>
     fn supports_notify(&self) -> bool {
         true

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -214,6 +214,11 @@ impl Dialect for PostgreSqlDialect {
     fn supports_comment_on(&self) -> bool {
         true
     }
+
+    /// See <https://www.postgresql.org/docs/current/sql-load.html>
+    fn supports_load_extension(&self) -> bool {
+        true
+    }
 }
 
 pub fn parse_create(parser: &mut Parser) -> Option<Result<Statement, ParserError>> {

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -799,6 +799,7 @@ define_keywords!(
     UNION,
     UNIQUE,
     UNKNOWN,
+    UNLISTEN,
     UNLOAD,
     UNLOCK,
     UNLOGGED,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1008,7 +1008,7 @@ impl<'a> Parser<'a> {
                 Ok(expr) => expr,
                 _ => {
                     self.prev_token();
-                    return self.expected("wildcard or identent", self.peek_token());
+                    return self.expected("wildcard or identifier", self.peek_token());
                 }
             }
         };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -532,9 +532,10 @@ impl<'a> Parser<'a> {
                 Keyword::EXECUTE | Keyword::EXEC => self.parse_execute(),
                 Keyword::PREPARE => self.parse_prepare(),
                 Keyword::MERGE => self.parse_merge(),
-                // `LISTEN` and `NOTIFY` are Postgres-specific
+                // `LISTEN`, `UNLISTEN` and `NOTIFY` are Postgres-specific
                 // syntaxes. They are used for Postgres statement.
                 Keyword::LISTEN if self.dialect.supports_listen() => self.parse_listen(),
+                Keyword::UNLISTEN if self.dialect.supports_unlisten() => self.parse_unlisten(),
                 Keyword::NOTIFY if self.dialect.supports_notify() => self.parse_notify(),
                 // `PRAGMA` is sqlite specific https://www.sqlite.org/pragma.html
                 Keyword::PRAGMA => self.parse_pragma(),
@@ -997,6 +998,21 @@ impl<'a> Parser<'a> {
     pub fn parse_listen(&mut self) -> Result<Statement, ParserError> {
         let channel = self.parse_identifier(false)?;
         Ok(Statement::LISTEN { channel })
+    }
+
+    pub fn parse_unlisten(&mut self) -> Result<Statement, ParserError> {
+        let channel = if self.consume_token(&Token::Mul) {
+            Ident::new(Expr::Wildcard.to_string())
+        } else {
+            match self.parse_identifier(false) {
+                Ok(expr) => expr,
+                _ => {
+                    self.prev_token();
+                    return self.expected("wildcard or identent", self.peek_token());
+                }
+            }
+        };
+        Ok(Statement::UNLISTEN { channel })
     }
 
     pub fn parse_notify(&mut self) -> Result<Statement, ParserError> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -534,9 +534,9 @@ impl<'a> Parser<'a> {
                 Keyword::MERGE => self.parse_merge(),
                 // `LISTEN`, `UNLISTEN` and `NOTIFY` are Postgres-specific
                 // syntaxes. They are used for Postgres statement.
-                Keyword::LISTEN if self.dialect.supports_listen() => self.parse_listen(),
-                Keyword::UNLISTEN if self.dialect.supports_unlisten() => self.parse_unlisten(),
-                Keyword::NOTIFY if self.dialect.supports_notify() => self.parse_notify(),
+                Keyword::LISTEN if self.dialect.supports_listen_notify() => self.parse_listen(),
+                Keyword::UNLISTEN if self.dialect.supports_listen_notify() => self.parse_unlisten(),
+                Keyword::NOTIFY if self.dialect.supports_listen_notify() => self.parse_notify(),
                 // `PRAGMA` is sqlite specific https://www.sqlite.org/pragma.html
                 Keyword::PRAGMA => self.parse_pragma(),
                 Keyword::UNLOAD => self.parse_unload(),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11637,7 +11637,7 @@ fn parse_unlisten_channel() {
 
     assert_eq!(
         dialects.parse_sql_statements("UNLISTEN +").unwrap_err(),
-        ParserError::ParserError("Expected: wildcard or identent, found: +".to_string())
+        ParserError::ParserError("Expected: wildcard or identifier, found: +".to_string())
     );
 
     let dialects = all_dialects_where(|d| !d.supports_listen());
@@ -11898,10 +11898,7 @@ fn parse_load_data() {
 #[test]
 fn test_load_extension() {
     let dialects = all_dialects_where(|d| d.supports_load_extension());
-    let only_supports_load_data_dialects =
-        all_dialects_where(|d| !d.supports_load_extension() && d.supports_load_data());
-    let not_supports_load_dialects =
-        all_dialects_where(|d| !d.supports_load_data() && !d.supports_load_extension());
+    let not_supports_load_extension_dialects = all_dialects_where(|d| !d.supports_load_extension());
     let sql = "LOAD my_extension";
 
     match dialects.verified_stmt(sql) {
@@ -11912,16 +11909,7 @@ fn test_load_extension() {
     };
 
     assert_eq!(
-        only_supports_load_data_dialects
-            .parse_sql_statements(sql)
-            .unwrap_err(),
-        ParserError::ParserError(
-            "Expected: `DATA` or an extension name after `LOAD`, found: my_extension".to_string()
-        )
-    );
-
-    assert_eq!(
-        not_supports_load_dialects
+        not_supports_load_extension_dialects
             .parse_sql_statements(sql)
             .unwrap_err(),
         ParserError::ParserError(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11618,6 +11618,37 @@ fn parse_listen_channel() {
 }
 
 #[test]
+fn parse_unlisten_channel() {
+    let dialects = all_dialects_where(|d| d.supports_unlisten());
+
+    match dialects.verified_stmt("UNLISTEN test1") {
+        Statement::UNLISTEN { channel } => {
+            assert_eq!(Ident::new("test1"), channel);
+        }
+        _ => unreachable!(),
+    };
+
+    match dialects.verified_stmt("UNLISTEN *") {
+        Statement::UNLISTEN { channel } => {
+            assert_eq!(Ident::new("*"), channel);
+        }
+        _ => unreachable!(),
+    };
+
+    assert_eq!(
+        dialects.parse_sql_statements("UNLISTEN +").unwrap_err(),
+        ParserError::ParserError("Expected: wildcard or identent, found: +".to_string())
+    );
+
+    let dialects = all_dialects_where(|d| !d.supports_listen());
+
+    assert_eq!(
+        dialects.parse_sql_statements("UNLISTEN test1").unwrap_err(),
+        ParserError::ParserError("Expected: an SQL statement, found: UNLISTEN".to_string())
+    );
+}
+
+#[test]
 fn parse_notify_channel() {
     let dialects = all_dialects_where(|d| d.supports_notify());
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11595,7 +11595,7 @@ fn test_show_dbs_schemas_tables_views() {
 
 #[test]
 fn parse_listen_channel() {
-    let dialects = all_dialects_where(|d| d.supports_listen());
+    let dialects = all_dialects_where(|d| d.supports_listen_notify());
 
     match dialects.verified_stmt("LISTEN test1") {
         Statement::LISTEN { channel } => {
@@ -11609,7 +11609,7 @@ fn parse_listen_channel() {
         ParserError::ParserError("Expected: identifier, found: *".to_string())
     );
 
-    let dialects = all_dialects_where(|d| !d.supports_listen());
+    let dialects = all_dialects_where(|d| !d.supports_listen_notify());
 
     assert_eq!(
         dialects.parse_sql_statements("LISTEN test1").unwrap_err(),
@@ -11619,7 +11619,7 @@ fn parse_listen_channel() {
 
 #[test]
 fn parse_unlisten_channel() {
-    let dialects = all_dialects_where(|d| d.supports_unlisten());
+    let dialects = all_dialects_where(|d| d.supports_listen_notify());
 
     match dialects.verified_stmt("UNLISTEN test1") {
         Statement::UNLISTEN { channel } => {
@@ -11640,7 +11640,7 @@ fn parse_unlisten_channel() {
         ParserError::ParserError("Expected: wildcard or identifier, found: +".to_string())
     );
 
-    let dialects = all_dialects_where(|d| !d.supports_listen());
+    let dialects = all_dialects_where(|d| !d.supports_listen_notify());
 
     assert_eq!(
         dialects.parse_sql_statements("UNLISTEN test1").unwrap_err(),
@@ -11650,7 +11650,7 @@ fn parse_unlisten_channel() {
 
 #[test]
 fn parse_notify_channel() {
-    let dialects = all_dialects_where(|d| d.supports_notify());
+    let dialects = all_dialects_where(|d| d.supports_listen_notify());
 
     match dialects.verified_stmt("NOTIFY test1") {
         Statement::NOTIFY { channel, payload } => {
@@ -11686,7 +11686,7 @@ fn parse_notify_channel() {
         "NOTIFY test1",
         "NOTIFY test1, 'this is a test notification'",
     ];
-    let dialects = all_dialects_where(|d| !d.supports_notify());
+    let dialects = all_dialects_where(|d| !d.supports_listen_notify());
 
     for &sql in &sql_statements {
         assert_eq!(

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -360,20 +360,6 @@ fn test_duckdb_install() {
 }
 
 #[test]
-fn test_duckdb_load_extension() {
-    let stmt = duckdb().verified_stmt("LOAD my_extension");
-    assert_eq!(
-        Statement::Load {
-            extension_name: Ident {
-                value: "my_extension".to_string(),
-                quote_style: None
-            }
-        },
-        stmt
-    );
-}
-
-#[test]
 fn test_duckdb_struct_literal() {
     //struct literal syntax https://duckdb.org/docs/sql/data_types/struct#creating-structs
     //syntax: {'field_name': expr1[, ... ]}


### PR DESCRIPTION
This PR supports two PostgreSQL syntaxes，one is
- `UNLISTEN` clause,. For more information, please refer to:
https://www.postgresql.org/docs/current/sql-unlisten.html

and the other is 
-  `LOAD extension` . For more information, please refer to:
https://www.postgresql.org/docs/current/sql-load.html

It also introduces the following keywords:
- UNLISTEN

