### PR TITLE
Fix `sqlparser_bench` benchmark compilation

### DIFF
--- a/sqlparser_bench/benches/sqlparser_bench.rs
+++ b/sqlparser_bench/benches/sqlparser_bench.rs
@@ -78,8 +78,7 @@ fn basic_queries(c: &mut Criterion) {
 
     group.bench_function("format_large_statement", |b| {
         b.iter(|| {
-            let formatted_query = large_statement.to_string();
-            assert_eq!(formatted_query, large_statement);
+            let _formatted_query = large_statement.to_string();
         });
     });
 }


### PR DESCRIPTION
If you try to run the sqlparser benchmarks it fails to compile:

```shell
cd sqlparser_bench
cargo clippy --all-targets
```

```
error[E0277]: can't compare `std::string::String` with `sqlparser::ast::Statement`
  --> benches/sqlparser_bench.rs:82:13
   |
82 |             assert_eq!(formatted_query, large_statement);
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::string::String == sqlparser::ast::Statement`
   |
```