### PR TITLE
Make numeric literal underscore test dialect agnostic

### DIFF
--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1649,21 +1649,6 @@ fn parse_table_sample() {
     clickhouse().verified_stmt("SELECT * FROM tbl SAMPLE 1 / 10 OFFSET 1 / 2");
 }
 
-#[test]
-fn parse_numbers_with_underscore() {
-    let canonical = if cfg!(feature = "bigdecimal") {
-        "SELECT 10000"
-    } else {
-        "SELECT 10_000"
-    };
-    let select = clickhouse().verified_only_select_with_canonical("SELECT 10_000", canonical);
-
-    assert_eq!(
-        select.projection,
-        vec![SelectItem::UnnamedExpr(Expr::Value(number("10_000")))]
-    )
-}
-
 fn clickhouse() -> TestedDialects {
     TestedDialects::new(vec![Box::new(ClickHouseDialect {})])
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -56,6 +56,24 @@ use sqlparser::ast::Value::Number;
 use sqlparser::test_utils::all_dialects_except;
 
 #[test]
+fn parse_numeric_literal_underscore() {
+    let dialects = all_dialects_where(|d| d.supports_numeric_literal_underscores());
+
+    let canonical = if cfg!(feature = "bigdecimal") {
+        "SELECT 10000"
+    } else {
+        "SELECT 10_000"
+    };
+
+    let select = dialects.verified_only_select_with_canonical("SELECT 10_000", canonical);
+
+    assert_eq!(
+        select.projection,
+        vec![UnnamedExpr(Expr::Value(number("10_000")))]
+    );
+}
+
+#[test]
 fn parse_insert_values() {
     let row = vec![
         Expr::Value(number("1")),


### PR DESCRIPTION
Minor follow up from #1677
Support was added for both Clickhouse and Postgres but the test only covered Clickhouse. This move the test to common and to use the `all_dialects_where` for auto test coverage.