### PR TITLE
Support Databricks struct literal

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -935,12 +935,14 @@ pub enum Expr {
     /// Syntax:
     /// ```sql
     /// STRUCT<[field_name] field_type, ...>( expr1 [, ... ])
+    ///
+    /// [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type)
+    /// [Databricks](https://docs.databricks.com/en/sql/language-manual/functions/struct.html)
     /// ```
     Struct {
         /// Struct values.
         values: Vec<Expr>,
-        /// BigQuery specific: Struct field definitions.
-        /// see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type
+        /// Struct field definitions.
         fields: Vec<StructField>,
     },
     /// `BigQuery` specific: An named expression in a typeless struct [1]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -931,16 +931,16 @@ pub enum Expr {
     Rollup(Vec<Vec<Expr>>),
     /// ROW / TUPLE a single value, such as `SELECT (1, 2)`
     Tuple(Vec<Expr>),
-    /// `BigQuery` specific `Struct` literal expression [1]
+    /// `Struct` literal expression
     /// Syntax:
     /// ```sql
     /// STRUCT<[field_name] field_type, ...>( expr1 [, ... ])
     /// ```
-    /// [1]: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type
     Struct {
         /// Struct values.
         values: Vec<Expr>,
-        /// Struct field definitions.
+        /// BigQuery specific: Struct field definitions.
+        /// see https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#struct_type
         fields: Vec<StructField>,
     },
     /// `BigQuery` specific: An named expression in a typeless struct [1]

--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -77,9 +77,4 @@ impl Dialect for BigQueryDialect {
     fn supports_struct_literal(&self) -> bool {
         true
     }
-
-    // See https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#typed_struct_syntax
-    fn supports_typed_struct_syntax(&self) -> bool {
-        true
-    }
 }

--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -72,4 +72,14 @@ impl Dialect for BigQueryDialect {
     fn require_interval_qualifier(&self) -> bool {
         true
     }
+
+    // See https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#constructing_a_struct
+    fn supports_struct_literal(&self) -> bool {
+        true
+    }
+
+    // See https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#typed_struct_syntax
+    fn supports_typed_struct_syntax(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/databricks.rs
+++ b/src/dialect/databricks.rs
@@ -59,4 +59,9 @@ impl Dialect for DatabricksDialect {
     fn require_interval_qualifier(&self) -> bool {
         true
     }
+
+    // See https://docs.databricks.com/en/sql/language-manual/functions/struct.html
+    fn supports_struct_literal(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -123,4 +123,12 @@ impl Dialect for GenericDialect {
     fn supports_named_fn_args_with_assignment_operator(&self) -> bool {
         true
     }
+
+    fn supports_struct_literal(&self) -> bool {
+        true
+    }
+
+    fn supports_typed_struct_syntax(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -127,8 +127,4 @@ impl Dialect for GenericDialect {
     fn supports_struct_literal(&self) -> bool {
         true
     }
-
-    fn supports_typed_struct_syntax(&self) -> bool {
-        true
-    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -385,16 +385,6 @@ pub trait Dialect: Debug + Any {
         false
     }
 
-    /// Return true if the dialect supports typed struct syntax
-    ///
-    /// Example for bigquery
-    /// ```sql
-    /// SELECT STRUCT<x int64, y string>(1, 'foo')
-    /// ```
-    fn supports_typed_struct_syntax(&self) -> bool {
-        false
-    }
-
     /// Dialect-specific infix parser override
     ///
     /// This method is called to parse the next infix expression.

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -375,6 +375,26 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Return true if the dialect supports the STRUCT literal
+    ///
+    /// Example
+    /// ```sql
+    /// SELECT STRUCT(1 as one, 'foo' as foo, false)
+    /// ```
+    fn supports_struct_literal(&self) -> bool {
+        false
+    }
+
+    /// Return true if the dialect supports typed struct syntax
+    ///
+    /// Example for bigquery
+    /// ```sql
+    /// SELECT STRUCT<x int64, y string>(1, 'foo')
+    /// ```
+    fn supports_typed_struct_syntax(&self) -> bool {
+        false
+    }
+
     /// Dialect-specific infix parser override
     ///
     /// This method is called to parse the next infix expression.

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -282,7 +282,7 @@ fn parse_use() {
 #[test]
 fn parse_databricks_struct_function() {
     assert_eq!(
-        databricks()
+        databricks_and_generic()
             .verified_only_select("SELECT STRUCT(1, 'foo')")
             .projection[0],
         SelectItem::UnnamedExpr(Expr::Struct {
@@ -294,7 +294,7 @@ fn parse_databricks_struct_function() {
         })
     );
     assert_eq!(
-        databricks()
+        databricks_and_generic()
             .verified_only_select("SELECT STRUCT(1 AS one, 'foo' AS foo, false)")
             .projection[0],
         SelectItem::UnnamedExpr(Expr::Struct {
@@ -311,15 +311,5 @@ fn parse_databricks_struct_function() {
             ],
             fields: vec![]
         })
-    );
-}
-
-#[test]
-fn parse_invalid_struct_function() {
-    assert_eq!(
-        databricks()
-            .parse_sql_statements("SELECT STRUCT<INT64>(1)") // This works only in BigQuery
-            .unwrap_err(),
-        ParserError::ParserError("Expected: (, found: <".to_string())
     );
 }


### PR DESCRIPTION
Databricks supports struct literal (struct function). Struct literal is already added for BigQuery. Databricks' syntax is very similar to the BigQuery one, except the fields definition part.
I added `supports_struct_literal` to `Dialect` trait to specify if the dialect support this literal or not

Databricks docs: https://docs.databricks.com/en/sql/language-manual/functions/struct.html
