### PR TITLE
Add support for BigQuery `ANY TYPE` data type

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -376,7 +376,7 @@ pub enum DataType {
     /// Any data type, used in BigQuery UDF definitions for templated parameters
     ///
     /// [bigquery]: https://cloud.google.com/bigquery/docs/user-defined-functions#templated-sql-udf-parameters
-    AnyType
+    AnyType,
 }
 
 impl fmt::Display for DataType {

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -373,6 +373,10 @@ pub enum DataType {
     ///
     /// [postgresql]: https://www.postgresql.org/docs/current/plpgsql-trigger.html
     Trigger,
+    /// Any data type, used in BigQuery UDF definitions for templated parameters
+    ///
+    /// [bigquery]: https://cloud.google.com/bigquery/docs/user-defined-functions#templated-sql-udf-parameters
+    AnyType
 }
 
 impl fmt::Display for DataType {
@@ -383,7 +387,6 @@ impl fmt::Display for DataType {
             DataType::CharacterVarying(size) => {
                 format_character_string_type(f, "CHARACTER VARYING", size)
             }
-
             DataType::CharVarying(size) => format_character_string_type(f, "CHAR VARYING", size),
             DataType::Varchar(size) => format_character_string_type(f, "VARCHAR", size),
             DataType::Nvarchar(size) => format_character_string_type(f, "NVARCHAR", size),
@@ -626,6 +629,7 @@ impl fmt::Display for DataType {
             }
             DataType::Unspecified => Ok(()),
             DataType::Trigger => write!(f, "TRIGGER"),
+            DataType::AnyType => write!(f, "ANY TYPE"),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8382,6 +8382,10 @@ impl<'a> Parser<'a> {
                     Ok(DataType::Tuple(field_defs))
                 }
                 Keyword::TRIGGER => Ok(DataType::Trigger),
+                Keyword::ANY => {
+                    self.expect_keyword(Keyword::TYPE)?;
+                    Ok(DataType::AnyType)
+                }
                 _ => {
                     self.prev_token();
                     let type_name = self.parse_object_name(false)?;
@@ -8391,6 +8395,7 @@ impl<'a> Parser<'a> {
                         Ok(DataType::Custom(type_name, vec![]))
                     }
                 }
+
             },
             _ => self.expected("a data type name", next_token),
         }?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8395,7 +8395,6 @@ impl<'a> Parser<'a> {
                         Ok(DataType::Custom(type_name, vec![]))
                     }
                 }
-
             },
             _ => self.expected("a data type name", next_token),
         }?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8382,8 +8382,8 @@ impl<'a> Parser<'a> {
                     Ok(DataType::Tuple(field_defs))
                 }
                 Keyword::TRIGGER => Ok(DataType::Trigger),
-                Keyword::ANY => {
-                    self.expect_keyword(Keyword::TYPE)?;
+                Keyword::ANY if self.peek_keyword(Keyword::TYPE) => {
+                    let _ = self.parse_keyword(Keyword::TYPE);
                     Ok(DataType::AnyType)
                 }
                 _ => {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2099,11 +2099,11 @@ fn test_bigquery_create_function() {
         ),
         // Templated
         concat!(
-        "CREATE OR REPLACE TEMPORARY FUNCTION ",
-        "my_function(param1 ANY TYPE) ",
-        "AS (",
-        "(SELECT 1)",
-        ")",
+            "CREATE OR REPLACE TEMPORARY FUNCTION ",
+            "my_function(param1 ANY TYPE) ",
+            "AS (",
+            "(SELECT 1)",
+            ")",
         ),
     ];
     for sql in sqls {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2097,6 +2097,14 @@ fn test_bigquery_create_function() {
             "REMOTE WITH CONNECTION us.myconnection ",
             "OPTIONS(a = [1, 2])",
         ),
+        // Templated
+        concat!(
+        "CREATE OR REPLACE TEMPORARY FUNCTION ",
+        "my_function(param1 ANY TYPE) ",
+        "AS (",
+        "(SELECT 1)",
+        ")",
+        ),
     ];
     for sql in sqls {
         bigquery().verified_stmt(sql);

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2097,14 +2097,6 @@ fn test_bigquery_create_function() {
             "REMOTE WITH CONNECTION us.myconnection ",
             "OPTIONS(a = [1, 2])",
         ),
-        // Templated
-        concat!(
-            "CREATE OR REPLACE TEMPORARY FUNCTION ",
-            "my_function(param1 ANY TYPE) ",
-            "AS (",
-            "(SELECT 1)",
-            ")",
-        ),
     ];
     for sql in sqls {
         bigquery().verified_stmt(sql);
@@ -2219,4 +2211,20 @@ fn test_any_value() {
     );
     bigquery_and_generic().verified_expr("ANY_VALUE(fruit HAVING MAX sold)");
     bigquery_and_generic().verified_expr("ANY_VALUE(fruit HAVING MIN sold)");
+}
+
+#[test]
+fn test_any_type() {
+    bigquery().verified_stmt(concat!(
+        "CREATE OR REPLACE TEMPORARY FUNCTION ",
+        "my_function(param1 ANY TYPE) ",
+        "AS (",
+        "(SELECT 1)",
+        ")",
+    ));
+}
+
+#[test]
+fn test_any_type_dont_break_custom_type() {
+    bigquery_and_generic().verified_stmt("CREATE TABLE foo (x ANY)");
 }


### PR DESCRIPTION
As referenced in #1601 , here is a PR, with a test, that verifies correct parsing of BigQuery User-defined functions using templated SQL parameters (what a mouthful :D). 

More docs on the actual feature/functionality in BQ can be found here: https://cloud.google.com/bigquery/docs/user-defined-functions

Thanks in advance for the consideration!

EDIT: This closes #1601 