### PR TITLE
Update rat_exclude_file.txt

### DIFF
--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -3,4 +3,5 @@
 .tool-versions
 dev/release/rat_exclude_files.txt
 fuzz/.gitignore
+sqlparser_bench/img/flamegraph.svg
 


### PR DESCRIPTION
- Part of https://github.com/apache/datafusion-sqlparser-rs/issues/1597

When I tried to create the release tarball this time I got an error:

```
Running rat license checker on /Users/andrewlamb/Software/sqlparser-rs/dev/dist/apache-datafusion-sqlparser-rs-0.54.0-rc1/apache-datafusion-sqlparser-rs-0.54.0.tar.gz
NOT APPROVED: sqlparser_bench/img/flamegraph.svg (apache-datafusion-sqlparser-rs-0.54.0/sqlparser_bench/img/flamegraph.svg): false
       1 unapproved licences. Check rat report: rat.txt
```

I think this is because svg files are XML so the rat checker checks them for the apache license

There is no reason to add the license explicitly I don't think so I propose adding to the exclude file

I was able to use this change locally to make the `0.54.0` RC so there is no particular urgency for this PR
