### PR TITLE
Improve parsing performance by reducing token cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,13 @@ You can run them with:
 ```
 git checkout main
 cd sqlparser_bench
-cargo bench
+cargo bench -- --save-baseline main
 git checkout <your branch>
-cargo bench
+cargo bench -- --baseline main
 ```
+
+By adding the `--save-baseline main` and `--baseline main` you can track the
+progress of your improvements as you continue working on the feature branch.
 
 ## Licensing
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -75,6 +75,15 @@ macro_rules! dialect_of {
     };
 }
 
+// Similar to above, but for applying directly against an instance of dialect
+// instead of a struct member named dialect. This avoids lifetime issues when
+// mixing match guards and token references.
+macro_rules! dialect_is {
+    ($dialect:ident is $($dialect_type:ty)|+) => {
+        ($($dialect.is::<$dialect_type>())||+)
+    }
+}
+
 /// Encapsulates the differences between SQL implementations.
 ///
 /// # SQL Dialects

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -235,11 +235,11 @@ impl Dialect for PostgreSqlDialect {
 
 pub fn parse_create(parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
     let name = parser.maybe_parse(|parser| -> Result<ObjectName, ParserError> {
-        parser.expect_keyword(Keyword::CREATE)?;
-        parser.expect_keyword(Keyword::TYPE)?;
+        parser.expect_keyword_is(Keyword::CREATE)?;
+        parser.expect_keyword_is(Keyword::TYPE)?;
         let name = parser.parse_object_name(false)?;
-        parser.expect_keyword(Keyword::AS)?;
-        parser.expect_keyword(Keyword::ENUM)?;
+        parser.expect_keyword_is(Keyword::AS)?;
+        parser.expect_keyword_is(Keyword::ENUM)?;
         Ok(name)
     });
 

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -269,7 +269,7 @@ pub fn parse_create_table(
         match &next_token.token {
             Token::Word(word) => match word.keyword {
                 Keyword::COPY => {
-                    parser.expect_keyword(Keyword::GRANTS)?;
+                    parser.expect_keyword_is(Keyword::GRANTS)?;
                     builder = builder.copy_grants(true);
                 }
                 Keyword::COMMENT => {
@@ -293,7 +293,7 @@ pub fn parse_create_table(
                     break;
                 }
                 Keyword::CLUSTER => {
-                    parser.expect_keyword(Keyword::BY)?;
+                    parser.expect_keyword_is(Keyword::BY)?;
                     parser.expect_token(&Token::LParen)?;
                     let cluster_by = Some(WrappedCollection::Parentheses(
                         parser.parse_comma_separated(|p| p.parse_identifier(false))?,
@@ -356,14 +356,14 @@ pub fn parse_create_table(
                     parser.prev_token();
                 }
                 Keyword::AGGREGATION => {
-                    parser.expect_keyword(Keyword::POLICY)?;
+                    parser.expect_keyword_is(Keyword::POLICY)?;
                     let aggregation_policy = parser.parse_object_name(false)?;
                     builder = builder.with_aggregation_policy(Some(aggregation_policy));
                 }
                 Keyword::ROW => {
                     parser.expect_keywords(&[Keyword::ACCESS, Keyword::POLICY])?;
                     let policy = parser.parse_object_name(false)?;
-                    parser.expect_keyword(Keyword::ON)?;
+                    parser.expect_keyword_is(Keyword::ON)?;
                     parser.expect_token(&Token::LParen)?;
                     let columns = parser.parse_comma_separated(|p| p.parse_identifier(false))?;
                     parser.expect_token(&Token::RParen)?;
@@ -528,15 +528,15 @@ pub fn parse_copy_into(parser: &mut Parser) -> Result<Statement, ParserError> {
     let from_stage: ObjectName;
     let stage_params: StageParamsObject;
 
-    parser.expect_keyword(Keyword::FROM)?;
+    parser.expect_keyword_is(Keyword::FROM)?;
     // check if data load transformations are present
     match parser.next_token().token {
         Token::LParen => {
             // data load with transformations
-            parser.expect_keyword(Keyword::SELECT)?;
+            parser.expect_keyword_is(Keyword::SELECT)?;
             from_transformations = parse_select_items_for_data_load(parser)?;
 
-            parser.expect_keyword(Keyword::FROM)?;
+            parser.expect_keyword_is(Keyword::FROM)?;
             from_stage = parse_snowflake_stage_name(parser)?;
             stage_params = parse_stage_params(parser)?;
 
@@ -852,7 +852,7 @@ fn parse_identity_property(parser: &mut Parser) -> Result<IdentityProperty, Pars
         ))
     } else if parser.parse_keyword(Keyword::START) {
         let seed = parser.parse_number()?;
-        parser.expect_keyword(Keyword::INCREMENT)?;
+        parser.expect_keyword_is(Keyword::INCREMENT)?;
         let increment = parser.parse_number()?;
 
         Some(IdentityPropertyFormatKind::StartAndIncrement(

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -52,11 +52,11 @@ impl Parser<'_> {
     /// [PostgreSQL](https://www.postgresql.org/docs/current/sql-alterpolicy.html)
     pub fn parse_alter_policy(&mut self) -> Result<Statement, ParserError> {
         let name = self.parse_identifier(false)?;
-        self.expect_keyword(Keyword::ON)?;
+        self.expect_keyword_is(Keyword::ON)?;
         let table_name = self.parse_object_name(false)?;
 
         if self.parse_keyword(Keyword::RENAME) {
-            self.expect_keyword(Keyword::TO)?;
+            self.expect_keyword_is(Keyword::TO)?;
             let new_name = self.parse_identifier(false)?;
             Ok(Statement::AlterPolicy {
                 name,
@@ -232,7 +232,7 @@ impl Parser<'_> {
             Some(Keyword::BYPASSRLS) => RoleOption::BypassRLS(true),
             Some(Keyword::NOBYPASSRLS) => RoleOption::BypassRLS(false),
             Some(Keyword::CONNECTION) => {
-                self.expect_keyword(Keyword::LIMIT)?;
+                self.expect_keyword_is(Keyword::LIMIT)?;
                 RoleOption::ConnectionLimit(Expr::Value(self.parse_number_value()?))
             }
             Some(Keyword::CREATEDB) => RoleOption::CreateDB(true),
@@ -256,7 +256,7 @@ impl Parser<'_> {
             Some(Keyword::SUPERUSER) => RoleOption::SuperUser(true),
             Some(Keyword::NOSUPERUSER) => RoleOption::SuperUser(false),
             Some(Keyword::VALID) => {
-                self.expect_keyword(Keyword::UNTIL)?;
+                self.expect_keyword_is(Keyword::UNTIL)?;
                 RoleOption::ValidUntil(Expr::Value(self.parse_value()?))
             }
             _ => self.expected("option", self.peek_token())?,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8606,14 +8606,14 @@ impl<'a> Parser<'a> {
     pub fn parse_identifiers(&mut self) -> Result<Vec<Ident>, ParserError> {
         let mut idents = vec![];
         loop {
-            match self.peek_token().token {
+            match &self.peek_token_ref().token {
                 Token::Word(w) => {
-                    idents.push(w.to_ident(self.peek_token().span));
+                    idents.push(w.to_ident(self.peek_token_ref().span));
                 }
                 Token::EOF | Token::Eq => break,
                 _ => {}
             }
-            self.next_token();
+            self.next_token_ref();
         }
         Ok(idents)
     }


### PR DESCRIPTION
This basically just takes the approach proposed by @alamb in #1561 and runs with it.

- Part of https://github.com/apache/datafusion-sqlparser-rs/issues/1558

The main changes involved:

1. A number of token parsing methods introduced that return a `&TokenWithSpan` instead of a cloned `TokenWithSpan`.
2. A bunch of updates to make use of these new ref returning functions.
3. Refactoring some of the core peek/expect/consume methods to avoid unnecessary clones
4. Replace all but one use of expect_keyword with expect_keyword_is.

Results on my M1 MacBook Pro:

```
# main:00abaf218

❯ cargo bench -- --save-baseline main
    Finished `bench` profile [optimized] target(s) in 0.11s
     Running benches/sqlparser_bench.rs (target/release/deps/sqlparser_bench-9f7a6e6e193d8f5c)
sqlparser-rs parsing benchmark/sqlparser::select
                        time:   [4.2036 µs 4.2197 µs 4.2372 µs]
                        change: [-2.4618% -2.1421% -1.8071%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
Benchmarking sqlparser-rs parsing benchmark/sqlparser::with_select: Collecting 100 samples in estimated 5.0715 s (278k iteratio
sqlparser-rs parsing benchmark/sqlparser::with_select
                        time:   [18.360 µs 18.425 µs 18.486 µs]
                        change: [-5.3763% -2.5663% -0.8662%] (p = 0.02 < 0.05)
                        Change within noise threshold.

# reduce-token-cloning:1ffa2aa4

❯ cargo bench -- --baseline main
   Compiling sqlparser v0.52.0 (/Users/davisp/github/davisp/datafusion-sqlparser-rs)
   Compiling sqlparser_bench v0.1.0 (/Users/davisp/github/davisp/datafusion-sqlparser-rs/sqlparser_bench)
    Finished `bench` profile [optimized] target(s) in 15.76s
     Running benches/sqlparser_bench.rs (target/release/deps/sqlparser_bench-9f7a6e6e193d8f5c)
sqlparser-rs parsing benchmark/sqlparser::select
                        time:   [2.9006 µs 2.9020 µs 2.9034 µs]
                        change: [-31.254% -31.013% -30.769%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
Benchmarking sqlparser-rs parsing benchmark/sqlparser::with_select: Collecting 100 samples in estimated 5.0415 s (364k iteratio
sqlparser-rs parsing benchmark/sqlparser::with_select
                        time:   [13.785 µs 13.813 µs 13.843 µs]
                        change: [-25.054% -24.778% -24.494%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

```