### PR TITLE
Handle empty projection in Postgres SELECT  statements

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -350,7 +350,9 @@ impl fmt::Display for Select {
             }
         }
 
-        write!(f, " {}", display_comma_separated(&self.projection))?;
+        if !self.projection.is_empty() {
+            write!(f, " {}", display_comma_separated(&self.projection))?;
+        }
 
         if let Some(ref into) = self.into {
             write!(f, " {into}")?;

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -127,4 +127,8 @@ impl Dialect for GenericDialect {
     fn supports_struct_literal(&self) -> bool {
         true
     }
+
+    fn supports_empty_projections(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -410,6 +410,16 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Return true if the dialect supports empty projections in SELECT statements
+    ///
+    /// Example
+    /// ```sql
+    /// SELECT from table_name
+    /// ```
+    fn supports_empty_projections(&self) -> bool {
+        false
+    }
+
     /// Dialect-specific infix parser override
     ///
     /// This method is called to parse the next infix expression.

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -231,6 +231,16 @@ impl Dialect for PostgreSqlDialect {
     fn supports_named_fn_args_with_expr_name(&self) -> bool {
         true
     }
+
+    /// Return true if the dialect supports empty projections in SELECT statements
+    ///
+    /// Example
+    /// ```sql
+    /// SELECT from table_name
+    /// ```
+    fn supports_empty_projections(&self) -> bool {
+        true
+    }
 }
 
 pub fn parse_create(parser: &mut Parser) -> Option<Result<Statement, ParserError>> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9604,7 +9604,13 @@ impl<'a> Parser<'a> {
             top = Some(self.parse_top()?);
         }
 
-        let projection = self.parse_projection()?;
+        let projection = if dialect_of!(self is PostgreSqlDialect | GenericDialect)
+            && self.peek_keyword(Keyword::FROM)
+        {
+            vec![]
+        } else {
+            self.parse_projection()?
+        };
 
         let into = if self.parse_keyword(Keyword::INTO) {
             let temporary = self

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9604,13 +9604,12 @@ impl<'a> Parser<'a> {
             top = Some(self.parse_top()?);
         }
 
-        let projection = if dialect_of!(self is PostgreSqlDialect | GenericDialect)
-            && self.peek_keyword(Keyword::FROM)
-        {
-            vec![]
-        } else {
-            self.parse_projection()?
-        };
+        let projection =
+            if self.dialect.supports_empty_projections() && self.peek_keyword(Keyword::FROM) {
+                vec![]
+            } else {
+                self.parse_projection()?
+            };
 
         let into = if self.parse_keyword(Keyword::INTO) {
             let temporary = self

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -12446,3 +12446,9 @@ fn overflow() {
     let statement = statements.pop().unwrap();
     assert_eq!(statement.to_string(), sql);
 }
+
+#[test]
+fn parse_select_without_projection() {
+    let dialects = all_dialects_where(|d| d.supports_empty_projections());
+    dialects.verified_stmt("SELECT FROM users");
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5195,8 +5195,3 @@ fn parse_bitstring_literal() {
         ))]
     );
 }
-
-#[test]
-fn parse_select_without_projection() {
-    pg_and_generic().verified_stmt("SELECT FROM users");
-}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5195,3 +5195,8 @@ fn parse_bitstring_literal() {
         ))]
     );
 }
+
+#[test]
+fn parse_select_without_projection() {
+    pg_and_generic().verified_stmt("SELECT FROM users");
+}


### PR DESCRIPTION
Handle empty projections in Postgres and the generic dialect

Statements in the form `SELECT FROM table` are valid in Postgres