### PR TITLE
Support Snowflake Update-From-Select

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -72,8 +72,8 @@ pub use self::query::{
     TableAlias, TableAliasColumnDef, TableFactor, TableFunctionArgs, TableSample,
     TableSampleBucket, TableSampleKind, TableSampleMethod, TableSampleModifier,
     TableSampleQuantity, TableSampleSeed, TableSampleSeedModifier, TableSampleUnit, TableVersion,
-    TableWithJoins, Top, TopQuantity, ValueTableMode, Values, WildcardAdditionalOptions, With,
-    WithFill,
+    TableWithJoins, Top, TopQuantity, UpdateTableFromKind, ValueTableMode, Values,
+    WildcardAdditionalOptions, With, WithFill,
 };
 
 pub use self::trigger::{
@@ -2479,7 +2479,7 @@ pub enum Statement {
         /// Column assignments
         assignments: Vec<Assignment>,
         /// Table which provide value to be set
-        from: Option<TableWithJoins>,
+        from: Option<UpdateTableFromKind>,
         /// WHERE
         selection: Option<Expr>,
         /// RETURNING
@@ -3751,10 +3751,13 @@ impl fmt::Display for Statement {
                     write!(f, "{or} ")?;
                 }
                 write!(f, "{table}")?;
+                if let Some(UpdateTableFromKind::BeforeSet(from)) = from {
+                    write!(f, " FROM {from}")?;
+                }
                 if !assignments.is_empty() {
                     write!(f, " SET {}", display_comma_separated(assignments))?;
                 }
-                if let Some(from) = from {
+                if let Some(UpdateTableFromKind::AfterSet(from)) = from {
                     write!(f, " FROM {from}")?;
                 }
                 if let Some(selection) = selection {

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2791,13 +2791,15 @@ impl fmt::Display for ValueTableMode {
     }
 }
 
-/// The update table from options
+/// The `FROM` clause of an `UPDATE TABLE` statement
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum UpdateTableFromKind {
-    /// Table sample located before the table alias option
+    /// Update Statment where the 'FROM' clause is before the 'SET' keyword (Supported by Snowflake)
+    /// For Example: UPDATE FROM t1 SET t1.name='aaa'
     BeforeSet(TableWithJoins),
-    /// Table sample located after the table alias option
+    /// Update Statment where the 'FROM' clause is after the 'SET' keyword (Which is the standard way)
+    /// For Example: UPDATE SET t1.name='aaa' FROM t1
     AfterSet(TableWithJoins),
 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2797,9 +2797,9 @@ impl fmt::Display for ValueTableMode {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum UpdateTableFromKind {
     /// Update Statment where the 'FROM' clause is before the 'SET' keyword (Supported by Snowflake)
-    /// For Example: UPDATE FROM t1 SET t1.name='aaa'
+    /// For Example: `UPDATE FROM t1 SET t1.name='aaa'`
     BeforeSet(TableWithJoins),
     /// Update Statment where the 'FROM' clause is after the 'SET' keyword (Which is the standard way)
-    /// For Example: UPDATE SET t1.name='aaa' FROM t1
+    /// For Example: `UPDATE SET t1.name='aaa' FROM t1`
     AfterSet(TableWithJoins),
 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2788,3 +2788,14 @@ impl fmt::Display for ValueTableMode {
         }
     }
 }
+
+/// The update table from options
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum UpdateTableFromKind {
+    /// Table sample located before the table alias option
+    BeforeSet(TableWithJoins),
+    /// Table sample located after the table alias option
+    AfterSet(TableWithJoins),
+}

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -32,8 +32,8 @@ use super::{
     PivotValueSource, ProjectionSelect, Query, ReferentialAction, RenameSelectItem,
     ReplaceSelectElement, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SqlOption,
     Statement, Subscript, SymbolDefinition, TableAlias, TableAliasColumnDef, TableConstraint,
-    TableFactor, TableOptionsClustered, TableWithJoins, Use, Value, Values, ViewColumnDef,
-    WildcardAdditionalOptions, With, WithFill,
+    TableFactor, TableOptionsClustered, TableWithJoins, UpdateTableFromKind, Use, Value, Values,
+    ViewColumnDef, WildcardAdditionalOptions, With, WithFill,
 };
 
 /// Given an iterator of spans, return the [Span::union] of all spans.
@@ -2095,6 +2095,15 @@ impl Spanned for SelectInto {
         } = self;
 
         name.span()
+    }
+}
+
+impl Spanned for UpdateTableFromKind {
+    fn span(&self) -> Span {
+        match self {
+            UpdateTableFromKind::BeforeSet(vec) => vec.span(),
+            UpdateTableFromKind::AfterSet(vec) => vec.span(),
+        }
     }
 }
 

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -2109,8 +2109,8 @@ impl Spanned for SelectInto {
 impl Spanned for UpdateTableFromKind {
     fn span(&self) -> Span {
         match self {
-            UpdateTableFromKind::BeforeSet(vec) => vec.span(),
-            UpdateTableFromKind::AfterSet(vec) => vec.span(),
+            UpdateTableFromKind::BeforeSet(from) => from.span(),
+            UpdateTableFromKind::AfterSet(from) => from.span(),
         }
     }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -940,6 +940,7 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     // Reserved for Snowflake table sample
     Keyword::SAMPLE,
     Keyword::TABLESAMPLE,
+    Keyword::FROM,
 ];
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11679,18 +11679,14 @@ impl<'a> Parser<'a> {
     pub fn parse_update(&mut self) -> Result<Statement, ParserError> {
         let or = self.parse_conflict_clause();
         let table = self.parse_table_and_joins()?;
-        let from_before_set = if self.parse_keyword(Keyword::FROM)
-            && dialect_of!(self is GenericDialect | PostgreSqlDialect | DuckDbDialect | BigQueryDialect | SnowflakeDialect | RedshiftSqlDialect | MsSqlDialect | SQLiteDialect )
-        {
+        let from_before_set = if self.parse_keyword(Keyword::FROM) {
             Some(self.parse_table_and_joins()?)
         } else {
             None
         };
         self.expect_keyword(Keyword::SET)?;
         let assignments = self.parse_comma_separated(Parser::parse_assignment)?;
-        let from = if self.parse_keyword(Keyword::FROM)
-            && dialect_of!(self is GenericDialect | PostgreSqlDialect | DuckDbDialect | BigQueryDialect | SnowflakeDialect | RedshiftSqlDialect | MsSqlDialect | SQLiteDialect )
-        {
+        let from = if from_before_set.is_none() && self.parse_keyword(Keyword::FROM) {
             Some(self.parse_table_and_joins()?)
         } else {
             from_before_set

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11699,14 +11699,16 @@ impl<'a> Parser<'a> {
         let or = self.parse_conflict_clause();
         let table = self.parse_table_and_joins()?;
         let from_before_set = if self.parse_keyword(Keyword::FROM) {
-            Some(self.parse_table_and_joins()?)
+            Some(UpdateTableFromKind::BeforeSet(
+                self.parse_table_and_joins()?,
+            ))
         } else {
             None
         };
         self.expect_keyword(Keyword::SET)?;
         let assignments = self.parse_comma_separated(Parser::parse_assignment)?;
         let from = if from_before_set.is_none() && self.parse_keyword(Keyword::FROM) {
-            Some(self.parse_table_and_joins()?)
+            Some(UpdateTableFromKind::AfterSet(self.parse_table_and_joins()?))
         } else {
             from_before_set
         };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11679,6 +11679,13 @@ impl<'a> Parser<'a> {
     pub fn parse_update(&mut self) -> Result<Statement, ParserError> {
         let or = self.parse_conflict_clause();
         let table = self.parse_table_and_joins()?;
+        let from_before_set = if self.parse_keyword(Keyword::FROM)
+            && dialect_of!(self is GenericDialect | PostgreSqlDialect | DuckDbDialect | BigQueryDialect | SnowflakeDialect | RedshiftSqlDialect | MsSqlDialect | SQLiteDialect )
+        {
+            Some(self.parse_table_and_joins()?)
+        } else {
+            None
+        };
         self.expect_keyword(Keyword::SET)?;
         let assignments = self.parse_comma_separated(Parser::parse_assignment)?;
         let from = if self.parse_keyword(Keyword::FROM)
@@ -11686,7 +11693,7 @@ impl<'a> Parser<'a> {
         {
             Some(self.parse_table_and_joins()?)
         } else {
-            None
+            from_before_set
         };
         let selection = if self.parse_keyword(Keyword::WHERE) {
             Some(self.parse_expr()?)

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -12396,3 +12396,17 @@ fn test_table_sample() {
     dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50)");
     dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
 }
+
+#[test]
+fn parse_update_from_before_select() {
+    let res = all_dialects()
+    .parse_sql_statements("UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name WHERE t1.id = t2.id");
+
+    assert!(res.is_ok(), "{res:?}");
+
+    let res = all_dialects().parse_sql_statements(
+        "UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name FROM (SELECT name from t2) AS t2",
+    );
+
+    assert!(res.is_err());
+}

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -12588,9 +12588,10 @@ fn parse_update_from_before_select() {
     all_dialects()
     .verified_stmt("UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name WHERE t1.id = t2.id");
 
-    let res = all_dialects().parse_sql_statements(
-        "UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name FROM (SELECT name from t2) AS t2",
+    let query =
+    "UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name FROM (SELECT name from t2) AS t2";
+    assert_eq!(
+        ParserError::ParserError("Expected: end of statement, found: FROM".to_string()),
+        parse_sql_statements(query).unwrap_err()
     );
-
-    assert!(res.is_err());
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -366,7 +366,7 @@ fn parse_update_set_from() {
                 target: AssignmentTarget::ColumnName(ObjectName(vec![Ident::new("name")])),
                 value: Expr::CompoundIdentifier(vec![Ident::new("t2"), Ident::new("name")])
             }],
-            from: Some(TableWithJoins {
+            from: Some(UpdateTableFromKind::AfterSet(TableWithJoins {
                 relation: TableFactor::Derived {
                     lateral: false,
                     subquery: Box::new(Query {
@@ -417,8 +417,8 @@ fn parse_update_set_from() {
                         columns: vec![],
                     })
                 },
-                joins: vec![],
-            }),
+                joins: vec![]
+            })),
             selection: Some(Expr::BinaryOp {
                 left: Box::new(Expr::CompoundIdentifier(vec![
                     Ident::new("t1"),
@@ -12449,10 +12449,8 @@ fn overflow() {
 
 #[test]
 fn parse_update_from_before_select() {
-    let res = all_dialects()
-    .parse_sql_statements("UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name WHERE t1.id = t2.id");
-
-    assert!(res.is_ok(), "{res:?}");
+    all_dialects()
+    .verified_stmt("UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name WHERE t1.id = t2.id");
 
     let res = all_dialects().parse_sql_statements(
         "UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name FROM (SELECT name from t2) AS t2",

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2974,10 +2974,3 @@ fn test_table_sample() {
     snowflake_and_generic().verified_stmt("SELECT id FROM mytable TABLESAMPLE (10) REPEATABLE (1)");
     snowflake_and_generic().verified_stmt("SELECT id FROM mytable TABLESAMPLE (10) SEED (1)");
 }
-
-#[test]
-fn parse_update_from_before_select() {
-    assert!(snowflake()
-    .parse_sql_statements("UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name WHERE t1.id = t2.id")
-    .is_ok());
-}

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2974,3 +2974,10 @@ fn test_table_sample() {
     snowflake_and_generic().verified_stmt("SELECT id FROM mytable TABLESAMPLE (10) REPEATABLE (1)");
     snowflake_and_generic().verified_stmt("SELECT id FROM mytable TABLESAMPLE (10) SEED (1)");
 }
+
+#[test]
+fn parse_update_from_before_select() {
+    assert!(snowflake()
+    .parse_sql_statements("UPDATE t1 FROM (SELECT name, id FROM t1 GROUP BY id) AS t2 SET name = t2.name WHERE t1.id = t2.id")
+    .is_ok());
+}


### PR DESCRIPTION
The following query works in Snowflake:


`UPDATE
    t1
FROM
    (
        SELECT
            name,
            id
        FROM
            t1
        GROUP BY
            id
    ) AS t2
SET
    name = t2.name
WHERE
    t1.id = t2.id
`

Today the parser only supports update-set-from