### PR TITLE
preserve sql formatting through a parse + display roundtrip (partial implementation)

### DIFF
--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1229,9 +1229,7 @@ impl Spanned for DoUpdate {
 
 impl Spanned for Assignment {
     fn span(&self) -> Span {
-        let Assignment { target, value } = self;
-
-        target.span().union(&value.span())
+        self.span
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12052,10 +12052,17 @@ impl<'a> Parser<'a> {
 
     /// Parse a `var = expr` assignment, used in an UPDATE statement
     pub fn parse_assignment(&mut self) -> Result<Assignment, ParserError> {
+        let start = self.peek_token().span.start;
         let target = self.parse_assignment_target()?;
         self.expect_token(&Token::Eq)?;
         let value = self.parse_expr()?;
-        Ok(Assignment { target, value })
+        self.prev_token();
+        let end = self.next_token().span.end;
+        Ok(Assignment {
+            target,
+            value,
+            span: Span::new(start, end),
+        })
     }
 
     /// Parse the left-hand side of an assignment, used in an UPDATE statement

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1624,16 +1624,18 @@ fn parse_merge() {
     let update_action = MergeAction::Update {
         assignments: vec![
             Assignment {
+                span: Span::empty(),
                 target: AssignmentTarget::ColumnName(ObjectName(vec![Ident::new("a")])),
                 value: Expr::Value(number("1")),
             },
             Assignment {
+                span: Span::empty(),
                 target: AssignmentTarget::ColumnName(ObjectName(vec![Ident::new("b")])),
                 value: Expr::Value(number("2")),
             },
         ],
     };
-    match bigquery_and_generic().verified_stmt(sql) {
+    match bigquery_and_generic().verified_stmt_no_span(sql) {
         Statement::Merge {
             into,
             table,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1826,40 +1826,50 @@ fn parse_insert_with_on_duplicate_update() {
                 })),
                 source
             );
+            let Some(OnInsert::DuplicateKeyUpdate(mut assignments)) = on else {
+                unreachable!("expected duplicate key update");
+            };
+            // remove the span from the assignments before comparison
+            assignments.iter_mut().for_each(|a| a.span = Span::empty());
             assert_eq!(
-                Some(OnInsert::DuplicateKeyUpdate(vec![
+                vec![
                     Assignment {
+                        span: Span::empty(),
                         target: AssignmentTarget::ColumnName(ObjectName(vec![Ident::new(
                             "description".to_string()
                         )])),
                         value: call("VALUES", [Expr::Identifier(Ident::new("description"))]),
                     },
                     Assignment {
+                        span: Span::empty(),
                         target: AssignmentTarget::ColumnName(ObjectName(vec![Ident::new(
                             "perm_create".to_string()
                         )])),
                         value: call("VALUES", [Expr::Identifier(Ident::new("perm_create"))]),
                     },
                     Assignment {
+                        span: Span::empty(),
                         target: AssignmentTarget::ColumnName(ObjectName(vec![Ident::new(
                             "perm_read".to_string()
                         )])),
                         value: call("VALUES", [Expr::Identifier(Ident::new("perm_read"))]),
                     },
                     Assignment {
+                        span: Span::empty(),
                         target: AssignmentTarget::ColumnName(ObjectName(vec![Ident::new(
                             "perm_update".to_string()
                         )])),
                         value: call("VALUES", [Expr::Identifier(Ident::new("perm_update"))]),
                     },
                     Assignment {
+                        span: Span::empty(),
                         target: AssignmentTarget::ColumnName(ObjectName(vec![Ident::new(
                             "perm_delete".to_string()
                         )])),
                         value: call("VALUES", [Expr::Identifier(Ident::new("perm_delete"))]),
                     },
-                ])),
-                on
+                ],
+                assignments
             );
         }
         _ => unreachable!(),
@@ -1986,7 +1996,7 @@ fn parse_update_with_joins() {
     match mysql().verified_stmt(sql) {
         Statement::Update {
             table,
-            assignments,
+            mut assignments,
             from: _from,
             selection,
             returning,
@@ -2039,8 +2049,11 @@ fn parse_update_with_joins() {
                 },
                 table
             );
+            // remove the span from the assignments before comparison
+            assignments.iter_mut().for_each(|a| a.span = Span::empty());
             assert_eq!(
                 vec![Assignment {
+                    span: Span::empty(),
                     target: AssignmentTarget::ColumnName(ObjectName(vec![
                         Ident::new("o"),
                         Ident::new("completed")

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -30,7 +30,7 @@ use sqlparser::ast::Value::Placeholder;
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, SQLiteDialect};
 use sqlparser::parser::{ParserError, ParserOptions};
-use sqlparser::tokenizer::Token;
+use sqlparser::tokenizer::{Span, Token};
 
 #[test]
 fn pragma_no_value() {
@@ -464,7 +464,7 @@ fn parse_attach_database() {
 fn parse_update_tuple_row_values() {
     // See https://github.com/sqlparser-rs/sqlparser-rs/issues/1311
     assert_eq!(
-        sqlite().verified_stmt("UPDATE x SET (a, b) = (1, 2)"),
+        sqlite().verified_stmt_no_span("UPDATE x SET (a, b) = (1, 2)"),
         Statement::Update {
             or: None,
             assignments: vec![Assignment {
@@ -475,7 +475,8 @@ fn parse_update_tuple_row_values() {
                 value: Expr::Tuple(vec![
                     Expr::Value(Value::Number("1".parse().unwrap(), false)),
                     Expr::Value(Value::Number("2".parse().unwrap(), false))
-                ])
+                ]),
+                span: Span::empty(),
             }],
             selection: None,
             table: TableWithJoins {

--- a/tests/test_formatting.rs
+++ b/tests/test_formatting.rs
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![warn(clippy::all)]
+//! Test SQL syntax, which all sqlparser dialects must parse in the same way.
+//!
+//! Note that it does not mean all SQL here is valid in all the dialects, only
+//! that 1) it's either standard or widely supported and 2) it can be parsed by
+//! sqlparser regardless of the chosen dialect (i.e. it doesn't conflict with
+//! dialect-specific parsing rules).
+
+extern crate core;
+
+use sqlparser::test_utils::all_dialects;
+
+#[test]
+fn format_update_tuple_row_values() {
+    all_dialects().verified_stmt(
+        "\
+UPDATE x
+SET (a, b) = (1, 2)
+WHERE c = 3\
+        ",
+    );
+}
+
+#[test]
+fn format_update_multiple_sets_newlines() {
+    all_dialects().verified_stmt(
+        "\
+UPDATE x
+SET a = 1,
+    b = 2,
+    c = 3
+WHERE d = 4\
+        ",
+    );
+}
+
+#[test]
+fn format_update_newline_before_where() {
+    all_dialects().verified_stmt(
+        "\
+UPDATE x SET x = 1
+WHERE c = 3\
+        ",
+    );
+}


### PR DESCRIPTION
this implements (a tiny portion of) https://github.com/apache/datafusion-sqlparser-rs/issues/1634

pros: really useful when passing formatted queries to a real database, in order for database error message locations to match the original user's source locations

cons: if we want to do it well, we need to track source locations better, and this adds a complexity to the Display imlementations