### PR TITLE
Parse Snowflake COPY INTO <location>

### DIFF
--- a/src/ast/helpers/stmt_data_loading.rs
+++ b/src/ast/helpers/stmt_data_loading.rs
@@ -58,6 +58,7 @@ pub enum DataLoadingOptionType {
     STRING,
     BOOLEAN,
     ENUM,
+    NUMBER,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -128,12 +129,9 @@ impl fmt::Display for DataLoadingOption {
             DataLoadingOptionType::STRING => {
                 write!(f, "{}='{}'", self.option_name, self.value)?;
             }
-            DataLoadingOptionType::ENUM => {
-                // single quote is omitted
-                write!(f, "{}={}", self.option_name, self.value)?;
-            }
-            DataLoadingOptionType::BOOLEAN => {
-                // single quote is omitted
+            DataLoadingOptionType::ENUM
+            | DataLoadingOptionType::BOOLEAN
+            | DataLoadingOptionType::NUMBER => {
                 write!(f, "{}={}", self.option_name, self.value)?;
             }
         }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2491,37 +2491,30 @@ pub enum Statement {
         values: Vec<Option<String>>,
     },
     /// ```sql
-    /// COPY INTO <table>
+    /// COPY INTO <table> | <location>
     /// ```
-    /// See <https://docs.snowflake.com/en/sql-reference/sql/copy-into-table>
+    /// See:
+    /// <https://docs.snowflake.com/en/sql-reference/sql/copy-into-table>
+    /// <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location>
+    ///
     /// Copy Into syntax available for Snowflake is different than the one implemented in
     /// Postgres. Although they share common prefix, it is reasonable to implement them
     /// in different enums. This can be refactored later once custom dialects
     /// are allowed to have custom Statements.
-    CopyIntoSnowflakeTable {
+    CopyIntoSnowflake {
+        kind: CopyIntoSnowflakeKind,
         into: ObjectName,
-        from_stage: ObjectName,
-        from_stage_alias: Option<Ident>,
+        from_obj: Option<ObjectName>,
+        from_obj_alias: Option<Ident>,
         stage_params: StageParamsObject,
         from_transformations: Option<Vec<StageLoadSelectItem>>,
+        from_query: Option<Box<Query>>,
         files: Option<Vec<String>>,
         pattern: Option<String>,
         file_format: DataLoadingOptions,
         copy_options: DataLoadingOptions,
         validation_mode: Option<String>,
-    },
-    /// ```sql
-    /// COPY INTO <location>
-    /// ```
-    /// See <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location>
-    CopyIntoSnowflakeLocation {
-        into: ObjectName,
-        from_table: Option<ObjectName>,
-        from_query: Option<Box<Query>>,
-        stage_params: StageParamsObject,
-        partition: Option<Expr>,
-        file_format: DataLoadingOptions,
-        copy_options: DataLoadingOptions,
+        partition: Option<Box<Expr>>,
     },
     /// ```sql
     /// CLOSE
@@ -4994,80 +4987,54 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::CopyIntoSnowflakeTable {
+            Statement::CopyIntoSnowflake {
+                kind,
                 into,
-                from_stage,
-                from_stage_alias,
+                from_obj,
+                from_obj_alias,
                 stage_params,
                 from_transformations,
+                from_query,
                 files,
                 pattern,
                 file_format,
                 copy_options,
                 validation_mode,
+                partition,
             } => {
                 write!(f, "COPY INTO {}", into)?;
-                if from_transformations.is_none() {
-                    // Standard data load
-                    write!(f, " FROM {}{}", from_stage, stage_params)?;
-                    if from_stage_alias.as_ref().is_some() {
-                        write!(f, " AS {}", from_stage_alias.as_ref().unwrap())?;
-                    }
-                } else {
+                if let Some(from_transformations) = from_transformations {
                     // Data load with transformation
-                    write!(
-                        f,
-                        " FROM (SELECT {} FROM {}{}",
-                        display_separated(from_transformations.as_ref().unwrap(), ", "),
-                        from_stage,
-                        stage_params,
-                    )?;
-                    if from_stage_alias.as_ref().is_some() {
-                        write!(f, " AS {}", from_stage_alias.as_ref().unwrap())?;
+                    if let Some(from_stage) = from_obj {
+                        write!(
+                            f,
+                            " FROM (SELECT {} FROM {}{}",
+                            display_separated(from_transformations, ", "),
+                            from_stage,
+                            stage_params
+                        )?;
+                    }
+                    if let Some(from_obj_alias) = from_obj_alias {
+                        write!(f, " AS {}", from_obj_alias)?;
                     }
                     write!(f, ")")?;
-                }
-                if files.is_some() {
-                    write!(
-                        f,
-                        " FILES = ('{}')",
-                        display_separated(files.as_ref().unwrap(), "', '")
-                    )?;
-                }
-                if pattern.is_some() {
-                    write!(f, " PATTERN = '{}'", pattern.as_ref().unwrap())?;
-                }
-                if !file_format.options.is_empty() {
-                    write!(f, " FILE_FORMAT=({})", file_format)?;
-                }
-                if !copy_options.options.is_empty() {
-                    write!(f, " COPY_OPTIONS=({})", copy_options)?;
-                }
-                if validation_mode.is_some() {
-                    write!(
-                        f,
-                        " VALIDATION_MODE = {}",
-                        validation_mode.as_ref().unwrap()
-                    )?;
-                }
-                Ok(())
-            }
-            Statement::CopyIntoSnowflakeLocation {
-                into,
-                from_table,
-                from_query,
-                stage_params,
-                partition,
-                file_format,
-                copy_options,
-            } => {
-                write!(f, "COPY INTO {into} FROM")?;
-                if let Some(from_table) = from_table {
-                    write!(f, " {from_table}")?;
+                } else if let Some(from_obj) = from_obj {
+                    // Standard data load
+                    write!(f, " FROM {}{}", from_obj, stage_params)?;
+                    if let Some(from_obj_alias) = from_obj_alias {
+                        write!(f, " AS {from_obj_alias}")?;
+                    }
                 } else if let Some(from_query) = from_query {
-                    write!(f, " ({from_query})")?;
+                    // Data unload from query
+                    write!(f, " FROM ({from_query})")?;
                 }
-                write!(f, "{stage_params}")?;
+
+                if let Some(files) = files {
+                    write!(f, " FILES = ('{}')", display_separated(files, "', '"))?;
+                }
+                if let Some(pattern) = pattern {
+                    write!(f, " PATTERN = '{}'", pattern)?;
+                }
                 if let Some(partition) = partition {
                     write!(f, " PARTITION BY {partition}")?;
                 }
@@ -5075,7 +5042,15 @@ impl fmt::Display for Statement {
                     write!(f, " FILE_FORMAT=({})", file_format)?;
                 }
                 if !copy_options.options.is_empty() {
-                    write!(f, " {}", copy_options)?;
+                    match kind {
+                        CopyIntoSnowflakeKind::Table => {
+                            write!(f, " COPY_OPTIONS=({})", copy_options)?
+                        }
+                        CopyIntoSnowflakeKind::Location => write!(f, " {copy_options}")?,
+                    }
+                }
+                if let Some(validation_mode) = validation_mode {
+                    write!(f, " VALIDATION_MODE = {}", validation_mode)?;
                 }
                 Ok(())
             }
@@ -8487,6 +8462,19 @@ impl Display for StorageSerializationPolicy {
             StorageSerializationPolicy::Optimized => write!(f, "OPTIMIZED"),
         }
     }
+}
+
+/// Variants of the Snowflake `COPY INTO` statement
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum CopyIntoSnowflakeKind {
+    /// Loads data from files to a table
+    /// See: <https://docs.snowflake.com/en/sql-reference/sql/copy-into-table>
+    Table,
+    /// Unloads data from a table or query to external files
+    /// See: <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location>
+    Location,
 }
 
 #[cfg(test)]

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -330,7 +330,7 @@ impl Spanned for Statement {
                 legacy_options: _,
                 values: _,
             } => source.span(),
-            Statement::CopyIntoSnowflake {
+            Statement::CopyIntoSnowflakeTable {
                 into: _,
                 from_stage: _,
                 from_stage_alias: _,
@@ -341,6 +341,15 @@ impl Spanned for Statement {
                 file_format: _,
                 copy_options: _,
                 validation_mode: _,
+            } => Span::empty(),
+            Statement::CopyIntoSnowflakeLocation {
+                into: _,
+                from_table: _,
+                from_query: _,
+                stage_params: _,
+                partition: _,
+                file_format: _,
+                copy_options: _,
             } => Span::empty(),
             Statement::Close { cursor } => match cursor {
                 CloseCursor::All => Span::empty(),

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -211,7 +211,8 @@ impl Spanned for Values {
 /// # partial span
 ///
 /// Missing spans:
-/// - [Statement::CopyIntoSnowflake]
+/// - [Statement::CopyIntoSnowflakeTable]
+/// - [Statement::CopyIntoSnowflakeLocation]
 /// - [Statement::CreateSecret]
 /// - [Statement::CreateRole]
 /// - [Statement::AlterRole]

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -211,8 +211,7 @@ impl Spanned for Values {
 /// # partial span
 ///
 /// Missing spans:
-/// - [Statement::CopyIntoSnowflakeTable]
-/// - [Statement::CopyIntoSnowflakeLocation]
+/// - [Statement::CopyIntoSnowflake]
 /// - [Statement::CreateSecret]
 /// - [Statement::CreateRole]
 /// - [Statement::AlterRole]
@@ -331,10 +330,10 @@ impl Spanned for Statement {
                 legacy_options: _,
                 values: _,
             } => source.span(),
-            Statement::CopyIntoSnowflakeTable {
+            Statement::CopyIntoSnowflake {
                 into: _,
-                from_stage: _,
-                from_stage_alias: _,
+                from_obj: _,
+                from_obj_alias: _,
                 stage_params: _,
                 from_transformations: _,
                 files: _,
@@ -342,15 +341,9 @@ impl Spanned for Statement {
                 file_format: _,
                 copy_options: _,
                 validation_mode: _,
-            } => Span::empty(),
-            Statement::CopyIntoSnowflakeLocation {
-                into: _,
-                from_table: _,
+                kind: _,
                 from_query: _,
-                stage_params: _,
                 partition: _,
-                file_format: _,
-                copy_options: _,
             } => Span::empty(),
             Statement::Close { cursor } => match cursor {
                 CloseCursor::All => Span::empty(),

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -33,14 +33,16 @@ use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
 use crate::tokenizer::{Token, Word};
 #[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec};
-use sqlparser::ast::StorageSerializationPolicy;
 
 use super::keywords::RESERVED_FOR_IDENTIFIER;
+use sqlparser::ast::StorageSerializationPolicy;
 
 /// A [`Dialect`] for [Snowflake](https://www.snowflake.com/)
 #[derive(Debug, Default)]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2043,7 +2043,10 @@ fn test_copy_into() {
             );
             assert_eq!(
                 from_obj,
-                Some(ObjectName::from(vec![Ident::with_quote('\'', "gcs://mybucket/./../a.csv")]))
+                Some(ObjectName::from(vec![Ident::with_quote(
+                    '\'',
+                    "gcs://mybucket/./../a.csv"
+                )]))
             );
             assert!(files.is_none());
             assert!(pattern.is_none());
@@ -2387,7 +2390,6 @@ fn test_copy_into_copy_options() {
 #[test]
 fn test_snowflake_stage_object_names_into_location() {
     let mut allowed_object_names = [
-        ObjectName::from(vec![Ident::new("my_company"), Ident::new("emp_basic")]),
         ObjectName::from(vec![Ident::new("@namespace"), Ident::new("%table_name")]),
         ObjectName::from(vec![
             Ident::new("@namespace"),
@@ -2456,7 +2458,10 @@ fn test_snowflake_copy_into() {
     assert_eq!(snowflake().verified_stmt(sql).to_string(), sql);
     match snowflake().verified_stmt(sql) {
         Statement::CopyIntoSnowflake { into, from_obj, .. } => {
-            assert_eq!(into, ObjectName::from(vec![Ident::new("a"), Ident::new("b")]));
+            assert_eq!(
+                into,
+                ObjectName::from(vec![Ident::new("a"), Ident::new("b")])
+            );
             assert_eq!(
                 from_obj,
                 Some(ObjectName::from(vec![


### PR DESCRIPTION
This PR adds support for parsing Snowflake's `COPY INTO <location>`, makes a distinction between `COPY INTO <table>`, and reuses much of its logic.