### PR TITLE
Avoid cloning during token creation

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -70,7 +70,8 @@ macro_rules! define_keywords {
     };
 }
 
-// The following keywords should be sorted to be able to match using binary search
+// Notes: The following keywords should be sorted to be able to match using
+// binary search
 define_keywords!(
     ABORT,
     ABS,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4160,7 +4160,7 @@ impl<'a> Parser<'a> {
             Keyword::ARCHIVE => Ok(Some(CreateFunctionUsing::Archive(uri))),
             _ => self.expected(
                 "JAR, FILE or ARCHIVE, got {:?}",
-                TokenWithSpan::wrap(Token::make_keyword(format!("{keyword:?}").as_str())),
+                TokenWithSpan::wrap(Token::make_keyword(format!("{keyword:?}"))),
             ),
         }
     }
@@ -6495,28 +6495,28 @@ impl<'a> Parser<'a> {
         {
             // Support AUTO_INCREMENT for MySQL
             Ok(Some(ColumnOption::DialectSpecific(vec![
-                Token::make_keyword("AUTO_INCREMENT"),
+                Token::make_keyword("AUTO_INCREMENT".into()),
             ])))
         } else if self.parse_keyword(Keyword::AUTOINCREMENT)
             && dialect_of!(self is SQLiteDialect |  GenericDialect)
         {
             // Support AUTOINCREMENT for SQLite
             Ok(Some(ColumnOption::DialectSpecific(vec![
-                Token::make_keyword("AUTOINCREMENT"),
+                Token::make_keyword("AUTOINCREMENT".into()),
             ])))
         } else if self.parse_keyword(Keyword::ASC)
             && self.dialect.supports_asc_desc_in_column_definition()
         {
             // Support ASC for SQLite
             Ok(Some(ColumnOption::DialectSpecific(vec![
-                Token::make_keyword("ASC"),
+                Token::make_keyword("ASC".into()),
             ])))
         } else if self.parse_keyword(Keyword::DESC)
             && self.dialect.supports_asc_desc_in_column_definition()
         {
             // Support DESC for SQLite
             Ok(Some(ColumnOption::DialectSpecific(vec![
-                Token::make_keyword("DESC"),
+                Token::make_keyword("DESC".into()),
             ])))
         } else if self.parse_keywords(&[Keyword::ON, Keyword::UPDATE])
             && dialect_of!(self is MySqlDialect | GenericDialect)
@@ -6889,7 +6889,7 @@ impl<'a> Parser<'a> {
                     return self.expected(
                         "FULLTEXT or SPATIAL option without constraint name",
                         TokenWithSpan {
-                            token: Token::make_keyword(&name.to_string()),
+                            token: Token::make_keyword(name.to_string()),
                             span: next_token.span,
                         },
                     );
@@ -13028,17 +13028,29 @@ mod tests {
     fn test_prev_index() {
         let sql = "SELECT version";
         all_dialects().run_parser_method(sql, |parser| {
-            assert_eq!(parser.peek_token(), Token::make_keyword("SELECT"));
-            assert_eq!(parser.next_token(), Token::make_keyword("SELECT"));
+            assert_eq!(parser.peek_token(), Token::make_keyword("SELECT".into()));
+            assert_eq!(parser.next_token(), Token::make_keyword("SELECT".into()));
             parser.prev_token();
-            assert_eq!(parser.next_token(), Token::make_keyword("SELECT"));
-            assert_eq!(parser.next_token(), Token::make_word("version", None));
+            assert_eq!(parser.next_token(), Token::make_keyword("SELECT".into()));
+            assert_eq!(
+                parser.next_token(),
+                Token::make_word("version".into(), None)
+            );
             parser.prev_token();
-            assert_eq!(parser.peek_token(), Token::make_word("version", None));
-            assert_eq!(parser.next_token(), Token::make_word("version", None));
+            assert_eq!(
+                parser.peek_token(),
+                Token::make_word("version".into(), None)
+            );
+            assert_eq!(
+                parser.next_token(),
+                Token::make_word("version".into(), None)
+            );
             assert_eq!(parser.peek_token(), Token::EOF);
             parser.prev_token();
-            assert_eq!(parser.next_token(), Token::make_word("version", None));
+            assert_eq!(
+                parser.next_token(),
+                Token::make_word("version".into(), None)
+            );
             assert_eq!(parser.next_token(), Token::EOF);
             assert_eq!(parser.next_token(), Token::EOF);
             parser.prev_token();

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -637,7 +637,7 @@ fn parse_create_table_auto_increment() {
                         ColumnOptionDef {
                             name: None,
                             option: ColumnOption::DialectSpecific(vec![Token::make_keyword(
-                                "AUTO_INCREMENT"
+                                "AUTO_INCREMENT".into()
                             )]),
                         },
                     ],
@@ -727,7 +727,7 @@ fn parse_create_table_primary_and_unique_key() {
                                 ColumnOptionDef {
                                     name: None,
                                     option: ColumnOption::DialectSpecific(vec![
-                                        Token::make_keyword("AUTO_INCREMENT")
+                                        Token::make_keyword("AUTO_INCREMENT".into())
                                     ]),
                                 },
                             ],

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -495,14 +495,14 @@ fn test_snowflake_single_line_tokenize() {
     let tokens = Tokenizer::new(&dialect, sql).tokenize().unwrap();
 
     let expected = vec![
-        Token::make_keyword("CREATE"),
+        Token::make_keyword("CREATE".into()),
         Token::Whitespace(Whitespace::Space),
-        Token::make_keyword("TABLE"),
+        Token::make_keyword("TABLE".into()),
         Token::Whitespace(Whitespace::SingleLineComment {
-            prefix: "#".to_string(),
-            comment: " this is a comment \n".to_string(),
+            prefix: "#".into(),
+            comment: " this is a comment \n".into(),
         }),
-        Token::make_word("table_1", None),
+        Token::make_word("table_1".into(), None),
     ];
 
     assert_eq!(expected, tokens);
@@ -511,15 +511,15 @@ fn test_snowflake_single_line_tokenize() {
     let tokens = Tokenizer::new(&dialect, sql).tokenize().unwrap();
 
     let expected = vec![
-        Token::make_keyword("CREATE"),
+        Token::make_keyword("CREATE".into()),
         Token::Whitespace(Whitespace::Space),
-        Token::make_keyword("TABLE"),
+        Token::make_keyword("TABLE".into()),
         Token::Whitespace(Whitespace::Space),
         Token::Whitespace(Whitespace::SingleLineComment {
             prefix: "//".to_string(),
             comment: " this is a comment \n".to_string(),
         }),
-        Token::make_word("table_1", None),
+        Token::make_word("table_1".into(), None),
     ];
 
     assert_eq!(expected, tokens);

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -226,7 +226,7 @@ fn parse_create_table_auto_increment() {
                         ColumnOptionDef {
                             name: None,
                             option: ColumnOption::DialectSpecific(vec![Token::make_keyword(
-                                "AUTOINCREMENT"
+                                "AUTOINCREMENT".into()
                             )]),
                         },
                     ],
@@ -262,14 +262,14 @@ fn parse_create_table_primary_key_asc_desc() {
     let sql = "CREATE TABLE foo (bar INT PRIMARY KEY ASC)";
     match sqlite_and_generic().verified_stmt(sql) {
         Statement::CreateTable(CreateTable { columns, .. }) => {
-            assert_eq!(vec![expected_column_def("ASC")], columns);
+            assert_eq!(vec![expected_column_def("ASC".into())], columns);
         }
         _ => unreachable!(),
     }
     let sql = "CREATE TABLE foo (bar INT PRIMARY KEY DESC)";
     match sqlite_and_generic().verified_stmt(sql) {
         Statement::CreateTable(CreateTable { columns, .. }) => {
-            assert_eq!(vec![expected_column_def("DESC")], columns);
+            assert_eq!(vec![expected_column_def("DESC".into())], columns);
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
# Rationale
Inspired by @davisp's https://github.com/apache/datafusion-sqlparser-rs/pull/1591 I was looking at `Token::make_word` and I noticed it made *2* clones (owned strings). Each copy slows things down so let's avoid them

# Changes
1. Change `Token::make_word` to reuse its argument and thus save a clone

# API Changes
This changes Token::make_word and Token::make_keyword to take `String` instead of `&str`. This would be a breaking API change. If it is a problem I can make owned variants (like `Token::make_word_owned` or something) 🤔 

# Performance benchmarks: 

```
++ critcmp main alamb_faster_keyword_lookup
group                                                    alamb_faster_keyword_lookup            main
-----                                                    ---------------------------            ----
sqlparser-rs parsing benchmark/sqlparser::select         1.00      6.4±0.03µs        ? ?/sec    1.00      6.4±0.03µs        ? ?/sec
sqlparser-rs parsing benchmark/sqlparser::with_select    1.02     31.5±0.10µs        ? ?/sec    1.00     31.0±0.13µs        ? ?/sec
```

🤔  it appears not to make much/any difference