### PR TITLE
Correctly look for end delimiter dollar quoted string

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1565,7 +1565,6 @@ impl<'a> Tokenizer<'a> {
                             if temp.ends_with(&end_delimiter) {
                                 if let Some(temp) = temp.strip_suffix(&end_delimiter) {
                                     s.push_str(temp);
-                                    break;
                                 }
                                 break;
                             }
@@ -1574,7 +1573,6 @@ impl<'a> Tokenizer<'a> {
                             if temp.ends_with(&end_delimiter) {
                                 if let Some(temp) = temp.strip_suffix(&end_delimiter) {
                                     s.push_str(temp);
-                                    break;
                                 }
                                 break;
                             }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -2620,7 +2620,6 @@ mod tests {
         );
     }
 
-
     #[test]
     fn tokenize_dollar_placeholder() {
         let sql = String::from("SELECT $$, $$ABC$$, $ABC$, $ABC");

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1563,13 +1563,19 @@ impl<'a> Tokenizer<'a> {
                             temp.push(ch);
 
                             if temp.ends_with(&end_delimiter) {
-                                s.push_str(&temp[..temp.len() - end_delimiter.len()]);
+                                if let Some(temp) = temp.strip_suffix(&end_delimiter) {
+                                    s.push_str(temp);
+                                    break;
+                                }
                                 break;
                             }
                         }
                         None => {
                             if temp.ends_with(&end_delimiter) {
-                                s.push_str(&temp[..temp.len() - end_delimiter.len()]);
+                                if let Some(temp) = temp.strip_suffix(&end_delimiter) {
+                                    s.push_str(temp);
+                                    break;
+                                }
                                 break;
                             }
 
@@ -2577,6 +2583,15 @@ mod tests {
                         tag: Some("abc".into()),
                     }),
                     Token::Number("1".into(), false),
+                ]
+            ),
+            (
+                String::from("$function$abc$q$data$q$$function$"),
+                vec![
+                    Token::DollarQuotedString(DollarQuotedString {
+                        value: "abc$q$data$q$".into(),
+                        tag: Some("function".into()),
+                    }),
                 ]
             ),
         ];

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1561,7 +1561,9 @@ impl<'a> Tokenizer<'a> {
                         Some('$') => {
                             if !end_tag_name.is_empty() {
                                 if end_tag_name == value {
-                                    // Found the end delimiter, truncate the string
+                                    // We found the end delimiter
+                                    // Let's remove the tag name from the string content
+                                    // (plus the dollar sign of the end delimiter)
                                     s.truncate(s.len() - value.len() - 1);
                                     break;
                                 } else {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1560,7 +1560,7 @@ impl<'a> Tokenizer<'a> {
                 loop {
                     match chars.next() {
                         Some(ch) => {
-                            temp.push(ch); // Collect all characters into `temp`
+                            temp.push(ch);
 
                             if temp.ends_with(&end_delimiter) {
                                 s.push_str(&temp[..temp.len() - end_delimiter.len()]);


### PR DESCRIPTION
Currently the tokenizer throws an error for

```sql
SELECT $abc$x$ab$abc$
```

The logic is also quite difficult to read so I made it a bit simpler.

Before

```rust
'searching_for_end: loop {
    s.push_str(&peeking_take_while(chars, |ch| ch != '$'));
    match chars.peek() {
        Some('$') => {
            chars.next();
            let mut maybe_s = String::from("$");
            for c in value.chars() {
                if let Some(next_char) = chars.next() {
                    maybe_s.push(next_char);
                    if next_char != c {
                        // This doesn't match the dollar quote delimiter so this
                        // is not the end of the string.
                        s.push_str(&maybe_s);
                        continue 'searching_for_end;
                    }
                } else {
                    return self.tokenizer_error(
                        chars.location(),
                        "Unterminated dollar-quoted, expected $",
                    );
                }
            }
            if chars.peek() == Some(&'$') {
                chars.next();
                maybe_s.push('$');
                // maybe_s matches the end delimiter
                break 'searching_for_end;
            } else {
                // This also doesn't match the dollar quote delimiter as there are
                // more characters before the second dollar so this is not the end
                // of the string.
                s.push_str(&maybe_s);
                continue 'searching_for_end;
            }
        }
        _ => {
            return self.tokenizer_error(
                chars.location(),
                "Unterminated dollar-quoted, expected $",
            )
        }
    }
}
```

After
```rust
let mut temp = String::new();
let end_delimiter = format!("${}$", value);

loop {
    match chars.next() {
        Some(ch) => {
            temp.push(ch);

            if temp.ends_with(&end_delimiter) {
                s.push_str(&temp[..temp.len() - end_delimiter.len()]);
                break;
            }
        }
        None => {
            if temp.ends_with(&end_delimiter) {
                s.push_str(&temp[..temp.len() - end_delimiter.len()]);
                break;
            }

            return self.tokenizer_error(
                chars.location(),
                "Unterminated dollar-quoted, expected $",
            );
        }
    }
}
```