### PR TITLE
SQLite: Allow dollar signs in placeholder names

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -636,10 +636,10 @@ pub trait Dialect: Debug + Any {
         false
     }
 
-    /// Returns true if this dialect allows dollar quoted strings
-    /// e.g. `SELECT $$Hello, world!$$` or `SELECT $tag$Hello, world!$tag$`
-    fn supports_dollar_quoted_string(&self) -> bool {
-        true
+    /// Returns true if this dialect allows dollar placeholders
+    /// e.g. `SELECT $var` (SQLite)
+    fn supports_dollar_placeholder(&self) -> bool {
+        false
     }
 
     /// Does the dialect support with clause in create index statement?

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -636,6 +636,8 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if this dialect allows dollar quoted strings
+    /// e.g. `SELECT $$Hello, world!$$` or `SELECT $tag$Hello, world!$tag$`
     fn supports_dollar_quoted_string(&self) -> bool {
         true
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -636,6 +636,10 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    fn supports_dollar_quoted_string(&self) -> bool {
+        true
+    }
+
     /// Does the dialect support with clause in create index statement?
     /// e.g. `CREATE INDEX idx ON t WITH (key = value, key2)`
     fn supports_create_index_with_clause(&self) -> bool {

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -82,7 +82,7 @@ impl Dialect for SQLiteDialect {
         true
     }
 
-    fn supports_dollar_quoted_string(&self) -> bool {
-        false
+    fn supports_dollar_placeholder(&self) -> bool {
+        true
     }
 }

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -81,4 +81,8 @@ impl Dialect for SQLiteDialect {
     fn supports_asc_desc_in_column_definition(&self) -> bool {
         true
     }
+
+    fn supports_dollar_quoted_string(&self) -> bool {
+        false
+    }
 }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -561,6 +561,16 @@ fn test_dollar_identifier_as_placeholder() {
         }
         _ => unreachable!(),
     }
+
+    // $$ is a valid placeholder in SQLite
+    match sqlite().verified_expr("id = $$") {
+        Expr::BinaryOp { op, left, right } => {
+            assert_eq!(op, BinaryOperator::Eq);
+            assert_eq!(left, Box::new(Expr::Identifier(Ident::new("id"))));
+            assert_eq!(right, Box::new(Expr::Value(Placeholder("$$".to_string()))));
+        }
+        _ => unreachable!(),
+    }
 }
 
 fn sqlite() -> TestedDialects {


### PR DESCRIPTION
Relevant: https://github.com/apache/datafusion-sqlparser-rs/pull/1402

<img width="406" alt="Screenshot 2024-12-26 at 14 46 58" src="https://github.com/user-attachments/assets/a71ec4e4-cf00-4e87-9b4c-b13f3f0842db" />

Not sure if this is the best way to fix, open for feedback.