### PR TITLE
Add support for the SQL OVERLAPS predicate

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -248,6 +248,11 @@ pub enum BinaryOperator {
     /// See [CREATE OPERATOR](https://www.postgresql.org/docs/current/sql-createoperator.html)
     /// for more information.
     PGCustomBinaryOperator(Vec<String>),
+    /// The `OVERLAPS` operator
+    ///
+    /// Specifies a test for an overlap between two datetime periods:
+    /// <https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#overlaps-predicate>
+    Overlaps,
 }
 
 impl fmt::Display for BinaryOperator {
@@ -304,6 +309,7 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::PGCustomBinaryOperator(idents) => {
                 write!(f, "OPERATOR({})", display_separated(idents, "."))
             }
+            BinaryOperator::Overlaps => f.write_str("OVERLAPS"),
         }
     }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -512,6 +512,7 @@ pub trait Dialect: Debug + Any {
             Token::Word(w) if w.keyword == Keyword::IS => Ok(p!(Is)),
             Token::Word(w) if w.keyword == Keyword::IN => Ok(p!(Between)),
             Token::Word(w) if w.keyword == Keyword::BETWEEN => Ok(p!(Between)),
+            Token::Word(w) if w.keyword == Keyword::OVERLAPS => Ok(p!(Between)),
             Token::Word(w) if w.keyword == Keyword::LIKE => Ok(p!(Like)),
             Token::Word(w) if w.keyword == Keyword::ILIKE => Ok(p!(Like)),
             Token::Word(w) if w.keyword == Keyword::RLIKE => Ok(p!(Like)),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3060,6 +3060,7 @@ impl<'a> Parser<'a> {
                 Keyword::AND => Some(BinaryOperator::And),
                 Keyword::OR => Some(BinaryOperator::Or),
                 Keyword::XOR => Some(BinaryOperator::Xor),
+                Keyword::OVERLAPS => Some(BinaryOperator::Overlaps),
                 Keyword::OPERATOR if dialect_is!(dialect is PostgreSqlDialect | GenericDialect) => {
                     self.expect_token(&Token::LParen)?;
                     // there are special rules for operator names in

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -12796,3 +12796,8 @@ fn parse_update_from_before_select() {
         parse_sql_statements(query).unwrap_err()
     );
 }
+
+#[test]
+fn parse_overlaps() {
+    verified_stmt("SELECT (DATE '2016-01-10', DATE '2016-02-01') OVERLAPS (DATE '2016-01-20', DATE '2016-02-10')");
+}


### PR DESCRIPTION
https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#overlaps-predicate

I did not gate this one by dialect, as it doesn't seem to conflict with anything and is documented as part of the standard.