### PR TITLE
Add support for data type specific methods

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1224,6 +1224,17 @@ impl<'a> Parser<'a> {
                             body: Box::new(self.parse_expr()?),
                         }));
                     }
+                    Token::DoubleColon if self.dialect.supports_methods() => {
+                        let namespace = w.value;
+                        self.expect_token(&Token::DoubleColon)?;
+                        let name_with_namespace = match self.next_token().token {
+                            Token::Word(func_name) => {
+                                ObjectName(vec![Ident::new(format!("{}::{}", namespace, func_name.value))])
+                            },
+                            _ => return self.expected("identifier", self.peek_token())
+                        };
+                        Ok(self.parse_function(name_with_namespace)?)
+                    }
                     _ => Ok(Expr::Identifier(w.to_ident())),
                 },
             }, // End of Token::Word

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11550,6 +11550,14 @@ fn parse_method_expr() {
         }
         _ => unreachable!(),
     }
+    
+    dialects.verified_stmt(
+        "SELECT phone, some_namespace::some_function().method_a(345345) FROM customers"
+    );
+
+    dialects.verified_stmt(
+        "SELECT geography::STGeomFromText('POLYGON((-122.358 47.653, -122.348 47.649, -122.348 47.658, -122.358 47.658, -122.358 47.653))', 4326).STAsText() FROM customers"
+    );
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11550,9 +11550,9 @@ fn parse_method_expr() {
         }
         _ => unreachable!(),
     }
-    
+
     dialects.verified_stmt(
-        "SELECT phone, some_namespace::some_function().method_a(345345) FROM customers"
+        "SELECT phone, some_namespace::some_function().method_a(345345) FROM customers",
     );
 
     dialects.verified_stmt(


### PR DESCRIPTION
This PR adds support for static method invocations of data type-specific methods. For example: 
`SELECT geography::STGeomFromText('LINESTRING(-122.360 47.656, -122.343 47.656 )', 4326)`

See more here: https://learn.microsoft.com/en-us/sql/t-sql/spatial-geography/spatial-types-geography?view=sql-server-ver16