### PR TITLE
BigQuery: Support trailing commas in column definitions list

### DIFF
--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -31,6 +31,11 @@ impl Dialect for BigQueryDialect {
         true
     }
 
+    /// See <https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_statement>
+    fn supports_column_definition_trailing_commas(&self) -> bool {
+        true
+    }
+
     fn is_identifier_start(&self, ch: char) -> bool {
         ch.is_ascii_lowercase() || ch.is_ascii_uppercase() || ch == '_'
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -405,8 +405,15 @@ pub trait Dialect: Debug + Any {
     }
 
     /// Returns true if the dialect supports trailing commas in the `FROM` clause of a `SELECT` statement.
-    /// /// Example: `SELECT 1 FROM T, U, LIMIT 1`
+    /// Example: `SELECT 1 FROM T, U, LIMIT 1`
     fn supports_from_trailing_commas(&self) -> bool {
+        false
+    }
+
+    /// Returns true if the dialect supports trailing commas in the
+    /// column definitions list of a `CREATE` statement.
+    /// Example: `CREATE TABLE T (x INT, y TEXT,)`
+    fn supports_column_definition_trailing_commas(&self) -> bool {
         false
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6718,7 +6718,11 @@ impl<'a> Parser<'a> {
                 return self.expected("',' or ')' after column definition", self.peek_token());
             };
 
-            if rparen && (!comma || self.options.trailing_commas) {
+            if rparen
+                && (!comma
+                    || self.dialect.supports_column_definition_trailing_commas()
+                    || self.options.trailing_commas)
+            {
                 let _ = self.consume_token(&Token::RParen);
                 break;
             }
@@ -9298,7 +9302,11 @@ impl<'a> Parser<'a> {
                 self.next_token();
                 Ok(vec![])
             } else {
-                let cols = self.parse_comma_separated(Parser::parse_view_column)?;
+                let cols = self.parse_comma_separated_with_trailing_commas(
+                    Parser::parse_view_column,
+                    self.dialect.supports_column_definition_trailing_commas(),
+                    None,
+                )?;
                 self.expect_token(&Token::RParen)?;
                 Ok(cols)
             }


### PR DESCRIPTION
Adds support for BigQuery's `CREATE` statement containing trailing commas in the columns definitions list

```sql
CREATE TABLE T (x INT64, y INT64,);
```
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_statement