### PR TITLE
Add RETURNS TABLE() support for CREATE FUNCTION in Postgresql

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -45,6 +45,10 @@ pub enum EnumMember {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum DataType {
+    /// Table type in [postgresql]. e.g. CREATE FUNCTION RETURNS TABLE(...)
+    ///
+    /// [postgresql]: https://www.postgresql.org/docs/15/sql-createfunction.html
+    Table(Vec<ColumnDef>),
     /// Fixed-length character type e.g. CHARACTER(10)
     Character(Option<CharacterLength>),
     /// Fixed-length char type e.g. CHAR(10)
@@ -630,6 +634,7 @@ impl fmt::Display for DataType {
             DataType::Unspecified => Ok(()),
             DataType::Trigger => write!(f, "TRIGGER"),
             DataType::AnyType => write!(f, "ANY TYPE"),
+            DataType::Table(fields) => write!(f, "TABLE({})", display_comma_separated(fields)),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4563,14 +4563,7 @@ impl<'a> Parser<'a> {
         self.expect_token(&Token::RParen)?;
 
         let return_type = if self.parse_keyword(Keyword::RETURNS) {
-            if dialect_of!(self is PostgreSqlDialect | GenericDialect)
-                && self.parse_keyword(Keyword::TABLE)
-            {
-                let columns = self.parse_parenthesized_columns()?;
-                Some(DataType::Table(columns))
-            } else {
-                Some(self.parse_data_type()?)
-            }
+            Some(self.parse_data_type()?)
         } else {
             None
         };
@@ -8873,6 +8866,10 @@ impl<'a> Parser<'a> {
                 Keyword::ANY if self.peek_keyword(Keyword::TYPE) => {
                     let _ = self.parse_keyword(Keyword::TYPE);
                     Ok(DataType::AnyType)
+                }
+                Keyword::TABLE => {
+                    let columns = self.parse_returns_table_columns()?;
+                    Ok(DataType::Table(columns))
                 }
                 _ => {
                     self.prev_token();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8912,7 +8912,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_parenthesized_columns(&mut self) -> Result<Vec<ColumnDef>, ParserError> {
+    fn parse_returns_table_columns(&mut self) -> Result<Vec<ColumnDef>, ParserError> {
         self.expect_token(&Token::LParen)?;
         let columns = self.parse_comma_separated(Parser::parse_returns_table_column)?;
         self.expect_token(&Token::RParen)?;

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4373,7 +4373,7 @@ fn parse_join_constraint_unnest_alias() {
                 with_ordinality: false,
             },
             global: false,
-            join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
+            join_operator: JoinOperator::Join(JoinConstraint::On(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("c1".into())),
                 op: BinaryOperator::Eq,
                 right: Box::new(Expr::Identifier("c2".into())),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5148,7 +5148,7 @@ fn parse_trigger_related_functions() {
             temporary: false,
             if_not_exists: false,
             name: ObjectName::from(vec![Ident::new("emp_stamp")]),
-            args: None,
+            args: Some(vec![]),
             return_type: Some(DataType::Trigger),
             function_body: Some(
                 CreateFunctionBody::AsBeforeOptions(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3803,6 +3803,7 @@ fn parse_create_function_detailed() {
     pg_and_generic().verified_stmt("CREATE OR REPLACE FUNCTION add(a INTEGER, IN b INTEGER = 1) RETURNS INTEGER LANGUAGE SQL STABLE CALLED ON NULL INPUT PARALLEL UNSAFE RETURN a + b");
     pg_and_generic().verified_stmt(r#"CREATE OR REPLACE FUNCTION increment(i INTEGER) RETURNS INTEGER LANGUAGE plpgsql AS $$ BEGIN RETURN i + 1; END; $$"#);
     pg_and_generic().verified_stmt(r#"CREATE OR REPLACE FUNCTION no_arg() RETURNS VOID LANGUAGE plpgsql AS $$ BEGIN DELETE FROM my_table; END; $$"#);
+    pg_and_generic().verified_stmt(r#"CREATE OR REPLACE FUNCTION return_table(i INTEGER) RETURNS TABLE(id UUID, is_active BOOLEAN) LANGUAGE plpgsql AS $$ BEGIN RETURN QUERY SELECT NULL::UUID, NULL::BOOLEAN; END; $$"#);
 }
 #[test]
 fn parse_incorrect_create_function_parallel() {
@@ -4372,7 +4373,7 @@ fn parse_join_constraint_unnest_alias() {
                 with_ordinality: false,
             },
             global: false,
-            join_operator: JoinOperator::Join(JoinConstraint::On(Expr::BinaryOp {
+            join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("c1".into())),
                 op: BinaryOperator::Eq,
                 right: Box::new(Expr::Identifier("c2".into())),
@@ -5147,7 +5148,7 @@ fn parse_trigger_related_functions() {
             temporary: false,
             if_not_exists: false,
             name: ObjectName::from(vec![Ident::new("emp_stamp")]),
-            args: Some(vec![]),
+            args: None,
             return_type: Some(DataType::Trigger),
             function_body: Some(
                 CreateFunctionBody::AsBeforeOptions(


### PR DESCRIPTION
Currently CREATE FUNCTION doesn't support the RETURNS TABLE datatype (https://www.postgresql.org/docs/15/sql-createfunction.html).

This PR adds it for the PostgresSQL and Generic dialect.