### PR TITLE
Fix clippy warnings on rust 1.83

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1327,15 +1327,18 @@ pub enum ColumnOption {
     /// `DEFAULT <restricted-expr>`
     Default(Expr),
 
-    /// ClickHouse supports `MATERIALIZE`, `EPHEMERAL` and `ALIAS` expr to generate default values.
-    /// Syntax: `b INT MATERIALIZE (a + 1)`
-    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/create/table#default_values)
-
     /// `MATERIALIZE <expr>`
+    /// Syntax: `b INT MATERIALIZE (a + 1)`
+    ///
+    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/create/table#default_values)
     Materialized(Expr),
     /// `EPHEMERAL [<expr>]`
+    ///
+    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/create/table#default_values)
     Ephemeral(Option<Expr>),
     /// `ALIAS <expr>`
+    ///
+    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/create/table#default_values)
     Alias(Expr),
 
     /// `{ PRIMARY KEY | UNIQUE } [<constraint_characteristics>]`
@@ -1552,7 +1555,7 @@ pub enum GeneratedExpressionMode {
 #[must_use]
 fn display_constraint_name(name: &'_ Option<Ident>) -> impl fmt::Display + '_ {
     struct ConstraintName<'a>(&'a Option<Ident>);
-    impl<'a> fmt::Display for ConstraintName<'a> {
+    impl fmt::Display for ConstraintName<'_> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(name) = self.0 {
                 write!(f, "CONSTRAINT {name} ")?;
@@ -1573,7 +1576,7 @@ fn display_option<'a, T: fmt::Display>(
     option: &'a Option<T>,
 ) -> impl fmt::Display + 'a {
     struct OptionDisplay<'a, T>(&'a str, &'a str, &'a Option<T>);
-    impl<'a, T: fmt::Display> fmt::Display for OptionDisplay<'a, T> {
+    impl<T: fmt::Display> fmt::Display for OptionDisplay<'_, T> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(inner) = self.2 {
                 let (prefix, postfix) = (self.0, self.1);

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -110,7 +110,7 @@ where
     sep: &'static str,
 }
 
-impl<'a, T> fmt::Display for DisplaySeparated<'a, T>
+impl<T> fmt::Display for DisplaySeparated<'_, T>
 where
     T: fmt::Display,
 {

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1713,7 +1713,7 @@ impl fmt::Display for Join {
         }
         fn suffix(constraint: &'_ JoinConstraint) -> impl fmt::Display + '_ {
             struct Suffix<'a>(&'a JoinConstraint);
-            impl<'a> fmt::Display for Suffix<'a> {
+            impl fmt::Display for Suffix<'_> {
                 fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                     match self.0 {
                         JoinConstraint::On(expr) => write!(f, " ON {expr}"),

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -261,7 +261,7 @@ pub struct EscapeQuotedString<'a> {
     quote: char,
 }
 
-impl<'a> fmt::Display for EscapeQuotedString<'a> {
+impl fmt::Display for EscapeQuotedString<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // EscapeQuotedString doesn't know which mode of escape was
         // chosen by the user. So this code must to correctly display
@@ -325,7 +325,7 @@ pub fn escape_double_quote_string(s: &str) -> EscapeQuotedString<'_> {
 
 pub struct EscapeEscapedStringLiteral<'a>(&'a str);
 
-impl<'a> fmt::Display for EscapeEscapedStringLiteral<'a> {
+impl fmt::Display for EscapeEscapedStringLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for c in self.0.chars() {
             match c {
@@ -359,7 +359,7 @@ pub fn escape_escaped_string(s: &str) -> EscapeEscapedStringLiteral<'_> {
 
 pub struct EscapeUnicodeStringLiteral<'a>(&'a str);
 
-impl<'a> fmt::Display for EscapeUnicodeStringLiteral<'a> {
+impl fmt::Display for EscapeUnicodeStringLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for c in self.0.chars() {
             match c {

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -26,7 +26,7 @@ use crate::{
     tokenizer::Token,
 };
 
-impl<'a> Parser<'a> {
+impl Parser<'_> {
     pub fn parse_alter_role(&mut self) -> Result<Statement, ParserError> {
         if dialect_of!(self is PostgreSqlDialect) {
             return self.parse_pg_alter_role();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10883,13 +10883,12 @@ impl<'a> Parser<'a> {
         Ok(ExprWithAlias { expr, alias })
     }
     /// Parses an expression with an optional alias
-
+    ///
     /// Examples:
-
+    ///
     /// ```sql
     /// SUM(price) AS total_price
     /// ```
-
     /// ```sql
     /// SUM(price)
     /// ```
@@ -10905,7 +10904,6 @@ impl<'a> Parser<'a> {
     /// assert_eq!(Some("b".to_string()), expr_with_alias.alias.map(|x|x.value));
     /// # Ok(())
     /// # }
-
     pub fn parse_expr_with_alias(&mut self) -> Result<ExprWithAlias, ParserError> {
         let expr = self.parse_expr()?;
         let alias = if self.parse_keyword(Keyword::AS) {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -584,7 +584,7 @@ struct State<'a> {
     pub col: u64,
 }
 
-impl<'a> State<'a> {
+impl State<'_> {
     /// return the next character and advance the stream
     pub fn next(&mut self) -> Option<char> {
         match self.peekable.next() {


### PR DESCRIPTION
Fixes [clippy warnings](https://github.com/apache/datafusion-sqlparser-rs/actions/runs/12071816871/job/33664408289?pr=1552) on 1.83

Closes https://github.com/apache/datafusion-sqlparser-rs/issues/1569