### PR TITLE
Support INSERT OVERWRITE INTO syntax

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11291,9 +11291,8 @@ impl<'a> Parser<'a> {
 
         let replace_into = false;
 
-        let action = self.parse_one_of_keywords(&[Keyword::INTO, Keyword::OVERWRITE]);
-        let into = action == Some(Keyword::INTO);
-        let overwrite = action == Some(Keyword::OVERWRITE);
+        let overwrite = self.parse_keyword(Keyword::OVERWRITE);
+        let into = self.parse_keyword(Keyword::INTO);
 
         let local = self.parse_keyword(Keyword::LOCAL);
 

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2952,3 +2952,9 @@ fn test_sf_double_dot_notation() {
 
 #[test]
 fn test_parse_double_dot_notation_wrong_position() {}
+
+#[test]
+fn parse_insert_overwrite() {
+    let insert_overwrite_into = r#"INSERT OVERWRITE INTO schema.table SELECT a FROM b"#;
+    snowflake().verified_stmt(insert_overwrite_into);
+}


### PR DESCRIPTION
The following query is valid in Snowflake:
`INSERT OVERWRITE INTO schema.table SELECT a FROM b`