### PR TITLE
Enhance the nested type access for Generic and DuckDB dialect

### DIFF
--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -72,4 +72,8 @@ impl Dialect for BigQueryDialect {
     fn require_interval_qualifier(&self) -> bool {
         true
     }
+
+    fn support_period_map_access_key(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -71,4 +71,9 @@ impl Dialect for DuckDbDialect {
     fn supports_load_extension(&self) -> bool {
         true
     }
+
+    /// See DuckDB <https://duckdb.org/docs/sql/data_types/struct.html#retrieving-from-structs>
+    fn support_period_map_access_key(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -119,4 +119,8 @@ impl Dialect for GenericDialect {
     fn supports_load_extension(&self) -> bool {
         true
     }
+
+    fn support_period_map_access_key(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -657,6 +657,15 @@ pub trait Dialect: Debug + Any {
     fn supports_create_table_select(&self) -> bool {
         false
     }
+
+    /// Return true if the dialect supports the period map access key
+    ///
+    /// Access on BigQuery nested and repeated expressions can
+    /// mix notations in the same expression.
+    /// https://cloud.google.com/bigquery/docs/nested-repeated#query_nested_and_repeated_columns
+    fn support_period_map_access_key(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -680,7 +680,7 @@ pub trait Dialect: Debug + Any {
     ///
     /// Access on BigQuery nested and repeated expressions can
     /// mix notations in the same expression.
-    /// https://cloud.google.com/bigquery/docs/nested-repeated#query_nested_and_repeated_columns
+    /// <https://cloud.google.com/bigquery/docs/nested-repeated#query_nested_and_repeated_columns>
     fn support_period_map_access_key(&self) -> bool {
         false
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3047,7 +3047,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse an multi-dimension array accessing like '[1:3][1][1]'
+    /// Parse an multi-dimension array accessing like `[1:3][1][1]`
     ///
     /// Parser is right after the first `[`
     pub fn parse_multi_dim_subscript(&mut self, mut expr: Expr) -> Result<Expr, ParserError> {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -12013,3 +12013,25 @@ fn parse_create_table_select() {
         );
     }
 }
+
+#[test]
+fn test_period_map_access() {
+    let supported_dialects = TestedDialects::new(vec![
+        Box::new(GenericDialect {}),
+        Box::new(DuckDbDialect {}),
+    ]);
+    let sqls = [
+        "SELECT abc[1] FROM t",
+        "SELECT abc[1].f1 FROM t",
+        "SELECT abc[1].f1.f2 FROM t",
+        "SELECT f1.abc[1] FROM t",
+        "SELECT f1.f2.abc[1] FROM t",
+        "SELECT f1.abc[1].f2 FROM t",
+        "SELECT abc['a'][1].f1 FROM t",
+        "SELECT abc['a'].f1[1].f2 FROM t",
+        "SELECT abc['a'].f1[1].f2[2] FROM t",
+    ];
+    for sql in sqls {
+        supported_dialects.verified_stmt(sql);
+    }
+}


### PR DESCRIPTION
# Description
- Close #1533 
- Allow Generic and DuckDB dialects to parse the access chain of a nested type like
```
select c1[1].f1.f2[2] from t1
```
- make `support_period_map_access_key` configurable.

# TODO items
- allow the SQL access the map element from a function call: `SELECT named_struct('a', 1, 'b', 2).a`

