### PR TITLE
Fix BigQuery hyphenated ObjectName with numbers

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8747,7 +8747,9 @@ impl<'a> Parser<'a> {
                             }
                             Token::Number(s, false) if s.chars().all(|c| c.is_ascii_digit()) => {
                                 ident.value.push_str(&s);
-                                true
+                                // If next token is period, then it is part of an ObjectName and we don't expect whitespace
+                                // after the number.
+                                !matches!(self.peek_token().token, Token::Period)
                             }
                             _ => {
                                 return self

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1119,7 +1119,7 @@ impl<'a> Tokenizer<'a> {
                         {
                             s.push('.');
                             chars.next();
-                        } else if s.is_empty() {
+                        } else if !s.is_empty() {
                             // Number might be part of period separated construct. Keep the period for next token
                             // e.g. a-12.b
                             return Ok(Some(Token::Number(s, false)));

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1108,15 +1108,29 @@ impl<'a> Tokenizer<'a> {
 
                     // match one period
                     if let Some('.') = chars.peek() {
-                        s.push('.');
-                        chars.next();
+                        // Check if this actually is a float point number
+                        let mut char_clone = chars.peekable.clone();
+                        char_clone.next();
+                        // Next char should be a digit, otherwise, it is not a float point number
+                        if char_clone
+                            .peek()
+                            .map(|c| c.is_ascii_digit())
+                            .unwrap_or(false)
+                        {
+                            s.push('.');
+                            chars.next();
+                        } else if s.is_empty() {
+                            // Number might be part of period separated construct. Keep the period for next token
+                            // e.g. a-12.b
+                            return Ok(Some(Token::Number(s, false)));
+                        } else {
+                            // No number -> Token::Period
+                            chars.next();
+                            return Ok(Some(Token::Period));
+                        }
                     }
-                    s += &peeking_take_while(chars, |ch| ch.is_ascii_digit());
 
-                    // No number -> Token::Period
-                    if s == "." {
-                        return Ok(Some(Token::Period));
-                    }
+                    s += &peeking_take_while(chars, |ch| ch.is_ascii_digit());
 
                     let mut exponent_part = String::new();
                     // Parse exponent as number
@@ -2125,6 +2139,23 @@ mod tests {
             Token::Number(String::from(".1"), false),
         ];
 
+        compare(expected, tokens);
+    }
+
+    #[test]
+    fn tokenize_select_float_hyphenated_identifier() {
+        let sql = String::from("SELECT a-12.b");
+        let dialect = GenericDialect {};
+        let tokens = Tokenizer::new(&dialect, &sql).tokenize().unwrap();
+        let expected = vec![
+            Token::make_keyword("SELECT"),
+            Token::Whitespace(Whitespace::Space),
+            Token::make_word("a", None),
+            Token::Minus,
+            Token::Number(String::from("12"), false),
+            Token::Period,
+            Token::make_word("b", None),
+        ];
         compare(expected, tokens);
     }
 

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1525,6 +1525,26 @@ fn parse_hyphenated_table_identifiers() {
     assert_eq!(
         bigquery()
             .verified_only_select_with_canonical(
+                "select * from foo-123.bar",
+                "SELECT * FROM foo-123.bar"
+            )
+            .from[0]
+            .relation,
+        TableFactor::Table {
+            name: ObjectName(vec![Ident::new("foo-123"), Ident::new("bar")]),
+            alias: None,
+            args: None,
+            with_hints: vec![],
+            version: None,
+            partitions: vec![],
+            with_ordinality: false,
+            json_path: None,
+        }
+    );
+
+    assert_eq!(
+        bigquery()
+            .verified_only_select_with_canonical(
                 "SELECT foo-bar.x FROM t",
                 "SELECT foo - bar.x FROM t"
             )


### PR DESCRIPTION
We currently support hyphenated identifiers for BigQuery. The current code expects the number segment to be the last segment ex: `foo-123` and should be followed by whitespace. That is true except when this identifier is part of an ObjectName. Ex: `SELECT * FROM foo-123.bar`. 
The issue is that tokenizer parse the previous string as: `[Word("foo"), Minus, Number("123."), Word("bar")]`
This PR:
1. Fixes the tokenizer to tokenize `foo-123.bar` as `[Word('"foo"), Minus, Number("123"), Period, Word("bar")]`
2. Fixes the parser to parse `foo-123.bar` as `ObjectName([Ident("foo-123"), Ident("bar")])` instead of erroring out.