### PR TITLE
Include license file in sqlparser_derive crate

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -28,6 +28,7 @@ license = "Apache-2.0"
 include = [
     "src/**/*.rs",
     "Cargo.toml",
+    "LICENSE.TXT",
 ]
 edition = "2021"
 

--- a/derive/LICENSE.TXT
+++ b/derive/LICENSE.TXT
@@ -1,0 +1,1 @@
+../LICENSE.TXT


### PR DESCRIPTION
Hi, this applies #871 to the `sqlparser_derive` crate.