### PR TITLE
Support single line comments starting with '#' for Hive

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -40,13 +40,13 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "visitor")]
 use sqlparser_derive::{Visit, VisitMut};
 
-use crate::ast::DollarQuotedString;
 use crate::dialect::Dialect;
 use crate::dialect::{
     BigQueryDialect, DuckDbDialect, GenericDialect, MySqlDialect, PostgreSqlDialect,
     SnowflakeDialect,
 };
 use crate::keywords::{Keyword, ALL_KEYWORDS, ALL_KEYWORDS_INDEX};
+use crate::{ast::DollarQuotedString, dialect::HiveDialect};
 
 /// SQL Token enumeration
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -1372,7 +1372,8 @@ impl<'a> Tokenizer<'a> {
                 }
                 '{' => self.consume_and_return(chars, Token::LBrace),
                 '}' => self.consume_and_return(chars, Token::RBrace),
-                '#' if dialect_of!(self is SnowflakeDialect | BigQueryDialect | MySqlDialect) => {
+                '#' if dialect_of!(self is SnowflakeDialect | BigQueryDialect | MySqlDialect | HiveDialect) =>
+                {
                     chars.next(); // consume the '#', starting a snowflake single-line comment
                     let comment = self.tokenize_single_line_comment(chars);
                     Ok(Some(Token::Whitespace(Whitespace::SingleLineComment {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -10423,6 +10423,7 @@ fn test_comment_hash_syntax() {
         Box::new(BigQueryDialect {}),
         Box::new(SnowflakeDialect {}),
         Box::new(MySqlDialect {}),
+        Box::new(HiveDialect {}),
     ]);
     let sql = r#"
     # comment


### PR DESCRIPTION
The code of Apache Hive reveals that beeline also supports shell-style "#" prefix.  Currently, Hive mainly uses Beeline to execute SQL, so it might be necessary to support this here as well.
See https://github.com/apache/hive/blob/62ad7d42d6fd4e10ef5b86545ae41011554fd2f5/common/src/java/org/apache/hive/common/util/HiveStringUtils.java#L1170

