### PR TITLE
Enable GROUP BY exp for Snowflake dialect

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -305,6 +305,11 @@ impl Dialect for SnowflakeDialect {
     fn supports_timestamp_versioning(&self) -> bool {
         true
     }
+
+    /// See: <https://docs.snowflake.com/en/sql-reference/constructs/group-by>
+    fn supports_group_by_expr(&self) -> bool {
+        true
+    }
 }
 
 fn parse_file_staging_command(kw: Keyword, parser: &mut Parser) -> Result<Statement, ParserError> {


### PR DESCRIPTION
Snowflake supports `GROUP BY <exp>` so just turning it on for this dialect