### PR TITLE
Allow plain JOIN without turning it into INNER

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2038,9 +2038,16 @@ impl fmt::Display for Join {
         }
 
         match &self.join_operator {
-            JoinOperator::Inner(constraint) => write!(
+            JoinOperator::Join(constraint) => write!(
                 f,
                 " {}JOIN {}{}",
+                prefix(constraint),
+                self.relation,
+                suffix(constraint)
+            ),
+            JoinOperator::Inner(constraint) => write!(
+                f,
+                " {}INNER JOIN {}{}",
                 prefix(constraint),
                 self.relation,
                 suffix(constraint)
@@ -2128,6 +2135,7 @@ impl fmt::Display for Join {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum JoinOperator {
+    Join(JoinConstraint),
     Inner(JoinConstraint),
     LeftOuter(JoinConstraint),
     RightOuter(JoinConstraint),

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -2001,6 +2001,7 @@ impl Spanned for Join {
 impl Spanned for JoinOperator {
     fn span(&self) -> Span {
         match self {
+            JoinOperator::Join(join_constraint) => join_constraint.span(),
             JoinOperator::Inner(join_constraint) => join_constraint.span(),
             JoinOperator::LeftOuter(join_constraint) => join_constraint.span(),
             JoinOperator::RightOuter(join_constraint) => join_constraint.span(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11000,9 +11000,13 @@ impl<'a> Parser<'a> {
 
                 let join_operator_type = match peek_keyword {
                     Keyword::INNER | Keyword::JOIN => {
-                        let _ = self.parse_keyword(Keyword::INNER); // [ INNER ]
+                        let inner = self.parse_keyword(Keyword::INNER); // [ INNER ]
                         self.expect_keyword_is(Keyword::JOIN)?;
-                        JoinOperator::Inner
+                        if inner {
+                            JoinOperator::Inner
+                        } else {
+                            JoinOperator::Join
+                        }
                     }
                     kw @ Keyword::LEFT | kw @ Keyword::RIGHT => {
                         let _ = self.next_token(); // consume LEFT/RIGHT

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -403,7 +403,7 @@ pub fn join(relation: TableFactor) -> Join {
     Join {
         relation,
         global: false,
-        join_operator: JoinOperator::Inner(JoinConstraint::Natural),
+        join_operator: JoinOperator::Join(JoinConstraint::Natural),
     }
 }
 

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1602,7 +1602,7 @@ fn parse_join_constraint_unnest_alias() {
                 with_ordinality: false,
             },
             global: false,
-            join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
+            join_operator: JoinOperator::Join(JoinConstraint::On(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("c1".into())),
                 op: BinaryOperator::Eq,
                 right: Box::new(Expr::Identifier("c2".into())),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -2055,7 +2055,7 @@ fn parse_update_with_joins() {
                             index_hints: vec![],
                         },
                         global: false,
-                        join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
+                        join_operator: JoinOperator::Join(JoinConstraint::On(Expr::BinaryOp {
                             left: Box::new(Expr::CompoundIdentifier(vec![
                                 Ident::new("o"),
                                 Ident::new("customer_id")

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4371,7 +4371,7 @@ fn parse_join_constraint_unnest_alias() {
                 with_ordinality: false,
             },
             global: false,
-            join_operator: JoinOperator::Inner(JoinConstraint::On(Expr::BinaryOp {
+            join_operator: JoinOperator::Join(JoinConstraint::On(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier("c1".into())),
                 op: BinaryOperator::Eq,
                 right: Box::new(Expr::Identifier("c2".into())),


### PR DESCRIPTION
Although these are syntactic equivalents in some dialects, we can preserve the input syntax without less rewriting this way.
