### PR TITLE
Support arbitrary composite access expressions

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -640,7 +640,7 @@ pub enum Expr {
         /// The path to the data to extract.
         path: JsonPath,
     },
-    /// CompositeAccess (postgres) eg: SELECT (information_schema._pg_expandarray(array['i','i'])).n
+    /// CompositeAccess eg: SELECT foo(bar).z, (information_schema._pg_expandarray(array['i','i'])).n
     CompositeAccess {
         expr: Box<Expr>,
         key: Ident,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -962,6 +962,14 @@ impl<'a> Parser<'a> {
         let _guard = self.recursion_counter.try_decrease()?;
         debug!("parsing expr");
         let mut expr = self.parse_prefix()?;
+        // Attempt to parse composite access. Example `SELECT f(x).a`
+        while self.consume_token(&Token::Period) {
+            expr = Expr::CompositeAccess {
+                expr: Box::new(expr),
+                key: self.parse_identifier(false)?,
+            }
+        }
+
         debug!("prefix: {:?}", expr);
         loop {
             let next_precedence = self.get_next_precedence()?;
@@ -1386,25 +1394,7 @@ impl<'a> Parser<'a> {
                     }
                 };
                 self.expect_token(&Token::RParen)?;
-                let expr = self.try_parse_method(expr)?;
-                if !self.consume_token(&Token::Period) {
-                    Ok(expr)
-                } else {
-                    let tok = self.next_token();
-                    let key = match tok.token {
-                        Token::Word(word) => word.to_ident(tok.span),
-                        _ => {
-                            return parser_err!(
-                                format!("Expected identifier, found: {tok}"),
-                                tok.span.start
-                            )
-                        }
-                    };
-                    Ok(Expr::CompositeAccess {
-                        expr: Box::new(expr),
-                        key,
-                    })
-                }
+                self.try_parse_method(expr)
             }
             Token::Placeholder(_) | Token::Colon | Token::AtSign => {
                 self.prev_token();

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -12335,7 +12335,7 @@ fn parse_create_table_with_bit_types() {
 }
 
 #[test]
-fn parse_composed_access_expr() {
+fn parse_composite_access_expr() {
     assert_eq!(
         verified_expr("f(a).b"),
         Expr::CompositeAccess {


### PR DESCRIPTION
Right now the `CompositeAccess` expression is limited to support the PostgreSQL syntax like `SELECT (on_hand.item).name FROM on_hand WHERE (on_hand.item).price > 9`.
This PR generalize it to support arbitrary composite access expressions.  `CompositeAccess` expression is any prefix expression followed by a period then an identifier. The `CompositeAccess` itself can also be nested.

This change fixes issues with dialects that can access fields from another expression. For example dialects that supports `struct` literal. Something like `SELECT struct(1 as a).a` wouldn't work before this PR.