### PR TITLE
Support optional table for `ANALYZE` statement

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2351,6 +2351,7 @@ pub enum Statement {
         cache_metadata: bool,
         noscan: bool,
         compute_statistics: bool,
+        has_table_keyword: bool,
     },
     /// ```sql
     /// TRUNCATE
@@ -3641,8 +3642,13 @@ impl fmt::Display for Statement {
                 cache_metadata,
                 noscan,
                 compute_statistics,
+                has_table_keyword,
             } => {
-                write!(f, "ANALYZE TABLE {table_name}")?;
+                write!(
+                    f,
+                    "ANALYZE{}{table_name}",
+                    if *has_table_keyword { " TABLE " } else { " " }
+                )?;
                 if let Some(ref parts) = partitions {
                     if !parts.is_empty() {
                         write!(f, " PARTITION ({})", display_comma_separated(parts))?;

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -267,6 +267,7 @@ impl Spanned for Statement {
                 cache_metadata: _,
                 noscan: _,
                 compute_statistics: _,
+                has_table_keyword: _,
             } => union_spans(
                 core::iter::once(table_name.span())
                     .chain(partitions.iter().flat_map(|i| i.iter().map(|k| k.span())))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -851,7 +851,9 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_analyze(&mut self) -> Result<Statement, ParserError> {
-        self.expect_keyword(Keyword::TABLE)?;
+        if dialect_of!(self is MySqlDialect | DatabricksDialect | HiveDialect | SnowflakeDialect) {
+            self.expect_keyword(Keyword::TABLE)?;
+        }
         let table_name = self.parse_object_name(false)?;
         let mut for_columns = false;
         let mut cache_metadata = false;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -851,9 +851,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_analyze(&mut self) -> Result<Statement, ParserError> {
-        if dialect_of!(self is MySqlDialect | DatabricksDialect | HiveDialect | SnowflakeDialect) {
-            self.expect_keyword(Keyword::TABLE)?;
-        }
+        let has_table_keyword = self.parse_keyword(Keyword::TABLE);
         let table_name = self.parse_object_name(false)?;
         let mut for_columns = false;
         let mut cache_metadata = false;
@@ -898,6 +896,7 @@ impl<'a> Parser<'a> {
         }
 
         Ok(Statement::Analyze {
+            has_table_keyword,
             table_name,
             for_columns,
             columns,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -579,6 +579,12 @@ fn parse_select_with_table_alias() {
 }
 
 #[test]
+fn parse_analyze() {
+    verified_stmt("ANALYZE TABLE test_table");
+    verified_stmt("ANALYZE test_table");
+}
+
+#[test]
 fn parse_invalid_table_name() {
     let ast = all_dialects().run_parser_method("db.public..customer", |parser| {
         parser.parse_object_name(false)


### PR DESCRIPTION
I am trying to fix issue https://github.com/apache/datafusion-sqlparser-rs/issues/1583 
I search the document, I think there only some dialect require the `table` keywords.
