### PR TITLE
Correctly tokenize nested comments

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -131,4 +131,8 @@ impl Dialect for GenericDialect {
     fn supports_empty_projections(&self) -> bool {
         true
     }
+
+    fn supports_nested_comments(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -682,6 +682,12 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports nested comments
+    /// e.g. `/* /* nested */ */`
+    fn supports_nested_comments(&self) -> bool {
+        false
+    }
+
     /// Returns true if this dialect supports treating the equals operator `=` within a `SelectItem`
     /// as an alias assignment operator, rather than a boolean expression.
     /// For example: the following statements are equivalent for such a dialect:

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -241,6 +241,10 @@ impl Dialect for PostgreSqlDialect {
     fn supports_empty_projections(&self) -> bool {
         true
     }
+
+    fn supports_nested_comments(&self) -> bool {
+        true
+    }
 }
 
 pub fn parse_create(parser: &mut Parser) -> Option<Result<Statement, ParserError>> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -2727,48 +2727,52 @@ mod tests {
     #[test]
     fn tokenize_nested_multiline_comment() {
         let dialect = GenericDialect {};
-
-        let sql = String::from("0/*multi-line\n* \n/* comment \n /*comment*/*/ */ /comment*/1");
-        let tokens = Tokenizer::new(&dialect, &sql).tokenize().unwrap();
-        let expected = vec![
-            Token::Number("0".to_string(), false),
-            Token::Whitespace(Whitespace::MultiLineComment(
-                "multi-line\n* \n/* comment \n /*comment*/*/ ".into(),
-            )),
-            Token::Whitespace(Whitespace::Space),
-            Token::Div,
-            Token::Word(Word {
-                value: "comment".to_string(),
-                quote_style: None,
-                keyword: Keyword::COMMENT,
-            }),
-            Token::Mul,
-            Token::Div,
-            Token::Number("1".to_string(), false),
+        let test_cases = vec![
+            (
+                "0/*multi-line\n* \n/* comment \n /*comment*/*/ */ /comment*/1",
+                vec![
+                    Token::Number("0".to_string(), false),
+                    Token::Whitespace(Whitespace::MultiLineComment(
+                        "multi-line\n* \n/* comment \n /*comment*/*/ ".into(),
+                    )),
+                    Token::Whitespace(Whitespace::Space),
+                    Token::Div,
+                    Token::Word(Word {
+                        value: "comment".to_string(),
+                        quote_style: None,
+                        keyword: Keyword::COMMENT,
+                    }),
+                    Token::Mul,
+                    Token::Div,
+                    Token::Number("1".to_string(), false),
+                ],
+            ),
+            (
+                "0/*multi-line\n* \n/* comment \n /*comment/**/ */ /comment*/*/1",
+                vec![
+                    Token::Number("0".to_string(), false),
+                    Token::Whitespace(Whitespace::MultiLineComment(
+                        "multi-line\n* \n/* comment \n /*comment/**/ */ /comment*/".into(),
+                    )),
+                    Token::Number("1".to_string(), false),
+                ],
+            ),
+            (
+                "SELECT 1/* a /* b */ c */0",
+                vec![
+                    Token::make_keyword("SELECT"),
+                    Token::Whitespace(Whitespace::Space),
+                    Token::Number("1".to_string(), false),
+                    Token::Whitespace(Whitespace::MultiLineComment(" a /* b */ c ".to_string())),
+                    Token::Number("0".to_string(), false),
+                ],
+            ),
         ];
-        compare(expected, tokens);
 
-        let sql2 = String::from("0/*multi-line\n* \n/* comment \n /*comment/**/ */ /comment*/*/1");
-        let tokens2 = Tokenizer::new(&dialect, &sql2).tokenize().unwrap();
-        let expected2 = vec![
-            Token::Number("0".to_string(), false),
-            Token::Whitespace(Whitespace::MultiLineComment(
-                "multi-line\n* \n/* comment \n /*comment/**/ */ /comment*/".into(),
-            )),
-            Token::Number("1".to_string(), false),
-        ];
-        compare(expected2, tokens2);
-
-        let sql3 = String::from("SELECT 1 /* a /* b */ c */");
-        let tokens3 = Tokenizer::new(&dialect, &sql3).tokenize().unwrap();
-        let expected3 = vec![
-            Token::make_keyword("SELECT"),
-            Token::Whitespace(Whitespace::Space),
-            Token::Number("1".to_string(), false),
-            Token::Whitespace(Whitespace::Space),
-            Token::Whitespace(Whitespace::MultiLineComment(" a /* b */ c ".to_string())),
-        ];
-        compare(expected3, tokens3);
+        for (sql, expected) in test_cases {
+            let tokens = Tokenizer::new(&dialect, sql).tokenize().unwrap();
+            compare(expected, tokens);
+        }
     }
 
     #[test]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -2777,16 +2777,16 @@ mod tests {
 
     #[test]
     fn tokenize_nested_multiline_comment_empty() {
-        let sql = "select 'foo' /*/**/*/";
+        let sql = "select 1/*/**/*/0";
 
         let dialect = GenericDialect {};
         let tokens = Tokenizer::new(&dialect, sql).tokenize().unwrap();
         let expected = vec![
             Token::make_keyword("select"),
             Token::Whitespace(Whitespace::Space),
-            Token::SingleQuotedString("foo".to_string()),
-            Token::Whitespace(Whitespace::Space),
+            Token::Number("1".to_string(), false),
             Token::Whitespace(Whitespace::MultiLineComment("/**/".to_string())),
+            Token::Number("0".to_string(), false),
         ];
 
         compare(expected, tokens);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1855,22 +1855,30 @@ impl<'a> Tokenizer<'a> {
     ) -> Result<Option<Token>, TokenizerError> {
         let mut s = String::new();
         let mut nested = 1;
-        let mut last_ch = ' ';
 
         loop {
             match chars.next() {
                 Some(ch) => {
-                    if last_ch == '/' && ch == '*' {
+                    if ch == '/' && matches!(chars.peek(), Some('*')) {
+                        s.push(ch);
+                        s.push(chars.next().unwrap()); // consume the '*'
                         nested += 1;
-                    } else if last_ch == '*' && ch == '/' {
+                        continue;
+                    }
+
+                    if ch == '*' && matches!(chars.peek(), Some('/')) {
+                        s.push(ch);
+                        let slash = chars.next();
                         nested -= 1;
                         if nested == 0 {
-                            s.pop();
+                            s.pop(); // remove the last '/'
                             break Ok(Some(Token::Whitespace(Whitespace::MultiLineComment(s))));
                         }
+                        s.push(slash.unwrap());
+                        continue;
                     }
+
                     s.push(ch);
-                    last_ch = ch;
                 }
                 None => {
                     break self.tokenizer_error(
@@ -2718,17 +2726,65 @@ mod tests {
 
     #[test]
     fn tokenize_nested_multiline_comment() {
-        let sql = String::from("0/*multi-line\n* \n/* comment \n /*comment*/*/ */ /comment*/1");
-
         let dialect = GenericDialect {};
+
+        let sql = String::from("0/*multi-line\n* \n/* comment \n /*comment*/*/ */ /comment*/1");
         let tokens = Tokenizer::new(&dialect, &sql).tokenize().unwrap();
         let expected = vec![
             Token::Number("0".to_string(), false),
             Token::Whitespace(Whitespace::MultiLineComment(
-                "multi-line\n* \n/* comment \n /*comment*/*/ */ /comment".to_string(),
+                "multi-line\n* \n/* comment \n /*comment*/*/ ".into(),
+            )),
+            Token::Whitespace(Whitespace::Space),
+            Token::Div,
+            Token::Word(Word {
+                value: "comment".to_string(),
+                quote_style: None,
+                keyword: Keyword::COMMENT,
+            }),
+            Token::Mul,
+            Token::Div,
+            Token::Number("1".to_string(), false),
+        ];
+        compare(expected, tokens);
+
+        let sql2 = String::from("0/*multi-line\n* \n/* comment \n /*comment/**/ */ /comment*/*/1");
+        let tokens2 = Tokenizer::new(&dialect, &sql2).tokenize().unwrap();
+        let expected2 = vec![
+            Token::Number("0".to_string(), false),
+            Token::Whitespace(Whitespace::MultiLineComment(
+                "multi-line\n* \n/* comment \n /*comment/**/ */ /comment*/".into(),
             )),
             Token::Number("1".to_string(), false),
         ];
+        compare(expected2, tokens2);
+
+        let sql3 = String::from("SELECT 1 /* a /* b */ c */");
+        let tokens3 = Tokenizer::new(&dialect, &sql3).tokenize().unwrap();
+        let expected3 = vec![
+            Token::make_keyword("SELECT"),
+            Token::Whitespace(Whitespace::Space),
+            Token::Number("1".to_string(), false),
+            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace(Whitespace::MultiLineComment(" a /* b */ c ".to_string())),
+        ];
+        compare(expected3, tokens3);
+    }
+
+    #[test]
+    fn tokenize_nested_multiline_comment_empty() {
+        let sql = "select 'foo' /*/**/*/";
+
+        let dialect = GenericDialect {};
+        let tokens = Tokenizer::new(&dialect, sql).tokenize().unwrap();
+        let expected = vec![
+            Token::make_keyword("select"),
+            Token::Whitespace(Whitespace::Space),
+            Token::SingleQuotedString("foo".to_string()),
+            Token::Whitespace(Whitespace::Space),
+            Token::Whitespace(Whitespace::MultiLineComment("/**/".to_string())),
+        ];
+
         compare(expected, tokens);
     }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1871,7 +1871,7 @@ impl<'a> Tokenizer<'a> {
                         let slash = chars.next();
                         nested -= 1;
                         if nested == 0 {
-                            s.pop(); // remove the last '/'
+                            s.pop(); // remove the last '*'
                             break Ok(Some(Token::Whitespace(Whitespace::MultiLineComment(s))));
                         }
                         s.push(slash.unwrap());


### PR DESCRIPTION
The tokenizer currently throws EOF error for `select 'foo' /*/**/*/`

`last_ch` causes problems when tokenizing nested comments, we have to consume the combination of `/*` or `*/`

The existing `tokenize_nested_multiline_comment` test fails after fixing this logic:

```
/*multi-line\n* \n/* comment \n /*comment*/*/ */ /comment*/
^^ Start                                      ^^ End nested comment
```

proof:

```
psql (14.15 (Homebrew), server 14.11)
Type "help" for help.

main_db=# SELECT 'foo' /*/**/*/;
 ?column?
----------
 foo
(1 row)

main_db=# SELECT 'foo' /*multi-line\n* \n/* comment \n /*comment*/*/ */ /comment*/;
ERROR:  syntax error at or near ";"
LINE 1: .../*multi-line\n* \n/* comment \n /*comment*/*/ */ /comment*/;
                                                                      ^
main_db=# SELECT 'foo' /*multi-line\n* \n/* comment \n /*comment*/*/ */;
 ?column?
----------
 foo
(1 row)
```

Relevant: https://github.com/apache/datafusion-sqlparser-rs/pull/726