### PR TITLE
Require space after -- to start single line comment in MySQL

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -881,12 +881,12 @@ pub trait Dialect: Debug + Any {
         false
     }
 
-    /// Returns whether it's the start of a single line comment
-    /// e.g. MySQL requires a space after `--` to be a single line comment
-    /// Otherwise it's interpreted as a double minus operator
+    /// Returns true if this dialect requires a whitespace character after `--` to start a single line comment.
     ///
     /// MySQL: <https://dev.mysql.com/doc/refman/8.4/en/ansi-diff-comments.html>
-    fn requires_whitespace_to_start_comment(&self) -> bool {
+    /// e.g. UPDATE account SET balance=balance--1
+    //       WHERE account_id=5752             ^^^ will be interpreted as two minus signs instead of a comment
+    fn requires_single_line_comment_whitespace(&self) -> bool {
         false
     }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -880,6 +880,15 @@ pub trait Dialect: Debug + Any {
     fn supports_table_hints(&self) -> bool {
         false
     }
+
+    /// Returns whether it's the start of a single line comment
+    /// e.g. MySQL requires a space after `--` to be a single line comment
+    /// Otherwise it's interpreted as a double minus operator
+    ///
+    /// MySQL: <https://dev.mysql.com/doc/refman/8.4/en/ansi-diff-comments.html>
+    fn is_start_of_single_line_comment(&self, _ch: char) -> bool {
+        true
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -886,8 +886,8 @@ pub trait Dialect: Debug + Any {
     /// Otherwise it's interpreted as a double minus operator
     ///
     /// MySQL: <https://dev.mysql.com/doc/refman/8.4/en/ansi-diff-comments.html>
-    fn is_start_of_single_line_comment(&self, _ch: char) -> bool {
-        true
+    fn requires_whitespace_to_start_comment(&self) -> bool {
+        false
     }
 }
 

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -125,6 +125,15 @@ impl Dialect for MySqlDialect {
     fn supports_table_hints(&self) -> bool {
         true
     }
+
+    /// Returns whether it's the start of a single line comment
+    /// e.g. MySQL requires a space after `--` to be a single line comment
+    /// Otherwise it's interpreted as a double minus operator
+    ///
+    /// MySQL: <https://dev.mysql.com/doc/refman/8.4/en/ansi-diff-comments.html>
+    fn is_start_of_single_line_comment(&self, _ch: char) -> bool {
+        _ch == ' '
+    }
 }
 
 /// `LOCK TABLES`

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -131,8 +131,8 @@ impl Dialect for MySqlDialect {
     /// Otherwise it's interpreted as a double minus operator
     ///
     /// MySQL: <https://dev.mysql.com/doc/refman/8.4/en/ansi-diff-comments.html>
-    fn is_start_of_single_line_comment(&self, _ch: char) -> bool {
-        _ch == ' '
+    fn requires_whitespace_to_start_comment(&self) -> bool {
+        true
     }
 }
 

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -126,12 +126,7 @@ impl Dialect for MySqlDialect {
         true
     }
 
-    /// Returns whether it's the start of a single line comment
-    /// e.g. MySQL requires a space after `--` to be a single line comment
-    /// Otherwise it's interpreted as a double minus operator
-    ///
-    /// MySQL: <https://dev.mysql.com/doc/refman/8.4/en/ansi-diff-comments.html>
-    fn requires_whitespace_to_start_comment(&self) -> bool {
+    fn requires_single_line_comment_whitespace(&self) -> bool {
         true
     }
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3244,3 +3244,62 @@ fn parse_double_precision() {
         "CREATE TABLE foo (bar DOUBLE(11,0))",
     );
 }
+
+#[test]
+fn parse_looks_like_single_line_comment() {
+    // See https://dev.mysql.com/doc/refman/8.4/en/ansi-diff-comments.html
+    match mysql().parse_sql_statements(
+        r#"
+            UPDATE account SET balance=balance--1
+            WHERE account_id=5752
+        "#,
+    ) {
+        Ok(statement) => match statement.first() {
+            Some(Statement::Update { assignments, .. }) => {
+                assert_eq!(assignments.len(), 1);
+                assert_eq!(
+                    assignments[0],
+                    Assignment {
+                        value: Expr::BinaryOp {
+                            left: Box::new(Expr::Identifier(Ident::new("balance"))),
+                            op: BinaryOperator::Minus,
+                            right: Box::new(Expr::UnaryOp {
+                                op: UnaryOperator::Minus,
+                                expr: Box::new(Expr::Value(number("1")))
+                            }),
+                        },
+                        target: AssignmentTarget::ColumnName(ObjectName::from(vec![Ident::new(
+                            "balance".to_string()
+                        )])),
+                    }
+                );
+            }
+            _ => panic!("expected update statement"),
+        },
+        _ => panic!("expected error"),
+    }
+
+    match mysql().parse_sql_statements(
+        r#"
+            UPDATE account SET balance=balance-- 1
+            WHERE account_id=5752
+        "#,
+    ) {
+        Ok(statement) => match statement.first() {
+            Some(Statement::Update { assignments, .. }) => {
+                assert_eq!(assignments.len(), 1);
+                assert_eq!(
+                    assignments[0],
+                    Assignment {
+                        value: Expr::Identifier(Ident::new("balance")),
+                        target: AssignmentTarget::ColumnName(ObjectName::from(vec![Ident::new(
+                            "balance".to_string()
+                        )])),
+                    }
+                );
+            }
+            _ => panic!("expected update statement"),
+        },
+        _ => panic!("expected error"),
+    }
+}


### PR DESCRIPTION
- Docs https://dev.mysql.com/doc/refman/8.4/en/ansi-diff-comments.html
- Lexer https://github.com/mysql/mysql-server/blob/trunk/sql/sql_lex.cc#L1465-L1472
- Char checks
```cpp
static constexpr uint8_t MY_CHAR_CTR =  040; /* Control character */

inline bool my_iscntrl(const CHARSET_INFO *cs, char ch) {
  return ((cs->ctype + 1)[static_cast<uint8_t>(ch)] & MY_CHAR_CTR) != 0;
}

static constexpr uint8_t MY_CHAR_SPC =  010; /* Spacing character */

inline bool my_isspace(const CHARSET_INFO *cs, char ch) {
  return ((cs->ctype + 1)[static_cast<uint8_t>(ch)] & MY_CHAR_SPC) != 0;
}
```

It's not super clear which characters belong to `my_iscntrl` and `my_isspace` but we cannot use `char.is_whitespace()` as it includes `'\n'`?
