### PR TITLE
Refactor advancing token to avoid duplication, avoid borrow checker issues

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3688,7 +3688,6 @@ impl<'a> Parser<'a> {
 
     /// If the current token is the `expected` keyword, consume it and returns a reference to the next token.
     ///
-    // TODO remove this in favor of advance??
     #[must_use]
     pub fn parse_keyword_token_ref(&mut self, expected: Keyword) -> Option<&TokenWithSpan> {
         match &self.peek_token_ref().token {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3562,7 +3562,8 @@ impl<'a> Parser<'a> {
 
     /// Advances to the next non-whitespace token and returns a copy.
     ///
-    /// See [`Self::next_token_ref`] to avoid the copy.
+    /// Please use [`Self::advance_token`] and [`Self::get_current_token`] to
+    /// avoid the copy.
     pub fn next_token(&mut self) -> TokenWithSpan {
         self.advance_token();
         self.get_current_token().clone()


### PR DESCRIPTION
- Follow on to https://github.com/apache/datafusion-sqlparser-rs/pull/1587
- Part of https://github.com/apache/datafusion-sqlparser-rs/issues/1558

@davisp made some great improvements to the `Parser` API to avoid copies, but now the API for managing tokens is a bit unwieldy. Before we release a new version I would like to improve the API

Speicfically some of the APIs take a `&mut self` to advance `index` but return a read only reference to the token. This means the borrow checker is overly stringent and will sometimes think the parser has a mutable borrow outstanding when it doesnt.

I think we can make the APIs easier to use (and thus more likely to use) with a bit of finagling and documentation

See definitions of previous/current/next on https://github.com/apache/datafusion-sqlparser-rs/pull/1617

I am hoping that we can get the API in shape a bit more and then deprecate some of the older style APIs. 

Changes:
1. Introduce `advance_token()` to advance to the next token and reduce redundancy
2. Introduce `get_current_token()`, `get_next_token()` `get_prev_token`
2. Introduce `current_token_index`
3. Remove `next_token_ref_with_index`  and `next_token_ref` in favor of the above

