### PR TITLE
Replace `ReferentialAction` enum in `DROP` statements

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1786,6 +1786,26 @@ impl fmt::Display for ReferentialAction {
     }
 }
 
+/// `<drop behavior> ::= CASCADE | RESTRICT`.
+///
+/// Used in `DROP` statements.
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum DropBehavior {
+    Restrict,
+    Cascade,
+}
+
+impl fmt::Display for DropBehavior {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            DropBehavior::Restrict => "RESTRICT",
+            DropBehavior::Cascade => "CASCADE",
+        })
+    }
+}
+
 /// SQL user defined type definition
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -49,12 +49,12 @@ pub use self::dcl::{
 pub use self::ddl::{
     AlterColumnOperation, AlterIndexOperation, AlterPolicyOperation, AlterTableOperation,
     ClusteredBy, ColumnDef, ColumnOption, ColumnOptionDef, ColumnPolicy, ColumnPolicyProperty,
-    ConstraintCharacteristics, CreateFunction, Deduplicate, DeferrableInitial, GeneratedAs,
-    GeneratedExpressionMode, IdentityParameters, IdentityProperty, IdentityPropertyFormatKind,
-    IdentityPropertyKind, IdentityPropertyOrder, IndexOption, IndexType, KeyOrIndexDisplay,
-    NullsDistinctOption, Owner, Partition, ProcedureParam, ReferentialAction, TableConstraint,
-    TagsColumnOption, UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation,
-    ViewColumnDef,
+    ConstraintCharacteristics, CreateFunction, Deduplicate, DeferrableInitial, DropBehavior,
+    GeneratedAs, GeneratedExpressionMode, IdentityParameters, IdentityProperty,
+    IdentityPropertyFormatKind, IdentityPropertyKind, IdentityPropertyOrder, IndexOption,
+    IndexType, KeyOrIndexDisplay, NullsDistinctOption, Owner, Partition, ProcedureParam,
+    ReferentialAction, TableConstraint, TagsColumnOption, UserDefinedTypeCompositeAttributeDef,
+    UserDefinedTypeRepresentation, ViewColumnDef,
 };
 pub use self::dml::{CreateIndex, CreateTable, Delete, Insert};
 pub use self::operator::{BinaryOperator, UnaryOperator};
@@ -2700,7 +2700,7 @@ pub enum Statement {
         /// One or more function to drop
         func_desc: Vec<FunctionDesc>,
         /// `CASCADE` or `RESTRICT`
-        option: Option<ReferentialAction>,
+        drop_behavior: Option<DropBehavior>,
     },
     /// ```sql
     /// DROP PROCEDURE
@@ -2710,7 +2710,7 @@ pub enum Statement {
         /// One or more function to drop
         proc_desc: Vec<FunctionDesc>,
         /// `CASCADE` or `RESTRICT`
-        option: Option<ReferentialAction>,
+        drop_behavior: Option<DropBehavior>,
     },
     /// ```sql
     /// DROP SECRET
@@ -2729,7 +2729,7 @@ pub enum Statement {
         if_exists: bool,
         name: Ident,
         table_name: ObjectName,
-        option: Option<ReferentialAction>,
+        drop_behavior: Option<DropBehavior>,
     },
     /// ```sql
     /// DECLARE
@@ -4317,7 +4317,7 @@ impl fmt::Display for Statement {
             Statement::DropFunction {
                 if_exists,
                 func_desc,
-                option,
+                drop_behavior,
             } => {
                 write!(
                     f,
@@ -4325,7 +4325,7 @@ impl fmt::Display for Statement {
                     if *if_exists { " IF EXISTS" } else { "" },
                     display_comma_separated(func_desc),
                 )?;
-                if let Some(op) = option {
+                if let Some(op) = drop_behavior {
                     write!(f, " {op}")?;
                 }
                 Ok(())
@@ -4333,7 +4333,7 @@ impl fmt::Display for Statement {
             Statement::DropProcedure {
                 if_exists,
                 proc_desc,
-                option,
+                drop_behavior,
             } => {
                 write!(
                     f,
@@ -4341,7 +4341,7 @@ impl fmt::Display for Statement {
                     if *if_exists { " IF EXISTS" } else { "" },
                     display_comma_separated(proc_desc),
                 )?;
-                if let Some(op) = option {
+                if let Some(op) = drop_behavior {
                     write!(f, " {op}")?;
                 }
                 Ok(())
@@ -4370,15 +4370,15 @@ impl fmt::Display for Statement {
                 if_exists,
                 name,
                 table_name,
-                option,
+                drop_behavior,
             } => {
                 write!(f, "DROP POLICY")?;
                 if *if_exists {
                     write!(f, " IF EXISTS")?;
                 }
                 write!(f, " {name} ON {table_name}")?;
-                if let Some(option) = option {
-                    write!(f, " {option}")?;
+                if let Some(drop_behavior) = drop_behavior {
+                    write!(f, " {drop_behavior}")?;
                 }
                 Ok(())
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5500,10 +5500,10 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_optional_referential_action(&mut self) -> Option<ReferentialAction> {
+    fn parse_optional_drop_behavior(&mut self) -> Option<DropBehavior> {
         match self.parse_one_of_keywords(&[Keyword::CASCADE, Keyword::RESTRICT]) {
-            Some(Keyword::CASCADE) => Some(ReferentialAction::Cascade),
-            Some(Keyword::RESTRICT) => Some(ReferentialAction::Restrict),
+            Some(Keyword::CASCADE) => Some(DropBehavior::Cascade),
+            Some(Keyword::RESTRICT) => Some(DropBehavior::Restrict),
             _ => None,
         }
     }
@@ -5515,11 +5515,11 @@ impl<'a> Parser<'a> {
     fn parse_drop_function(&mut self) -> Result<Statement, ParserError> {
         let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
         let func_desc = self.parse_comma_separated(Parser::parse_function_desc)?;
-        let option = self.parse_optional_referential_action();
+        let drop_behavior = self.parse_optional_drop_behavior();
         Ok(Statement::DropFunction {
             if_exists,
             func_desc,
-            option,
+            drop_behavior,
         })
     }
 
@@ -5533,12 +5533,12 @@ impl<'a> Parser<'a> {
         let name = self.parse_identifier()?;
         self.expect_keyword_is(Keyword::ON)?;
         let table_name = self.parse_object_name(false)?;
-        let option = self.parse_optional_referential_action();
+        let drop_behavior = self.parse_optional_drop_behavior();
         Ok(Statement::DropPolicy {
             if_exists,
             name,
             table_name,
-            option,
+            drop_behavior,
         })
     }
 
@@ -5549,11 +5549,11 @@ impl<'a> Parser<'a> {
     fn parse_drop_procedure(&mut self) -> Result<Statement, ParserError> {
         let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
         let proc_desc = self.parse_comma_separated(Parser::parse_function_desc)?;
-        let option = self.parse_optional_referential_action();
+        let drop_behavior = self.parse_optional_drop_behavior();
         Ok(Statement::DropProcedure {
             if_exists,
             proc_desc,
-            option,
+            drop_behavior,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11690,12 +11690,12 @@ fn test_drop_policy() {
             if_exists,
             name,
             table_name,
-            option,
+            drop_behavior,
         } => {
             assert_eq!(if_exists, true);
             assert_eq!(name.to_string(), "my_policy");
             assert_eq!(table_name.to_string(), "my_table");
-            assert_eq!(option, Some(ReferentialAction::Restrict));
+            assert_eq!(drop_behavior, Some(DropBehavior::Restrict));
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3805,7 +3805,7 @@ fn parse_drop_function() {
                 }]),
                 args: None
             }],
-            option: None
+            drop_behavior: None
         }
     );
 
@@ -3830,7 +3830,7 @@ fn parse_drop_function() {
                     }
                 ]),
             }],
-            option: None
+            drop_behavior: None
         }
     );
 
@@ -3879,7 +3879,7 @@ fn parse_drop_function() {
                     ]),
                 }
             ],
-            option: None
+            drop_behavior: None
         }
     );
 }
@@ -3899,7 +3899,7 @@ fn parse_drop_procedure() {
                 }]),
                 args: None
             }],
-            option: None
+            drop_behavior: None
         }
     );
 
@@ -3924,7 +3924,7 @@ fn parse_drop_procedure() {
                     }
                 ]),
             }],
-            option: None
+            drop_behavior: None
         }
     );
 
@@ -3973,7 +3973,7 @@ fn parse_drop_procedure() {
                     ]),
                 }
             ],
-            option: None
+            drop_behavior: None
         }
     );
 


### PR DESCRIPTION
There's `<drop behavior>` definition [in the grammar](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#drop-behavior), so corresponding enum seems appropriate:

```
pub enum DropBehavior {
    Restrict,
    Cascade,
}
```

vs

```
pub enum ReferentialAction {
    Restrict,
    Cascade,
    SetNull,
    NoAction,
    SetDefault,
}
```

Context: `ALTER TABLE DROP COLUMN` sqlparser does not support `RESTRICT`. I wanted to add it, but adding `ReferentialAction` there too might be misleading, so here I introduce an enum.