### PR TITLE
Redshift: Fix parsing for quoted numbered columns

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -128,16 +128,22 @@ pub trait Dialect: Debug + Any {
         ch == '"' || ch == '`'
     }
 
-    /// Return the character used to quote identifiers.
-    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
-        None
+    /// Determine if a character starts a potential nested quoted identifier.
+    /// RedShift support old way of quotation with `[` and it can cover even nested quoted identifier.
+    fn is_nested_delimited_identifier_start(&self, _ch: char) -> bool {
+        false
     }
 
-    /// Determine if special way quoted characters are presented
-    fn special_delimited_identifier_start(
+    /// Determine if nested quoted characters are presented
+    fn nested_delimited_identifier(
         &self,
         mut _chars: Peekable<Chars<'_>>,
     ) -> Option<(char, Option<char>)> {
+        None
+    }
+
+    /// Return the character used to quote identifiers.
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
         None
     }
 
@@ -851,19 +857,23 @@ mod tests {
                 self.0.is_delimited_identifier_start(ch)
             }
 
+            fn is_nested_delimited_identifier_start(&self, ch: char) -> bool {
+                self.0.is_nested_delimited_identifier_start(ch)
+            }
+
+            fn nested_delimited_identifier(
+                &self,
+                chars: std::iter::Peekable<std::str::Chars<'_>>,
+            ) -> Option<(char, Option<char>)> {
+                self.0.nested_delimited_identifier(chars)
+            }
+
             fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
                 self.0.identifier_quote_style(identifier)
             }
 
             fn supports_string_literal_backslash_escape(&self) -> bool {
                 self.0.supports_string_literal_backslash_escape()
-            }
-
-            fn special_delimited_identifier_start(
-                &self,
-                chars: std::iter::Peekable<std::str::Chars<'_>>,
-            ) -> Option<(char, Option<char>)> {
-                self.0.special_delimited_identifier_start(chars)
             }
 
             fn supports_filter_during_aggregation(&self) -> bool {

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -138,6 +138,15 @@ pub trait Dialect: Debug + Any {
         true
     }
 
+    /// Determine if nested quote start is presented and return it
+    fn nested_quote_start(
+        &self,
+        _quote_start: char,
+        mut _chars: Peekable<Chars<'_>>,
+    ) -> Option<char> {
+        None
+    }
+
     /// Determine if a character is a valid start character for an unquoted identifier
     fn is_identifier_start(&self, ch: char) -> bool;
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -146,8 +146,9 @@ pub trait Dialect: Debug + Any {
     ///
     /// Example (Redshift):
     /// ```text
-    /// `["foo"]` => (Some(`[`), Some(`"`))
-    /// `[foo]` => (Some(`[`), None)
+    /// `["foo"]` => Some(`[`, Some(`"`))
+    /// `[foo]` => Some(`[`, None)
+    /// `[0]` => None
     /// `"foo"` => None
     /// ```
     fn peek_nested_delimited_identifier_quotes(

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -133,17 +133,11 @@ pub trait Dialect: Debug + Any {
         None
     }
 
-    /// Determine if quoted characters are proper for identifier
-    fn is_proper_identifier_inside_quotes(&self, mut _chars: Peekable<Chars<'_>>) -> bool {
-        true
-    }
-
-    /// Determine if nested quote start is presented and return it
-    fn nested_quote_start(
+    /// Determine if special way quoted characters are presented
+    fn special_delimited_identifier_start(
         &self,
-        _quote_start: char,
         mut _chars: Peekable<Chars<'_>>,
-    ) -> Option<char> {
+    ) -> Option<(char, Option<char>)> {
         None
     }
 
@@ -865,11 +859,11 @@ mod tests {
                 self.0.supports_string_literal_backslash_escape()
             }
 
-            fn is_proper_identifier_inside_quotes(
+            fn special_delimited_identifier_start(
                 &self,
                 chars: std::iter::Peekable<std::str::Chars<'_>>,
-            ) -> bool {
-                self.0.is_proper_identifier_inside_quotes(chars)
+            ) -> Option<(char, Option<char>)> {
+                self.0.special_delimited_identifier_start(chars)
             }
 
             fn supports_filter_during_aggregation(&self) -> bool {

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -53,7 +53,7 @@ impl Dialect for RedshiftSqlDialect {
             // PartiQL uses single quote as starting identification inside a quote
             // It is a normal identifier if it has no single quote at the beginning.
             // Additionally square bracket can contain quoted identifier.
-            return ch == '"' || ch != '\'' && self.is_identifier_start(ch);
+            return ch == '"' || self.is_identifier_start(ch);
         }
         false
     }

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -41,7 +41,7 @@ impl Dialect for RedshiftSqlDialect {
     /// treating them as json path. If there is identifier then we assume
     /// there is no json path.
     fn is_proper_identifier_inside_quotes(&self, mut chars: Peekable<Chars<'_>>) -> bool {
-        // PartiQL uses square bracket as a start character and a quote is a beginning of quoted identifier
+        // PartiQL (used as json path query language in Redshift) uses square bracket as a start character and a quote is a beginning of quoted identifier
         if let Some(quote_start) = chars.peek() {
             if *quote_start == '"' {
                 return true;
@@ -51,8 +51,9 @@ impl Dialect for RedshiftSqlDialect {
         let mut not_white_chars = chars.skip_while(|ch| ch.is_whitespace()).peekable();
         if let Some(&ch) = not_white_chars.peek() {
             // PartiQL uses single quote as starting identification inside a quote
-            // It is a normal identifier if it has no single quote at the beginning
-            return ch != '\'' && self.is_identifier_start(ch);
+            // It is a normal identifier if it has no single quote at the beginning.
+            // Additionally square bracket can contain quoted identifier.
+            return ch == '"' || ch != '\'' && self.is_identifier_start(ch);
         }
         false
     }

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -41,10 +41,18 @@ impl Dialect for RedshiftSqlDialect {
     /// treating them as json path. If there is identifier then we assume
     /// there is no json path.
     fn is_proper_identifier_inside_quotes(&self, mut chars: Peekable<Chars<'_>>) -> bool {
+        // PartiQL uses square bracket as a start character and a quote is a beginning of quoted identifier
+        if let Some(quote_start) = chars.peek() {
+            if *quote_start == '"' {
+                return true;
+            }
+        };
         chars.next();
         let mut not_white_chars = chars.skip_while(|ch| ch.is_whitespace()).peekable();
         if let Some(&ch) = not_white_chars.peek() {
-            return self.is_identifier_start(ch);
+            // PartiQL uses single quote as starting identification inside a quote
+            // It is a normal identifier if it has no single quote at the beginning
+            return ch != '\'' && self.is_identifier_start(ch);
         }
         false
     }

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -50,8 +50,9 @@ impl Dialect for RedshiftSqlDialect {
     ///
     /// Example (Redshift):
     /// ```text
-    /// `["foo"]` => (Some(`[`), Some(`"`))
-    /// `[foo]` => (Some(`[`), None)
+    /// `["foo"]` => Some(`[`, Some(`"`))
+    /// `[foo]` => Some(`[`, None)
+    /// `[0]` => None
     /// `"foo"` => None
     /// ```
     fn peek_nested_delimited_identifier_quotes(

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -32,11 +32,15 @@ pub struct RedshiftSqlDialect {}
 // in the Postgres dialect, the query will be parsed as an array, while in the Redshift dialect it will
 // be a json path
 impl Dialect for RedshiftSqlDialect {
+    fn is_nested_delimited_identifier_start(&self, ch: char) -> bool {
+        ch == '['
+    }
+
     /// Determine if quoted characters are looks like special case of quotation begining with `[`.
     /// It's needed to distinguish treating square brackets as quotes from
     /// treating them as json path. If there is identifier then we assume
     /// there is no json path.
-    fn special_delimited_identifier_start(
+    fn nested_delimited_identifier(
         &self,
         mut chars: Peekable<Chars<'_>>,
     ) -> Option<(char, Option<char>)> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1110,7 +1110,7 @@ impl<'a> Tokenizer<'a> {
                     let error_loc = chars.location();
 
                     chars.next(); // skip the first delimiter
-                    word.push(peeking_take_while(chars, |ch| ch.is_whitespace()));
+                    peeking_take_while(chars, |ch| ch.is_whitespace());
                     if chars.peek() != Some(&nested_quote_start) {
                         return self.tokenizer_error(
                             error_loc,
@@ -1120,7 +1120,7 @@ impl<'a> Tokenizer<'a> {
                     word.push(nested_quote_start.into());
                     word.push(self.tokenize_quoted_identifier(nested_quote_end, chars)?);
                     word.push(nested_quote_end.into());
-                    word.push(peeking_take_while(chars, |ch| ch.is_whitespace()));
+                    peeking_take_while(chars, |ch| ch.is_whitespace());
                     if chars.peek() != Some(&quote_end) {
                         return self.tokenizer_error(
                             error_loc,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1080,14 +1080,18 @@ impl<'a> Tokenizer<'a> {
                     Ok(Some(Token::make_word(&word, Some(quote_start))))
                 }
                 // special (quoted) identifier
-                _ if self
-                    .dialect
-                    .special_delimited_identifier_start(chars.peekable.clone())
-                    .is_some() =>
+                quote_start
+                    if self
+                        .dialect
+                        .is_nested_delimited_identifier_start(quote_start)
+                        && self
+                            .dialect
+                            .nested_delimited_identifier(chars.peekable.clone())
+                            .is_some() =>
                 {
                     let (quote_start, nested_quote_start) = self
                         .dialect
-                        .special_delimited_identifier_start(chars.peekable.clone())
+                        .nested_delimited_identifier(chars.peekable.clone())
                         .unwrap();
 
                     let Some(nested_quote_start) = nested_quote_start else {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1612,7 +1612,7 @@ impl<'a> Tokenizer<'a> {
         s
     }
 
-    /// Tokenize an identifier or keyword, after the first char is already consumed.
+    /// Read a quoted identifier
     fn tokenize_quoted_identifier(
         &self,
         quote_start: char,

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -353,3 +353,15 @@ fn test_parse_json_path_from() {
         _ => panic!(),
     }
 }
+
+#[test]
+fn test_parse_select_numbered_columns() {
+    redshift_and_generic().verified_stmt(r#"SELECT 1 AS "1" FROM a"#);
+}
+
+#[test]
+fn test_parse_create_numbered_columns() {
+    redshift_and_generic().verified_stmt(
+        r#"CREATE TABLE test_table_1 ("1" INT, "d" VARCHAR(155), "2" DOUBLE PRECISION)"#,
+    );
+}

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -391,10 +391,11 @@ fn test_parse_select_numbered_columns() {
 #[test]
 fn test_parse_nested_quoted_identifier() {
     redshift().verified_stmt(r#"SELECT 1 AS ["1"] FROM a"#);
-    redshift().verified_stmt(r#"SELECT 1 AS [ " 1 " ]"#);
     redshift().verified_stmt(r#"SELECT 1 AS ["[="] FROM a"#);
     redshift().verified_stmt(r#"SELECT 1 AS ["=]"] FROM a"#);
     redshift().verified_stmt(r#"SELECT 1 AS ["a[b]"] FROM a"#);
+    // trim spaces
+    redshift().one_statement_parses_to(r#"SELECT 1 AS [ " 1 " ]"#, r#"SELECT 1 AS [" 1 "]"#);
     // invalid query
     assert!(redshift()
         .parse_sql_statements(r#"SELECT 1 AS ["1]"#)

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -384,6 +384,9 @@ fn test_parse_select_numbered_columns() {
     redshift_and_generic().verified_stmt(r#"SELECT 1 AS "1" FROM a"#);
     // RedShift specific case - quoted identifier inside square bracket
     redshift().verified_stmt(r#"SELECT 1 AS ["1"] FROM a"#);
+    redshift().verified_stmt(r#"SELECT 1 AS ["[="] FROM a"#);
+    redshift().verified_stmt(r#"SELECT 1 AS ["=]"] FROM a"#);
+    redshift().verified_stmt(r#"SELECT 1 AS ["a[b]"] FROM a"#);
 }
 
 #[test]


### PR DESCRIPTION
Quoted identifiers allow the use of any characters and can start with any character, including digits. For example:

```sql
SELECT 1 AS "1" FROM a
```

However, the tokenizer cannot parse such types of quoted identifiers in the case of Redshift. This issue is related to the handling of potential identifiers in PartiQL.

This merge request (MR) clarifies the behavior of quoted identifiers in PartiQL and fixes the parsing of quoted identifiers for Redshift.

I added an additional case of a valid JSON path in a specific unit test to ensure that JSON path parsing is not broken.