### PR TITLE
Fix DDL generation in case of an empty arguments function.

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2011,6 +2011,8 @@ impl fmt::Display for CreateFunction {
         )?;
         if let Some(args) = &self.args {
             write!(f, "({})", display_comma_separated(args))?;
+        } else {
+            write!(f, "()")?;
         }
         if let Some(return_type) = &self.return_type {
             write!(f, " RETURNS {return_type}")?;

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -3802,6 +3802,7 @@ fn parse_create_function_detailed() {
     pg_and_generic().verified_stmt("CREATE OR REPLACE FUNCTION add(a INTEGER, IN b INTEGER = 1) RETURNS INTEGER LANGUAGE SQL STABLE PARALLEL UNSAFE RETURN a + b");
     pg_and_generic().verified_stmt("CREATE OR REPLACE FUNCTION add(a INTEGER, IN b INTEGER = 1) RETURNS INTEGER LANGUAGE SQL STABLE CALLED ON NULL INPUT PARALLEL UNSAFE RETURN a + b");
     pg_and_generic().verified_stmt(r#"CREATE OR REPLACE FUNCTION increment(i INTEGER) RETURNS INTEGER LANGUAGE plpgsql AS $$ BEGIN RETURN i + 1; END; $$"#);
+    pg_and_generic().verified_stmt(r#"CREATE OR REPLACE FUNCTION no_arg() RETURNS VOID LANGUAGE plpgsql AS $$ BEGIN DELETE FROM my_table; END; $$"#);
 }
 #[test]
 fn parse_incorrect_create_function_parallel() {


### PR DESCRIPTION
Functions with an empty argument list are properly parsed into the AST but the string representation of such function removes the parenthesis required after the function name, causing an error at the database level.

For eg.
`CREATE OR REPLACE FUNCTION no_arg() RETURNS VOID LANGUAGE plpgsql AS $$ BEGIN DELETE FROM my_table; END; $$`
Becomes:
`CREATE OR REPLACE FUNCTION no_arg RETURNS VOID LANGUAGE plpgsql AS $$ BEGIN DELETE FROM my_table; END; $$ 
`
And causes Postgres to reject the query with a 
`[96579] ERROR:  syntax error at or near "RETURNS"`

This PR fixes the string representation in this specific case.