### PR TITLE
Allow empty options for BigQuery

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7341,6 +7341,10 @@ impl<'a> Parser<'a> {
     pub fn parse_options(&mut self, keyword: Keyword) -> Result<Vec<SqlOption>, ParserError> {
         if self.parse_keyword(keyword) {
             self.expect_token(&Token::LParen)?;
+            if self.peek_token() == Token::RParen {
+                self.next_token();
+                return Ok(vec![]);
+            }
             let options = self.parse_comma_separated(Parser::parse_sql_option)?;
             self.expect_token(&Token::RParen)?;
             Ok(options)

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2244,3 +2244,15 @@ fn test_any_type() {
 fn test_any_type_dont_break_custom_type() {
     bigquery_and_generic().verified_stmt("CREATE TABLE foo (x ANY)");
 }
+
+#[test]
+fn parse_create_table_with_empty_table_options() {
+    let sql = "CREATE TABLE foo (x INT64) OPTIONS()";
+    bigquery().verified_stmt(sql);
+}
+
+#[test]
+fn parse_create_table_with_empty_table_options_and_column_options() {
+    let sql = "CREATE TABLE db.schema.test (x INT64 OPTIONS(description = 'An optional INTEGER field')) OPTIONS()";
+    bigquery().verified_stmt(sql);
+}


### PR DESCRIPTION
In BigQuery, it's possible to have statements like these (added tests for them):

```sql
CREATE TABLE foo (x INT64) OPTIONS()
```

```sql
CREATE TABLE db.schema.test (x INT64 OPTIONS(description = 'An optional INTEGER field')) OPTIONS()
```

While this may look silly (and clearly is), it's very common that companies are using tools (like dbt) to generate the SQL based on a certain configuration defined at runtime using macros and other abominations (but that is off-topic). 

This PR, with tests, allows specifying empty options. Seeing that all tests run, this can hopefully be merged quickly. Also ran `fmt` and `clippy`.