### PR TITLE
Do not parse ASOF and MATCH_CONDITION as table factor aliases

### DIFF
--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1000,6 +1000,8 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::ANTI,
     Keyword::SEMI,
     Keyword::RETURNING,
+    Keyword::ASOF,
+    Keyword::MATCH_CONDITION,
     // for MSSQL-specific OUTER APPLY (seems reserved in most dialects)
     Keyword::OUTER,
     Keyword::SET,

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -2731,6 +2731,20 @@ fn asof_joins() {
               "ON s.state = p.state ",
           "ORDER BY s.observed",
     ));
+
+    // Test without explicit aliases
+    #[rustfmt::skip]
+    snowflake_and_generic().verified_query(concat!(
+        "SELECT * ",
+          "FROM snowtime ",
+            "ASOF JOIN raintime ",
+              "MATCH_CONDITION (snowtime.observed >= raintime.observed) ",
+              "ON snowtime.state = raintime.state ",
+            "ASOF JOIN preciptime ",
+              "MATCH_CONDITION (showtime.observed >= preciptime.observed) ",
+              "ON showtime.state = preciptime.state ",
+          "ORDER BY showtime.observed",
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Example 1 - `SELECT * FROM tbl ASOF`
`ASOF` is parsed as the alias for `tbl`, but on Snowflake, it's reserved for the `ASOF JOIN` option.

Example 2 - `SELECT * FROM tbl1 ASOF JOIN tbl2 MATCH_CONDITION(...)`
`MATCH_CONDITION` is parsed as the alias for `tbl2`, but on Snowflake, it's reserved for the `ASOF JOIN` option.

Added `ASOF` AND `MATCH_CONDITION` as reserved keywords for table alias and added a test for the ASOF JOIN functionality without explicit aliases.
