### PR TITLE
Add support for TABLESAMPLE

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -69,11 +69,11 @@ pub use self::query::{
     OrderBy, OrderByExpr, PivotValueSource, ProjectionSelect, Query, RenameSelectItem,
     RepetitionQuantifier, ReplaceSelectElement, ReplaceSelectItem, RowsPerMatch, Select,
     SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, Setting, SymbolDefinition, Table,
-    TableAlias, TableAliasColumnDef, TableFactor, TableFunctionArgs, TableSampleBernoulli,
-    TableSampleBucket, TableSampleImplicit, TableSampleKind, TableSampleMethod,
-    TableSampleMethodName, TableSampleSeed, TableSampleSeedModifier, TableSampleSystem,
-    TableSampleUnit, TableVersion, TableWithJoins, Top, TopQuantity, ValueTableMode, Values,
-    WildcardAdditionalOptions, With, WithFill,
+    TableAlias, TableAliasColumnDef, TableFactor, TableFunctionArgs, TableSample,
+    TableSampleBucket, TableSampleKind, TableSampleMethod, TableSampleModifier,
+    TableSampleQuantity, TableSampleSeed, TableSampleSeedModifier, TableSampleUnit, TableVersion,
+    TableWithJoins, Top, TopQuantity, ValueTableMode, Values, WildcardAdditionalOptions, With,
+    WithFill,
 };
 
 pub use self::trigger::{

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -70,7 +70,8 @@ pub use self::query::{
     RepetitionQuantifier, ReplaceSelectElement, ReplaceSelectItem, RowsPerMatch, Select,
     SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, Setting, SymbolDefinition, Table,
     TableAlias, TableAliasColumnDef, TableFactor, TableFunctionArgs, TableSampleBernoulli,
-    TableSampleBucket, TableSampleImplicit, TableSampleKind, TableSampleMethod, TableSampleSystem,
+    TableSampleBucket, TableSampleImplicit, TableSampleKind, TableSampleMethod,
+    TableSampleMethodName, TableSampleSeed, TableSampleSeedModifier, TableSampleSystem,
     TableSampleUnit, TableVersion, TableWithJoins, Top, TopQuantity, ValueTableMode, Values,
     WildcardAdditionalOptions, With, WithFill,
 };

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -69,8 +69,8 @@ pub use self::query::{
     OrderBy, OrderByExpr, PivotValueSource, ProjectionSelect, Query, RenameSelectItem,
     RepetitionQuantifier, ReplaceSelectElement, ReplaceSelectItem, RowsPerMatch, Select,
     SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, Setting, SymbolDefinition, Table,
-    TableAlias, TableAliasColumnDef, TableFactor, TableFunctionArgs, TableSample,
-    TableSampleBernoulli, TableSampleBucket, TableSampleImplicit, TableSampleSystem,
+    TableAlias, TableAliasColumnDef, TableFactor, TableFunctionArgs, TableSampleBernoulli,
+    TableSampleBucket, TableSampleImplicit, TableSampleKind, TableSampleMethod, TableSampleSystem,
     TableSampleUnit, TableVersion, TableWithJoins, Top, TopQuantity, ValueTableMode, Values,
     WildcardAdditionalOptions, With, WithFill,
 };

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -69,8 +69,10 @@ pub use self::query::{
     OrderBy, OrderByExpr, PivotValueSource, ProjectionSelect, Query, RenameSelectItem,
     RepetitionQuantifier, ReplaceSelectElement, ReplaceSelectItem, RowsPerMatch, Select,
     SelectInto, SelectItem, SetExpr, SetOperator, SetQuantifier, Setting, SymbolDefinition, Table,
-    TableAlias, TableAliasColumnDef, TableFactor, TableFunctionArgs, TableVersion, TableWithJoins,
-    Top, TopQuantity, ValueTableMode, Values, WildcardAdditionalOptions, With, WithFill,
+    TableAlias, TableAliasColumnDef, TableFactor, TableFunctionArgs, TableSample,
+    TableSampleBernoulli, TableSampleBucket, TableSampleImplicit, TableSampleSystem,
+    TableSampleUnit, TableVersion, TableWithJoins, Top, TopQuantity, ValueTableMode, Values,
+    WildcardAdditionalOptions, With, WithFill,
 };
 
 pub use self::trigger::{

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1177,7 +1177,7 @@ pub struct TableSampleBernoulli {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct TableSampleSystem {
     pub probability: Expr,
-    pub seed: Option<Expr>,
+    pub repeatable: Option<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1252,8 +1252,8 @@ impl fmt::Display for TableSample {
             }
             TableSample::System(sample) => {
                 write!(f, " SYSTEM ({})", sample.probability)?;
-                if let Some(seed) = &sample.seed {
-                    write!(f, " SEED ({})", seed)?;
+                if let Some(repeatable) = &sample.repeatable {
+                    write!(f, " REPEATABLE ({})", repeatable)?;
                 }
             }
             TableSample::Bucket(sample) => {

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1004,7 +1004,7 @@ pub enum TableFactor {
         json_path: Option<JsonPath>,
         /// Optional table sample modifier
         /// See: <https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#sample-clause>
-        sample: Option<TableSample>,
+        sample: Option<Box<TableSample>>,
         /// Position of the table sample modifier in the table factor. Default is after the table alias
         /// e.g. `SELECT * FROM tbl t TABLESAMPLE (10 ROWS)`. See `Dialect::supports_table_sample_before_alias`.
         sample_before_alias: bool,

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1700,7 +1700,6 @@ impl Spanned for TableFactor {
                 partitions: _,
                 json_path: _,
                 sample: _,
-                sample_before_alias: _,
             } => union_spans(
                 name.0
                     .iter()

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1699,6 +1699,8 @@ impl Spanned for TableFactor {
                 with_ordinality: _,
                 partitions: _,
                 json_path: _,
+                sample: _,
+                sample_before_alias: _,
             } => union_spans(
                 name.0
                     .iter()

--- a/src/dialect/hive.rs
+++ b/src/dialect/hive.rs
@@ -68,7 +68,7 @@ impl Dialect for HiveDialect {
     }
 
     /// See Hive <https://cwiki.apache.org/confluence/display/hive/languagemanual+sampling>
-    fn supports_implicit_table_sample(&self) -> bool {
+    fn supports_implicit_table_sample_method(&self) -> bool {
         true
     }
 }

--- a/src/dialect/hive.rs
+++ b/src/dialect/hive.rs
@@ -61,4 +61,9 @@ impl Dialect for HiveDialect {
     fn supports_load_data(&self) -> bool {
         true
     }
+
+    /// See Hive <https://cwiki.apache.org/confluence/display/hive/languagemanual+sampling>
+    fn supports_table_sample_before_alias(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/hive.rs
+++ b/src/dialect/hive.rs
@@ -66,9 +66,4 @@ impl Dialect for HiveDialect {
     fn supports_table_sample_before_alias(&self) -> bool {
         true
     }
-
-    /// See Hive <https://cwiki.apache.org/confluence/display/hive/languagemanual+sampling>
-    fn supports_implicit_table_sample_method(&self) -> bool {
-        true
-    }
 }

--- a/src/dialect/hive.rs
+++ b/src/dialect/hive.rs
@@ -66,4 +66,9 @@ impl Dialect for HiveDialect {
     fn supports_table_sample_before_alias(&self) -> bool {
         true
     }
+
+    /// See Hive <https://cwiki.apache.org/confluence/display/hive/languagemanual+sampling>
+    fn supports_implicit_table_sample(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -707,6 +707,13 @@ pub trait Dialect: Debug + Any {
     fn is_reserved_for_identifier(&self, kw: Keyword) -> bool {
         keywords::RESERVED_FOR_IDENTIFIER.contains(&kw)
     }
+
+    /// Returns true if the dialect supports the `TABLESAMPLE` option
+    /// before the table alias option.
+    /// <https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_7_6_table_reference>
+    fn supports_table_sample_before_alias(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -718,16 +718,6 @@ pub trait Dialect: Debug + Any {
     fn supports_table_sample_before_alias(&self) -> bool {
         false
     }
-
-    /// Returns true if this dialect support not specifying a table sample method. For example:
-    ///
-    /// Implicit table sample method: `SELECT * FROM tbl TABLESAMPLE (10)`
-    /// Explicit table sample method: `SELECT * FROM tbl TABLESAMPLE BERNOULLI (10)`
-    ///
-    /// <https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#sample-clause>
-    fn supports_implicit_table_sample_method(&self) -> bool {
-        false
-    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -709,15 +709,23 @@ pub trait Dialect: Debug + Any {
     }
 
     /// Returns true if this dialect supports the `TABLESAMPLE` option
-    /// before the table alias option.
+    /// before the table alias option. For example:
+    ///
+    /// Table sample before alias: `SELECT * FROM tbl AS t TABLESAMPLE (10)`
+    /// Table sample after alias: `SELECT * FROM tbl TABLESAMPLE (10) AS t`
+    ///
     /// <https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_7_6_table_reference>
     fn supports_table_sample_before_alias(&self) -> bool {
         false
     }
 
-    /// Returns true if this dialect support not specifying a table sample method.
+    /// Returns true if this dialect support not specifying a table sample method. For example:
+    ///
+    /// Implicit table sample method: `SELECT * FROM tbl TABLESAMPLE (10)`
+    /// Explicit table sample method: `SELECT * FROM tbl TABLESAMPLE BERNOULLI (10)`
+    ///
     /// <https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#sample-clause>
-    fn supports_implicit_table_sample(&self) -> bool {
+    fn supports_implicit_table_sample_method(&self) -> bool {
         false
     }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -708,10 +708,16 @@ pub trait Dialect: Debug + Any {
         keywords::RESERVED_FOR_IDENTIFIER.contains(&kw)
     }
 
-    /// Returns true if the dialect supports the `TABLESAMPLE` option
+    /// Returns true if this dialect supports the `TABLESAMPLE` option
     /// before the table alias option.
     /// <https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#_7_6_table_reference>
     fn supports_table_sample_before_alias(&self) -> bool {
+        false
+    }
+
+    /// Returns true if this dialect support not specifying a table sample method.
+    /// <https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#sample-clause>
+    fn supports_implicit_table_sample(&self) -> bool {
         false
     }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -120,6 +120,7 @@ define_keywords!(
     BEGIN,
     BEGIN_FRAME,
     BEGIN_PARTITION,
+    BERNOULLI,
     BETWEEN,
     BIGDECIMAL,
     BIGINT,
@@ -128,12 +129,14 @@ define_keywords!(
     BINDING,
     BIT,
     BLOB,
+    BLOCK,
     BLOOMFILTER,
     BOOL,
     BOOLEAN,
     BOTH,
     BROWSE,
     BTREE,
+    BUCKET,
     BUCKETS,
     BY,
     BYPASSRLS,
@@ -680,6 +683,7 @@ define_keywords!(
     RUN,
     SAFE,
     SAFE_CAST,
+    SAMPLE,
     SAVEPOINT,
     SCHEMA,
     SCHEMAS,
@@ -690,6 +694,7 @@ define_keywords!(
     SECONDARY,
     SECRET,
     SECURITY,
+    SEED,
     SELECT,
     SEMI,
     SENSITIVE,
@@ -932,6 +937,9 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::CONNECT,
     // Reserved for snowflake MATCH_RECOGNIZE
     Keyword::MATCH_RECOGNIZE,
+    // Reserved for Snowflake table sample
+    Keyword::SAMPLE,
+    Keyword::TABLESAMPLE,
 ];
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10703,7 +10703,7 @@ impl<'a> Parser<'a> {
             };
             Ok(Some(TableSample::System(TableSampleSystem {
                 probability,
-                seed,
+                repeatable: seed,
             })))
         } else if self.peek_token().token == Token::LParen {
             self.expect_token(&Token::LParen)?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10717,11 +10717,7 @@ impl<'a> Parser<'a> {
                     None
                 };
                 self.expect_token(&Token::RParen)?;
-                TableSample::Bucket(TableSampleBucket {
-                    bucket,
-                    total,
-                    on,
-                })
+                TableSample::Bucket(TableSampleBucket { bucket, total, on })
             } else {
                 let value = match self.try_parse(|p| p.parse_number_value()) {
                     Ok(num) => num,
@@ -10754,10 +10750,7 @@ impl<'a> Parser<'a> {
                         None
                     };
                     self.expect_token(&Token::RParen)?;
-                    TableSample::Implicit(TableSampleImplicit {
-                        value,
-                        unit,
-                    })
+                    TableSample::Implicit(TableSampleImplicit { value, unit })
                 }
             }
         } else {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -346,6 +346,23 @@ pub fn table(name: impl Into<String>) -> TableFactor {
         partitions: vec![],
         with_ordinality: false,
         json_path: None,
+        sample: None,
+        sample_before_alias: false,
+    }
+}
+
+pub fn table_from_name(name: ObjectName) -> TableFactor {
+    TableFactor::Table {
+        name,
+        alias: None,
+        args: None,
+        with_hints: vec![],
+        version: None,
+        partitions: vec![],
+        with_ordinality: false,
+        json_path: None,
+        sample: None,
+        sample_before_alias: false,
     }
 }
 
@@ -362,6 +379,8 @@ pub fn table_with_alias(name: impl Into<String>, alias: impl Into<String>) -> Ta
         partitions: vec![],
         with_ordinality: false,
         json_path: None,
+        sample: None,
+        sample_before_alias: false,
     }
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -347,7 +347,6 @@ pub fn table(name: impl Into<String>) -> TableFactor {
         with_ordinality: false,
         json_path: None,
         sample: None,
-        sample_before_alias: false,
     }
 }
 
@@ -362,7 +361,6 @@ pub fn table_from_name(name: ObjectName) -> TableFactor {
         with_ordinality: false,
         json_path: None,
         sample: None,
-        sample_before_alias: false,
     }
 }
 
@@ -380,7 +378,6 @@ pub fn table_with_alias(name: impl Into<String>, alias: impl Into<String>) -> Ta
         with_ordinality: false,
         json_path: None,
         sample: None,
-        sample_before_alias: false,
     }
 }
 

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1545,7 +1545,6 @@ fn parse_table_time_travel() {
                 with_ordinality: false,
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             joins: vec![]
         },]
@@ -1646,7 +1645,6 @@ fn parse_merge() {
                     with_ordinality: false,
                     json_path: None,
                     sample: None,
-                    sample_before_alias: false,
                 },
                 table
             );
@@ -1664,7 +1662,6 @@ fn parse_merge() {
                     with_ordinality: false,
                     json_path: None,
                     sample: None,
-                    sample_before_alias: false,
                 },
                 source
             );

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -222,16 +222,7 @@ fn parse_delete_statement() {
             ..
         }) => {
             assert_eq!(
-                TableFactor::Table {
-                    name: ObjectName(vec![Ident::with_quote('"', "table")]),
-                    alias: None,
-                    args: None,
-                    with_hints: vec![],
-                    version: None,
-                    partitions: vec![],
-                    with_ordinality: false,
-                    json_path: None,
-                },
+                table_from_name(ObjectName(vec![Ident::with_quote('"', "table")])),
                 from[0].relation
             );
         }
@@ -1379,16 +1370,7 @@ fn parse_table_identifiers() {
         assert_eq!(
             select.from,
             vec![TableWithJoins {
-                relation: TableFactor::Table {
-                    name: ObjectName(expected),
-                    alias: None,
-                    args: None,
-                    with_hints: vec![],
-                    version: None,
-                    partitions: vec![],
-                    with_ordinality: false,
-                    json_path: None,
-                },
+                relation: table_from_name(ObjectName(expected)),
                 joins: vec![]
             },]
         );
@@ -1562,6 +1544,8 @@ fn parse_table_time_travel() {
                 partitions: vec![],
                 with_ordinality: false,
                 json_path: None,
+                sample: None,
+                sample_before_alias: false,
             },
             joins: vec![]
         },]
@@ -1661,6 +1645,8 @@ fn parse_merge() {
                     partitions: Default::default(),
                     with_ordinality: false,
                     json_path: None,
+                    sample: None,
+                    sample_before_alias: false,
                 },
                 table
             );
@@ -1677,6 +1663,8 @@ fn parse_merge() {
                     partitions: Default::default(),
                     with_ordinality: false,
                     json_path: None,
+                    sample: None,
+                    sample_before_alias: false,
                 },
                 source
             );

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -63,16 +63,7 @@ fn parse_map_access_expr() {
             })],
             into: None,
             from: vec![TableWithJoins {
-                relation: Table {
-                    name: ObjectName(vec![Ident::new("foos")]),
-                    alias: None,
-                    args: None,
-                    with_hints: vec![],
-                    version: None,
-                    partitions: vec![],
-                    with_ordinality: false,
-                    json_path: None,
-                },
+                relation: table_from_name(ObjectName(vec![Ident::new("foos")])),
                 joins: vec![],
             }],
             lateral_views: vec![],
@@ -175,9 +166,7 @@ fn parse_delimited_identifiers() {
             args,
             with_hints,
             version,
-            with_ordinality: _,
-            partitions: _,
-            json_path: _,
+            ..
         } => {
             assert_eq!(vec![Ident::with_quote('"', "a table")], name.0);
             assert_eq!(Ident::with_quote('"', "alias"), alias.unwrap().name);

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1614,6 +1614,14 @@ fn parse_explain_table() {
     }
 }
 
+#[test]
+fn parse_table_sample() {
+    clickhouse().verified_stmt("SELECT * FROM tbl SAMPLE 0.1");
+    clickhouse().verified_stmt("SELECT * FROM tbl SAMPLE 1000");
+    clickhouse().verified_stmt("SELECT * FROM tbl SAMPLE 1 / 10");
+    clickhouse().verified_stmt("SELECT * FROM tbl SAMPLE 1 / 10 OFFSET 1 / 2");
+}
+
 fn clickhouse() -> TestedDialects {
     TestedDialects::new(vec![Box::new(ClickHouseDialect {})])
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -463,7 +463,6 @@ fn parse_update_with_table_alias() {
                         with_ordinality: false,
                         json_path: None,
                         sample: None,
-                        sample_before_alias: false,
                     },
                     joins: vec![],
                 },
@@ -557,7 +556,6 @@ fn parse_select_with_table_alias() {
                 with_ordinality: false,
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             joins: vec![],
         }]
@@ -748,7 +746,6 @@ fn parse_where_delete_with_alias_statement() {
                     with_ordinality: false,
                     json_path: None,
                     sample: None,
-                    sample_before_alias: false,
                 },
                 from[0].relation,
             );
@@ -767,7 +764,6 @@ fn parse_where_delete_with_alias_statement() {
                         with_ordinality: false,
                         json_path: None,
                         sample: None,
-                        sample_before_alias: false,
                     },
                     joins: vec![],
                 }]),
@@ -6119,7 +6115,6 @@ fn parse_joins_on() {
                 with_ordinality: false,
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             global,
             join_operator: f(JoinConstraint::On(Expr::BinaryOp {
@@ -6249,7 +6244,6 @@ fn parse_joins_using() {
                 with_ordinality: false,
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             global: false,
             join_operator: f(JoinConstraint::Using(vec!["c1".into()])),
@@ -6325,7 +6319,6 @@ fn parse_natural_join() {
                 with_ordinality: false,
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             global: false,
             join_operator: f(JoinConstraint::Natural),
@@ -8343,7 +8336,6 @@ fn parse_merge() {
                     with_ordinality: false,
                     json_path: None,
                     sample: None,
-                    sample_before_alias: false,
                 }
             );
             assert_eq!(table, table_no_into);
@@ -9451,7 +9443,6 @@ fn parse_pivot_table() {
                 with_ordinality: false,
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             }),
             aggregate_functions: vec![
                 expected_function("a", None),
@@ -9528,7 +9519,6 @@ fn parse_unpivot_table() {
                 with_ordinality: false,
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             }),
             value: Ident {
                 value: "quantity".to_string(),
@@ -9600,7 +9590,6 @@ fn parse_pivot_unpivot_table() {
                     with_ordinality: false,
                     json_path: None,
                     sample: None,
-                    sample_before_alias: false,
                 }),
                 value: Ident {
                     value: "population".to_string(),
@@ -12397,14 +12386,14 @@ fn parse_create_table_with_enum_types() {
 
 #[test]
 fn test_table_sample() {
-    let dialects = all_dialects_where(|d| !d.supports_implicit_table_sample());
+    let dialects = all_dialects_where(|d| !d.supports_implicit_table_sample_method());
     dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE BERNOULLI (50)");
     dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50)");
     dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
 
     // The only dialect that supports implicit tablesample is Hive and it requires aliase after the table sample
     let dialects = all_dialects_where(|d| {
-        d.supports_implicit_table_sample() && d.supports_table_sample_before_alias()
+        d.supports_implicit_table_sample_method() && d.supports_table_sample_before_alias()
     });
     dialects.verified_stmt("SELECT * FROM tbl TABLESAMPLE (50) AS t");
     dialects.verified_stmt("SELECT * FROM tbl TABLESAMPLE (50 ROWS) AS t");

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -12386,16 +12386,13 @@ fn parse_create_table_with_enum_types() {
 
 #[test]
 fn test_table_sample() {
-    let dialects = all_dialects_where(|d| !d.supports_implicit_table_sample_method());
-    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE BERNOULLI (50)");
-    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50)");
-    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
-
-    // The only dialect that supports implicit tablesample is Hive and it requires aliase after the table sample
-    let dialects = all_dialects_where(|d| {
-        d.supports_implicit_table_sample_method() && d.supports_table_sample_before_alias()
-    });
+    let dialects = all_dialects_where(|d| d.supports_table_sample_before_alias());
     dialects.verified_stmt("SELECT * FROM tbl TABLESAMPLE (50) AS t");
     dialects.verified_stmt("SELECT * FROM tbl TABLESAMPLE (50 ROWS) AS t");
     dialects.verified_stmt("SELECT * FROM tbl TABLESAMPLE (50 PERCENT) AS t");
+
+    let dialects = all_dialects_where(|d| !d.supports_table_sample_before_alias());
+    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE BERNOULLI (50)");
+    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50)");
+    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
 }

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -185,16 +185,7 @@ fn test_values_clause() {
         "SELECT * FROM values",
     ));
     assert_eq!(
-        Some(&TableFactor::Table {
-            name: ObjectName(vec![Ident::new("values")]),
-            alias: None,
-            args: None,
-            with_hints: vec![],
-            version: None,
-            partitions: vec![],
-            with_ordinality: false,
-            json_path: None,
-        }),
+        Some(&table_from_name(ObjectName(vec![Ident::new("values")]))),
         query
             .body
             .as_select()

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -268,20 +268,11 @@ fn test_select_union_by_name() {
                 top_before_distinct: false,
                 into: None,
                 from: vec![TableWithJoins {
-                    relation: TableFactor::Table {
-                        name: ObjectName(vec![Ident {
-                            value: "capitals".to_string(),
-                            quote_style: None,
-                            span: Span::empty(),
-                        }]),
-                        alias: None,
-                        args: None,
-                        with_hints: vec![],
-                        version: None,
-                        partitions: vec![],
-                        with_ordinality: false,
-                        json_path: None,
-                    },
+                    relation: table_from_name(ObjectName(vec![Ident {
+                        value: "capitals".to_string(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    }])),
                     joins: vec![],
                 }],
                 lateral_views: vec![],
@@ -306,20 +297,11 @@ fn test_select_union_by_name() {
                 top_before_distinct: false,
                 into: None,
                 from: vec![TableWithJoins {
-                    relation: TableFactor::Table {
-                        name: ObjectName(vec![Ident {
-                            value: "weather".to_string(),
-                            quote_style: None,
-                            span: Span::empty(),
-                        }]),
-                        alias: None,
-                        args: None,
-                        with_hints: vec![],
-                        version: None,
-                        partitions: vec![],
-                        with_ordinality: false,
-                        json_path: None,
-                    },
+                    relation: table_from_name(ObjectName(vec![Ident {
+                        value: "weather".to_string(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    }])),
                     joins: vec![],
                 }],
                 lateral_views: vec![],

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -459,6 +459,8 @@ fn parse_delimited_identifiers() {
             with_ordinality: _,
             partitions: _,
             json_path: _,
+            sample: _,
+            sample_before_alias: _,
         } => {
             assert_eq!(vec![Ident::with_quote('"', "a table")], name.0);
             assert_eq!(Ident::with_quote('"', "alias"), alias.unwrap().name);
@@ -535,6 +537,15 @@ fn parse_use() {
         hive().verified_stmt("USE DEFAULT"),
         Statement::Use(Use::Default)
     );
+}
+
+#[test]
+fn test_tample_sample() {
+    hive().verified_stmt("SELECT * FROM source TABLESAMPLE (BUCKET 3 OUT OF 32 ON rand()) AS s");
+    hive().verified_stmt("SELECT * FROM source TABLESAMPLE (BUCKET 3 OUT OF 16 ON id)");
+    hive().verified_stmt("SELECT * FROM source TABLESAMPLE (100M) AS s");
+    hive().verified_stmt("SELECT * FROM source TABLESAMPLE (0.1 PERCENT) AS s");
+    hive().verified_stmt("SELECT * FROM source TABLESAMPLE (10 ROWS)");
 }
 
 fn hive() -> TestedDialects {

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -460,7 +460,6 @@ fn parse_delimited_identifiers() {
             partitions: _,
             json_path: _,
             sample: _,
-            sample_before_alias: _,
         } => {
             assert_eq!(vec![Ident::with_quote('"', "a table")], name.0);
             assert_eq!(Ident::with_quote('"', "alias"), alias.unwrap().name);

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -73,6 +73,8 @@ fn parse_table_time_travel() {
                 partitions: vec![],
                 with_ordinality: false,
                 json_path: None,
+                sample: None,
+                sample_before_alias: false,
             },
             joins: vec![]
         },]
@@ -221,6 +223,8 @@ fn parse_mssql_openjson() {
                 with_ordinality: false,
                 partitions: vec![],
                 json_path: None,
+                sample: None,
+                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {
@@ -279,6 +283,8 @@ fn parse_mssql_openjson() {
                 with_ordinality: false,
                 partitions: vec![],
                 json_path: None,
+                sample: None,
+                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {
@@ -338,6 +344,8 @@ fn parse_mssql_openjson() {
                 with_ordinality: false,
                 partitions: vec![],
                 json_path: None,
+                sample: None,
+                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {
@@ -396,6 +404,8 @@ fn parse_mssql_openjson() {
                 with_ordinality: false,
                 partitions: vec![],
                 json_path: None,
+                sample: None,
+                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {
@@ -434,6 +444,8 @@ fn parse_mssql_openjson() {
                 with_ordinality: false,
                 partitions: vec![],
                 json_path: None,
+                sample: None,
+                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {
@@ -611,9 +623,7 @@ fn parse_delimited_identifiers() {
             args,
             with_hints,
             version,
-            with_ordinality: _,
-            partitions: _,
-            json_path: _,
+            ..
         } => {
             assert_eq!(vec![Ident::with_quote('"', "a table")], name.0);
             assert_eq!(Ident::with_quote('"', "alias"), alias.unwrap().name);
@@ -1082,20 +1092,11 @@ fn parse_substring_in_select() {
                         })],
                         into: None,
                         from: vec![TableWithJoins {
-                            relation: TableFactor::Table {
-                                name: ObjectName(vec![Ident {
-                                    value: "test".to_string(),
-                                    quote_style: None,
-                                    span: Span::empty(),
-                                }]),
-                                alias: None,
-                                args: None,
-                                with_hints: vec![],
-                                version: None,
-                                partitions: vec![],
-                                with_ordinality: false,
-                                json_path: None,
-                            },
+                            relation: table_from_name(ObjectName(vec![Ident {
+                                value: "test".to_string(),
+                                quote_style: None,
+                                span: Span::empty(),
+                            }])),
                             joins: vec![]
                         }],
                         lateral_views: vec![],

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -74,7 +74,6 @@ fn parse_table_time_travel() {
                 with_ordinality: false,
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             joins: vec![]
         },]
@@ -224,7 +223,6 @@ fn parse_mssql_openjson() {
                 partitions: vec![],
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {
@@ -284,7 +282,6 @@ fn parse_mssql_openjson() {
                 partitions: vec![],
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {
@@ -345,7 +342,6 @@ fn parse_mssql_openjson() {
                 partitions: vec![],
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {
@@ -405,7 +401,6 @@ fn parse_mssql_openjson() {
                 partitions: vec![],
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {
@@ -445,7 +440,6 @@ fn parse_mssql_openjson() {
                 partitions: vec![],
                 json_path: None,
                 sample: None,
-                sample_before_alias: false,
             },
             joins: vec![Join {
                 relation: TableFactor::OpenJsonTable {

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1884,16 +1884,9 @@ fn parse_select_with_numeric_prefix_column_name() {
                     )))],
                     into: None,
                     from: vec![TableWithJoins {
-                        relation: TableFactor::Table {
-                            name: ObjectName(vec![Ident::with_quote('"', "table")]),
-                            alias: None,
-                            args: None,
-                            with_hints: vec![],
-                            version: None,
-                            partitions: vec![],
-                            with_ordinality: false,
-                            json_path: None,
-                        },
+                        relation: table_from_name(ObjectName(vec![Ident::with_quote(
+                            '"', "table"
+                        )])),
                         joins: vec![]
                     }],
                     lateral_views: vec![],
@@ -1943,16 +1936,9 @@ fn parse_select_with_concatenation_of_exp_number_and_numeric_prefix_column() {
                     ],
                     into: None,
                     from: vec![TableWithJoins {
-                        relation: TableFactor::Table {
-                            name: ObjectName(vec![Ident::with_quote('"', "table")]),
-                            alias: None,
-                            args: None,
-                            with_hints: vec![],
-                            version: None,
-                            partitions: vec![],
-                            with_ordinality: false,
-                            json_path: None,
-                        },
+                        relation: table_from_name(ObjectName(vec![Ident::with_quote(
+                            '"', "table"
+                        )])),
                         joins: vec![]
                     }],
                     lateral_views: vec![],
@@ -2020,6 +2006,8 @@ fn parse_update_with_joins() {
                         partitions: vec![],
                         with_ordinality: false,
                         json_path: None,
+                        sample: None,
+                        sample_before_alias: false,
                     },
                     joins: vec![Join {
                         relation: TableFactor::Table {
@@ -2034,6 +2022,8 @@ fn parse_update_with_joins() {
                             partitions: vec![],
                             with_ordinality: false,
                             json_path: None,
+                            sample: None,
+                            sample_before_alias: false,
                         },
                         global: false,
                         join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
@@ -2464,20 +2454,11 @@ fn parse_substring_in_select() {
                         })],
                         into: None,
                         from: vec![TableWithJoins {
-                            relation: TableFactor::Table {
-                                name: ObjectName(vec![Ident {
-                                    value: "test".to_string(),
-                                    quote_style: None,
-                                    span: Span::empty(),
-                                }]),
-                                alias: None,
-                                args: None,
-                                with_hints: vec![],
-                                version: None,
-                                partitions: vec![],
-                                with_ordinality: false,
-                                json_path: None,
-                            },
+                            relation: table_from_name(ObjectName(vec![Ident {
+                                value: "test".to_string(),
+                                quote_style: None,
+                                span: Span::empty(),
+                            }])),
                             joins: vec![]
                         }],
                         lateral_views: vec![],

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -2007,7 +2007,6 @@ fn parse_update_with_joins() {
                         with_ordinality: false,
                         json_path: None,
                         sample: None,
-                        sample_before_alias: false,
                     },
                     joins: vec![Join {
                         relation: TableFactor::Table {
@@ -2023,7 +2022,6 @@ fn parse_update_with_joins() {
                             with_ordinality: false,
                             json_path: None,
                             sample: None,
-                            sample_before_alias: false,
                         },
                         global: false,
                         join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3581,9 +3581,7 @@ fn parse_delimited_identifiers() {
             args,
             with_hints,
             version,
-            with_ordinality: _,
-            partitions: _,
-            json_path: _,
+            ..
         } => {
             assert_eq!(vec![Ident::with_quote('"', "a table")], name.0);
             assert_eq!(Ident::with_quote('"', "alias"), alias.unwrap().name);

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -39,27 +39,18 @@ fn test_square_brackets_over_db_schema_table_name() {
     assert_eq!(
         select.from[0],
         TableWithJoins {
-            relation: TableFactor::Table {
-                name: ObjectName(vec![
-                    Ident {
-                        value: "test_schema".to_string(),
-                        quote_style: Some('['),
-                        span: Span::empty(),
-                    },
-                    Ident {
-                        value: "test_table".to_string(),
-                        quote_style: Some('['),
-                        span: Span::empty(),
-                    }
-                ]),
-                alias: None,
-                args: None,
-                with_hints: vec![],
-                version: None,
-                partitions: vec![],
-                with_ordinality: false,
-                json_path: None,
-            },
+            relation: table_from_name(ObjectName(vec![
+                Ident {
+                    value: "test_schema".to_string(),
+                    quote_style: Some('['),
+                    span: Span::empty(),
+                },
+                Ident {
+                    value: "test_table".to_string(),
+                    quote_style: Some('['),
+                    span: Span::empty(),
+                }
+            ])),
             joins: vec![],
         }
     );
@@ -90,27 +81,18 @@ fn test_double_quotes_over_db_schema_table_name() {
     assert_eq!(
         select.from[0],
         TableWithJoins {
-            relation: TableFactor::Table {
-                name: ObjectName(vec![
-                    Ident {
-                        value: "test_schema".to_string(),
-                        quote_style: Some('"'),
-                        span: Span::empty(),
-                    },
-                    Ident {
-                        value: "test_table".to_string(),
-                        quote_style: Some('"'),
-                        span: Span::empty(),
-                    }
-                ]),
-                alias: None,
-                args: None,
-                with_hints: vec![],
-                version: None,
-                partitions: vec![],
-                with_ordinality: false,
-                json_path: None,
-            },
+            relation: table_from_name(ObjectName(vec![
+                Ident {
+                    value: "test_schema".to_string(),
+                    quote_style: Some('"'),
+                    span: Span::empty(),
+                },
+                Ident {
+                    value: "test_table".to_string(),
+                    quote_style: Some('"'),
+                    span: Span::empty(),
+                }
+            ])),
             joins: vec![],
         }
     );
@@ -130,9 +112,7 @@ fn parse_delimited_identifiers() {
             args,
             with_hints,
             version,
-            with_ordinality: _,
-            partitions: _,
-            json_path: _,
+            ..
         } => {
             assert_eq!(vec![Ident::with_quote('"', "a table")], name.0);
             assert_eq!(Ident::with_quote('"', "alias"), alias.unwrap().name);

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2961,10 +2961,8 @@ fn parse_insert_overwrite() {
 
 #[test]
 fn test_table_sample() {
-    snowflake_and_generic().one_statement_parses_to(
-        "SELECT * FROM testtable SAMPLE (10)",
-        "SELECT * FROM testtable TABLESAMPLE (10)",
-    );
+    snowflake_and_generic().verified_stmt("SELECT * FROM testtable SAMPLE (10)");
+    snowflake_and_generic().verified_stmt("SELECT * FROM testtable TABLESAMPLE (10)");
     snowflake_and_generic()
         .verified_stmt("SELECT * FROM testtable AS t TABLESAMPLE BERNOULLI (10)");
     snowflake_and_generic().verified_stmt("SELECT * FROM testtable AS t TABLESAMPLE ROW (10)");
@@ -2973,4 +2971,6 @@ fn test_table_sample() {
         .verified_stmt("SELECT * FROM testtable TABLESAMPLE BLOCK (3) SEED (82)");
     snowflake_and_generic()
         .verified_stmt("SELECT * FROM testtable TABLESAMPLE SYSTEM (3) REPEATABLE (82)");
+    snowflake_and_generic().verified_stmt("SELECT id FROM mytable TABLESAMPLE (10) REPEATABLE (1)");
+    snowflake_and_generic().verified_stmt("SELECT id FROM mytable TABLESAMPLE (10) SEED (1)");
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2961,30 +2961,16 @@ fn parse_insert_overwrite() {
 
 #[test]
 fn test_table_sample() {
+    snowflake_and_generic().one_statement_parses_to(
+        "SELECT * FROM testtable SAMPLE (10)",
+        "SELECT * FROM testtable TABLESAMPLE (10)",
+    );
     snowflake_and_generic()
         .verified_stmt("SELECT * FROM testtable AS t TABLESAMPLE BERNOULLI (10)");
-
-    // In Snowflake we translate implicit table sample method to bernoulli
-    snowflake().one_statement_parses_to(
-        "SELECT * FROM testtable SAMPLE (10)",
-        "SELECT * FROM testtable TABLESAMPLE BERNOULLI (10)",
-    );
-
-    snowflake_and_generic().one_statement_parses_to(
-        "SELECT * FROM testtable TABLESAMPLE ROW (20.3)",
-        "SELECT * FROM testtable TABLESAMPLE BERNOULLI (20.3)",
-    );
-
-    snowflake_and_generic().one_statement_parses_to(
-        "SELECT * FROM testtable SAMPLE BLOCK (3) SEED (82)",
-        "SELECT * FROM testtable TABLESAMPLE SYSTEM (3) REPEATABLE (82)",
-    );
-
-    snowflake_and_generic().one_statement_parses_to(
-        "SELECT * FROM testtable SAMPLE BLOCK (0.012) SEED (99992)",
-        "SELECT * FROM testtable TABLESAMPLE SYSTEM (0.012) REPEATABLE (99992)",
-    );
-
+    snowflake_and_generic().verified_stmt("SELECT * FROM testtable AS t TABLESAMPLE ROW (10)");
+    snowflake_and_generic().verified_stmt("SELECT * FROM testtable AS t TABLESAMPLE ROW (10 ROWS)");
     snowflake_and_generic()
-        .verified_stmt("SELECT * FROM testtable TABLESAMPLE BERNOULLI (10 ROWS)");
+        .verified_stmt("SELECT * FROM testtable TABLESAMPLE BLOCK (3) SEED (82)");
+    snowflake_and_generic()
+        .verified_stmt("SELECT * FROM testtable TABLESAMPLE SYSTEM (3) REPEATABLE (82)");
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2964,6 +2964,7 @@ fn test_table_sample() {
     snowflake_and_generic()
         .verified_stmt("SELECT * FROM testtable AS t TABLESAMPLE BERNOULLI (10)");
 
+    // In Snowflake we translate implicit table sample method to bernoulli
     snowflake().one_statement_parses_to(
         "SELECT * FROM testtable SAMPLE (10)",
         "SELECT * FROM testtable TABLESAMPLE BERNOULLI (10)",
@@ -2976,12 +2977,12 @@ fn test_table_sample() {
 
     snowflake_and_generic().one_statement_parses_to(
         "SELECT * FROM testtable SAMPLE BLOCK (3) SEED (82)",
-        "SELECT * FROM testtable TABLESAMPLE SYSTEM (3) SEED (82)",
+        "SELECT * FROM testtable TABLESAMPLE SYSTEM (3) REPEATABLE (82)",
     );
 
     snowflake_and_generic().one_statement_parses_to(
-        "SELECT * FROM testtable SAMPLE BLOCK (0.012) REPEATABLE (99992)",
-        "SELECT * FROM testtable TABLESAMPLE SYSTEM (0.012) SEED (99992)",
+        "SELECT * FROM testtable SAMPLE BLOCK (0.012) SEED (99992)",
+        "SELECT * FROM testtable TABLESAMPLE SYSTEM (0.012) REPEATABLE (99992)",
     );
 
     snowflake_and_generic()

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -479,16 +479,7 @@ fn parse_update_tuple_row_values() {
             }],
             selection: None,
             table: TableWithJoins {
-                relation: TableFactor::Table {
-                    name: ObjectName(vec![Ident::new("x")]),
-                    alias: None,
-                    args: None,
-                    with_hints: vec![],
-                    version: None,
-                    partitions: vec![],
-                    with_ordinality: false,
-                    json_path: None,
-                },
+                relation: table_from_name(ObjectName(vec![Ident::new("x")])),
                 joins: vec![],
             },
             from: None,


### PR DESCRIPTION
This PR adds support for the `TABLESAMPLE` option in the following dialects:
 - Standard SQL: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#sample-clause
 - Snowflake: https://docs.snowflake.com/en/sql-reference/constructs/sample
 - Hive: https://cwiki.apache.org/confluence/display/hive/languagemanual+sampling
 - Clickhouse: https://clickhouse.com/docs/en/sql-reference/statements/select/sample

Collateral work includes expanding the use of a constructor function to create `Table` structs in unit tests to avoid modifying many files when adding default options to the `Table` struct.