### PR TITLE
Increase version of sqlparser_derive from 0.2.2 to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 # of dev-dependencies because of
 # https://github.com/rust-lang/cargo/issues/1596
 serde_json = { version = "1.0", optional = true }
-sqlparser_derive = { version = "0.2.0", path = "derive", optional = true }
+sqlparser_derive = { version = "0.3.0", path = "derive", optional = true }
 
 [dev-dependencies]
 simple_logger = "5.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -17,8 +17,8 @@
 
 [package]
 name = "sqlparser_derive"
-description = "proc macro for sqlparser"
-version = "0.2.2"
+description = "Procedural (proc) macros for sqlparser"
+version = "0.3.0"
 authors = ["sqlparser-rs authors"]
 homepage = "https://github.com/sqlparser-rs/sqlparser-rs"
 documentation = "https://docs.rs/sqlparser_derive/"


### PR DESCRIPTION
- Part of  https://github.com/apache/datafusion-sqlparser-rs/issues/1517


https://github.com/apache/datafusion-sqlparser-rs/pull/1556 from @goldmedal requires a newer version of sqlparser-derive (in order to visit `Option`) so I would like to increase the version now so I don't forget to do so before releasing