### PR TITLE
Support parsing `EXPLAIN ESTIMATE` of Clickhouse

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3239,6 +3239,9 @@ pub enum Statement {
         ///
         /// [SQLite](https://sqlite.org/lang_explain.html)
         query_plan: bool,
+        /// `EXPLAIN ESTIMATE`
+        /// [Clickhouse](https://clickhouse.com/docs/en/sql-reference/statements/explain#explain-estimate)
+        estimate: bool,
         /// A SQL query that specifies what to explain
         statement: Box<Statement>,
         /// Optional output format of explain
@@ -3471,6 +3474,7 @@ impl fmt::Display for Statement {
                 verbose,
                 analyze,
                 query_plan,
+                estimate,
                 statement,
                 format,
                 options,
@@ -3482,6 +3486,9 @@ impl fmt::Display for Statement {
                 }
                 if *analyze {
                     write!(f, "ANALYZE ")?;
+                }
+                if *estimate {
+                    write!(f, "ESTIMATE ")?;
                 }
 
                 if *verbose {

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -298,6 +298,7 @@ define_keywords!(
     ERROR,
     ESCAPE,
     ESCAPED,
+    ESTIMATE,
     EVENT,
     EVERY,
     EXCEPT,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9087,6 +9087,7 @@ impl<'a> Parser<'a> {
         let mut analyze = false;
         let mut verbose = false;
         let mut query_plan = false;
+        let mut estimate = false;
         let mut format = None;
         let mut options = None;
 
@@ -9099,6 +9100,8 @@ impl<'a> Parser<'a> {
             options = Some(self.parse_utility_options()?)
         } else if self.parse_keywords(&[Keyword::QUERY, Keyword::PLAN]) {
             query_plan = true;
+        } else if self.parse_keyword(Keyword::ESTIMATE) {
+            estimate = true;
         } else {
             analyze = self.parse_keyword(Keyword::ANALYZE);
             verbose = self.parse_keyword(Keyword::VERBOSE);
@@ -9116,6 +9119,7 @@ impl<'a> Parser<'a> {
                 analyze,
                 verbose,
                 query_plan,
+                estimate,
                 statement: Box::new(statement),
                 format,
                 options,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4375,6 +4375,7 @@ fn run_explain_analyze(
             analyze,
             verbose,
             query_plan,
+            estimate,
             statement,
             format,
             options,
@@ -4384,6 +4385,7 @@ fn run_explain_analyze(
             assert_eq!(format, expected_format);
             assert_eq!(options, exepcted_options);
             assert!(!query_plan);
+            assert!(!estimate);
             assert_eq!("SELECT sqrt(id) FROM foo", statement.to_string());
         }
         _ => panic!("Unexpected Statement, must be Explain"),
@@ -4525,6 +4527,34 @@ fn parse_explain_query_plan() {
         all_dialects()
             .parse_sql_statements("EXPLAIN QUERY SELECT sqrt(id) FROM foo")
             .unwrap_err()
+    );
+}
+
+#[test]
+fn parse_explain_estimate() {
+    let statement = all_dialects().verified_stmt("EXPLAIN ESTIMATE SELECT sqrt(id) FROM foo");
+
+    match &statement {
+        Statement::Explain {
+            query_plan,
+            estimate,
+            analyze,
+            verbose,
+            statement,
+            ..
+        } => {
+            assert!(estimate);
+            assert!(!query_plan);
+            assert!(!analyze);
+            assert!(!verbose);
+            assert_eq!("SELECT sqrt(id) FROM foo", statement.to_string());
+        }
+        _ => unreachable!(),
+    }
+
+    assert_eq!(
+        "EXPLAIN ESTIMATE SELECT sqrt(id) FROM foo",
+        statement.to_string()
     );
 }
 


### PR DESCRIPTION
Support [`EXPLAIN ESTIMATE`](https://clickhouse.com/docs/en/sql-reference/statements/explain#explain-estimate) of Clickhouse.