### PR TITLE
Fix incorrect parsing of JsonAccess bracket notation after cast in Snowflae

### DIFF
--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -80,4 +80,9 @@ impl Dialect for DuckDbDialect {
     fn supports_load_extension(&self) -> bool {
         true
     }
+
+    // See DuckDB <https://duckdb.org/docs/sql/data_types/array.html#defining-an-array-field>
+    fn supports_array_typedef_size(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -143,4 +143,8 @@ impl Dialect for GenericDialect {
     fn supports_string_escape_constant(&self) -> bool {
         true
     }
+
+    fn supports_array_typedef_size(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -890,6 +890,12 @@ pub trait Dialect: Debug + Any {
     fn requires_single_line_comment_whitespace(&self) -> bool {
         false
     }
+
+    /// Returns true if the dialect supports size definition for array types.
+    /// For example: ```CREATE TABLE my_table (my_array INT[3])```.
+    fn supports_array_typedef_size(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -253,6 +253,11 @@ impl Dialect for PostgreSqlDialect {
     fn supports_numeric_literal_underscores(&self) -> bool {
         true
     }
+
+    /// See: <https://www.postgresql.org/docs/current/arrays.html#ARRAYS-DECLARATION>
+    fn supports_array_typedef_size(&self) -> bool {
+        true
+    }
 }
 
 pub fn parse_create(parser: &mut Parser) -> Option<Result<Statement, ParserError>> {

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1256,6 +1256,32 @@ fn parse_semi_structured_data_traversal() {
             .to_string(),
         "sql parser error: Expected: variant object key name, found: 42"
     );
+
+    // casting a json access and accessing an array element
+    assert_eq!(
+        snowflake().verified_expr("a:b::ARRAY[1]"),
+        Expr::JsonAccess {
+            value: Box::new(Expr::Cast {
+                kind: CastKind::DoubleColon,
+                data_type: DataType::Array(ArrayElemTypeDef::None),
+                format: None,
+                expr: Box::new(Expr::JsonAccess {
+                    value: Box::new(Expr::Identifier(Ident::new("a"))),
+                    path: JsonPath {
+                        path: vec![JsonPathElem::Dot {
+                            key: "b".to_string(),
+                            quoted: false
+                        }]
+                    }
+                })
+            }),
+            path: JsonPath {
+                path: vec![JsonPathElem::Bracket {
+                    key: Expr::Value(number("1"))
+                }]
+            }
+        }
+    );
 }
 
 #[test]


### PR DESCRIPTION
Some dialects support a size parameter for array type definitions, using bracket notation. For example: `INT[100]`. For other dialects, the bracket notation should be parsed as JsonAccess, for example in Snowflake this statement means to extract the second element after casting the JSONPath `b.c` from column a to an array: `SELECT a:b:c::ARRAY[1]`.

This PR makes a distinction between these dialects to ensure the correct parsing of JsonAccess after a cast expression.