### PR TITLE
Add support for Snowflake column aliases that use SQL keywords

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -827,6 +827,13 @@ pub trait Dialect: Debug + Any {
     fn is_select_item_alias(&self, explicit: bool, kw: &Keyword, _parser: &mut Parser) -> bool {
         explicit || !keywords::RESERVED_FOR_COLUMN_ALIAS.contains(kw)
     }
+
+    /// Returns true if the specified keyword should be parsed as a table factor alias.
+    /// When explicit is true, the keyword is preceded by an `AS` word. Parser is provided
+    /// to enable looking ahead if needed.
+    fn is_table_factor_alias(&self, explicit: bool, kw: &Keyword, _parser: &mut Parser) -> bool {
+        explicit || !keywords::RESERVED_FOR_TABLE_ALIAS.contains(kw)
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -820,6 +820,13 @@ pub trait Dialect: Debug + Any {
     fn supports_set_stmt_without_operator(&self) -> bool {
         false
     }
+
+    /// Returns true if the specified keyword should be parsed as a select item alias.
+    /// When explicit is true, the keyword is preceded by an `AS` word. Parser is provided
+    /// to enable looking ahead if needed.
+    fn is_select_item_alias(&self, explicit: bool, kw: &Keyword, _parser: &mut Parser) -> bool {
+        explicit || !keywords::RESERVED_FOR_COLUMN_ALIAS.contains(kw)
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -285,6 +285,7 @@ impl Dialect for SnowflakeDialect {
             | Keyword::HAVING
             | Keyword::INTERSECT
             | Keyword::INTO
+            | Keyword::MINUS
             | Keyword::ORDER
             | Keyword::SELECT
             | Keyword::UNION

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8895,7 +8895,7 @@ impl<'a> Parser<'a> {
             // By default, if a word is located after the `AS` keyword we consider it an alias
             // as long as it's not reserved.
             Token::Word(w)
-                if after_as || reserved_kwds.map_or(false, |x| !x.contains(&w.keyword)) =>
+                if after_as || reserved_kwds.is_some_and(|x| !x.contains(&w.keyword)) =>
             {
                 Ok(Some(w.into_ident(next_token.span)))
             }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -3022,3 +3022,32 @@ fn parse_ls_and_rm() {
 
     snowflake().verified_stmt(r#"LIST @"STAGE_WITH_QUOTES""#);
 }
+
+#[test]
+fn test_sql_keywords_as_select_item_aliases() {
+    // Some keywords that should be parsed as an alias
+    let unreserved_kws = vec!["CLUSTER", "FETCH", "RETURNING", "LIMIT", "EXCEPT"];
+    for kw in unreserved_kws {
+        snowflake()
+            .one_statement_parses_to(&format!("SELECT 1 {kw}"), &format!("SELECT 1 AS {kw}"));
+    }
+
+    // Some keywords that should not be parsed as an alias
+    let reserved_kws = vec![
+        "FROM",
+        "GROUP",
+        "HAVING",
+        "INTERSECT",
+        "INTO",
+        "ORDER",
+        "SELECT",
+        "UNION",
+        "WHERE",
+        "WITH",
+    ];
+    for kw in reserved_kws {
+        assert!(snowflake()
+            .parse_sql_statements(&format!("SELECT 1 {kw}"))
+            .is_err());
+    }
+}


### PR DESCRIPTION
Attempts at solving issue #1607 

Snowflake is not very strict with using SQL keywords as select list item aliases. Added support for the dialect to control if a word is parsed as an alias or not. Parsing of aliases is quite centralized now, and this PR breaks that up a bit, so feedback is welcomed if this is a good approach or alternative solutions are preferred.