### PR TITLE
Add Apache license header to spans.rs

### DIFF
--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use core::iter;
 
 use crate::tokenizer::Span;


### PR DESCRIPTION
- part of https://github.com/apache/datafusion-sqlparser-rs/issues/1517

While trying to make a release candidate, the license check failed 
```
Running rat license checker on /Users/andrewlamb/Software/sqlparser-rs/dev/dist/apache-datafusion-sqlparser-rs-0.53.0-rc1/apache-datafusion-sqlparser-rs-0.53.0.tar.gz
NOT APPROVED: src/ast/spans.rs (apache-datafusion-sqlparser-rs-0.53.0/src/ast/spans.rs): false
```

This PR adds the license to spans.rs (a newly added file)