### PR TITLE
Parse `INSERT` with subquery when lacking column names

### DIFF
--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -10964,6 +10964,8 @@ fn insert_into_with_parentheses() {
         Box::new(GenericDialect {}),
     ]);
     dialects.verified_stmt("INSERT INTO t1 (id, name) (SELECT t2.id, t2.name FROM t2)");
+    dialects.verified_stmt("INSERT INTO t1 (SELECT t2.id, t2.name FROM t2)");
+    dialects.verified_stmt(r#"INSERT INTO t1 ("select", name) (SELECT t2.name FROM t2)"#);
 }
 
 #[test]


### PR DESCRIPTION
Adds support to parse the example scenario:
```sql
INSERT INTO t1 (SELECT 1)
```

The parser previously looked to parse the subquery as a parenthesized list of column names which was
incorrect in this case.