### PR TITLE
Replace `Method` and `CompositeAccess` with `CompoundFieldAccess`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -659,11 +659,6 @@ pub enum Expr {
         /// The path to the data to extract.
         path: JsonPath,
     },
-    /// CompositeAccess eg: SELECT foo(bar).z, (information_schema._pg_expandarray(array['i','i'])).n
-    CompositeAccess {
-        expr: Box<Expr>,
-        key: Ident,
-    },
     /// `IS FALSE` operator
     IsFalse(Box<Expr>),
     /// `IS NOT FALSE` operator
@@ -913,23 +908,6 @@ pub enum Expr {
     },
     /// Scalar function call e.g. `LEFT(foo, 5)`
     Function(Function),
-    /// Arbitrary expr method call
-    ///
-    /// Syntax:
-    ///
-    /// `<arbitrary-expr>.<function-call>.<function-call-expr>...`
-    ///
-    /// > `arbitrary-expr` can be any expression including a function call.
-    ///
-    /// Example:
-    ///
-    /// ```sql
-    /// SELECT (SELECT ',' + name FROM sys.objects  FOR XML PATH(''), TYPE).value('.','NVARCHAR(MAX)')
-    /// SELECT CONVERT(XML,'<Book>abc</Book>').value('.','NVARCHAR(MAX)').value('.','NVARCHAR(MAX)')
-    /// ```
-    ///
-    /// (mssql): <https://learn.microsoft.com/en-us/sql/t-sql/xml/xml-data-type-methods?view=sql-server-ver16>
-    Method(Method),
     /// `CASE [<operand>] WHEN <condition> THEN <result> ... [ELSE <result>] END`
     ///
     /// Note we only recognize a complete single expression as `<condition>`,
@@ -1629,7 +1607,6 @@ impl fmt::Display for Expr {
                 write!(f, " {value}")
             }
             Expr::Function(fun) => write!(f, "{fun}"),
-            Expr::Method(method) => write!(f, "{method}"),
             Expr::Case {
                 operand,
                 conditions,
@@ -1786,9 +1763,6 @@ impl fmt::Display for Expr {
             }
             Expr::JsonAccess { value, path } => {
                 write!(f, "{value}{path}")
-            }
-            Expr::CompositeAccess { expr, key } => {
-                write!(f, "{expr}.{key}")
             }
             Expr::AtTimeZone {
                 timestamp,

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1286,7 +1286,6 @@ impl Spanned for Expr {
         match self {
             Expr::Identifier(ident) => ident.span,
             Expr::CompoundIdentifier(vec) => union_spans(vec.iter().map(|i| i.span)),
-            Expr::CompositeAccess { expr, key } => expr.span().union(&key.span),
             Expr::CompoundFieldAccess { root, access_chain } => {
                 union_spans(iter::once(root.span()).chain(access_chain.iter().map(|i| i.span())))
             }
@@ -1476,7 +1475,6 @@ impl Spanned for Expr {
             Expr::OuterJoin(expr) => expr.span(),
             Expr::Prior(expr) => expr.span(),
             Expr::Lambda(_) => Span::empty(),
-            Expr::Method(_) => Span::empty(),
         }
     }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -245,6 +245,11 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports the `(+)` syntax for OUTER JOIN.
+    fn supports_outer_join_operator(&self) -> bool {
+        false
+    }
+
     /// Returns true if the dialect supports CONNECT BY.
     fn supports_connect_by(&self) -> bool {
         false
@@ -343,15 +348,6 @@ pub trait Dialect: Debug + Any {
     /// SELECT transform(array(1, 2, 3), x -> x + 1); -- returns [2,3,4]
     /// ```
     fn supports_lambda_functions(&self) -> bool {
-        false
-    }
-
-    /// Returns true if the dialect supports method calls, for example:
-    ///
-    /// ```sql
-    /// SELECT (SELECT ',' + name FROM sys.objects  FOR XML PATH(''), TYPE).value('.','NVARCHAR(MAX)')
-    /// ```
-    fn supports_methods(&self) -> bool {
         false
     }
 
@@ -559,6 +555,7 @@ pub trait Dialect: Debug + Any {
             Token::Word(w) if w.keyword == Keyword::SIMILAR => Ok(p!(Like)),
             Token::Word(w) if w.keyword == Keyword::OPERATOR => Ok(p!(Between)),
             Token::Word(w) if w.keyword == Keyword::DIV => Ok(p!(MulDivModOp)),
+            Token::Period => Ok(p!(Period)),
             Token::Eq
             | Token::Lt
             | Token::LtEq
@@ -632,6 +629,7 @@ pub trait Dialect: Debug + Any {
     /// Uses (APPROXIMATELY) <https://www.postgresql.org/docs/7.0/operators.htm#AEN2026> as a reference
     fn prec_value(&self, prec: Precedence) -> u8 {
         match prec {
+            Precedence::Period => 100,
             Precedence::DoubleColon => 50,
             Precedence::AtTz => 41,
             Precedence::MulDivModOp => 40,
@@ -903,6 +901,7 @@ pub trait Dialect: Debug + Any {
 /// higher number -> higher precedence
 #[derive(Debug, Clone, Copy)]
 pub enum Precedence {
+    Period,
     DoubleColon,
     AtTz,
     MulDivModOp,

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -46,6 +46,10 @@ impl Dialect for MsSqlDialect {
         true
     }
 
+    fn supports_outer_join_operator(&self) -> bool {
+        true
+    }
+
     fn supports_connect_by(&self) -> bool {
         true
     }
@@ -61,10 +65,6 @@ impl Dialect for MsSqlDialect {
     /// In MSSQL, there is no boolean type, and `true` and `false` are valid column names
     fn supports_boolean_literals(&self) -> bool {
         false
-    }
-
-    fn supports_methods(&self) -> bool {
-        true
     }
 
     fn supports_named_fn_args_with_colon_operator(&self) -> bool {

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -38,6 +38,7 @@ use crate::tokenizer::Token;
 #[derive(Debug)]
 pub struct PostgreSqlDialect {}
 
+const PERIOD_PREC: u8 = 200;
 const DOUBLE_COLON_PREC: u8 = 140;
 const BRACKET_PREC: u8 = 130;
 const COLLATE_PREC: u8 = 120;
@@ -154,6 +155,7 @@ impl Dialect for PostgreSqlDialect {
 
     fn prec_value(&self, prec: Precedence) -> u8 {
         match prec {
+            Precedence::Period => PERIOD_PREC,
             Precedence::DoubleColon => DOUBLE_COLON_PREC,
             Precedence::AtTz => AT_TZ_PREC,
             Precedence::MulDivModOp => MUL_DIV_MOD_OP_PREC,

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -87,6 +87,11 @@ impl Dialect for SnowflakeDialect {
         true
     }
 
+    /// See <https://docs.snowflake.com/en/sql-reference/constructs/where#joins-in-the-where-clause>
+    fn supports_outer_join_operator(&self) -> bool {
+        true
+    }
+
     fn supports_connect_by(&self) -> bool {
         true
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -74,6 +74,23 @@ fn parse_numeric_literal_underscore() {
 }
 
 #[test]
+fn parse_function_object_name() {
+    let select = verified_only_select("SELECT a.b.c.d(1, 2, 3) FROM T");
+    let Expr::Function(func) = expr_from_projection(&select.projection[0]) else {
+        unreachable!()
+    };
+    assert_eq!(
+        ObjectName::from(
+            ["a", "b", "c", "d"]
+                .into_iter()
+                .map(Ident::new)
+                .collect::<Vec<_>>()
+        ),
+        func.name,
+    );
+}
+
+#[test]
 fn parse_insert_values() {
     let row = vec![
         Expr::Value(number("1")),
@@ -932,6 +949,44 @@ fn parse_select_distinct_tuple() {
             Expr::Identifier(Ident::new("id")),
         ]))],
         &select.projection
+    );
+}
+
+#[test]
+fn parse_outer_join_operator() {
+    let dialects = all_dialects_where(|d| d.supports_outer_join_operator());
+
+    let select = dialects.verified_only_select("SELECT 1 FROM T WHERE a = b (+)");
+    assert_eq!(
+        select.selection,
+        Some(Expr::BinaryOp {
+            left: Box::new(Expr::Identifier(Ident::new("a"))),
+            op: BinaryOperator::Eq,
+            right: Box::new(Expr::OuterJoin(Box::new(Expr::Identifier(Ident::new("b")))))
+        })
+    );
+
+    let select = dialects.verified_only_select("SELECT 1 FROM T WHERE t1.c1 = t2.c2.d3 (+)");
+    assert_eq!(
+        select.selection,
+        Some(Expr::BinaryOp {
+            left: Box::new(Expr::CompoundIdentifier(vec![
+                Ident::new("t1"),
+                Ident::new("c1")
+            ])),
+            op: BinaryOperator::Eq,
+            right: Box::new(Expr::OuterJoin(Box::new(Expr::CompoundIdentifier(vec![
+                Ident::new("t2"),
+                Ident::new("c2"),
+                Ident::new("d3"),
+            ]))))
+        })
+    );
+
+    let res = dialects.parse_sql_statements("SELECT 1 FROM T WHERE 1 = 2 (+)");
+    assert_eq!(
+        ParserError::ParserError("Expected: column identifier before (+), found: 2".to_string()),
+        res.unwrap_err()
     );
 }
 
@@ -12504,68 +12559,76 @@ fn test_try_convert() {
 
 #[test]
 fn parse_method_select() {
-    let dialects = all_dialects_where(|d| d.supports_methods());
-    let _ = dialects.verified_only_select(
+    let _ = verified_only_select(
         "SELECT LEFT('abc', 1).value('.', 'NVARCHAR(MAX)').value('.', 'NVARCHAR(MAX)') AS T",
     );
-    let _ = dialects.verified_only_select("SELECT STUFF((SELECT ',' + name FROM sys.objects FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 1, '') AS T");
-    let _ = dialects
-        .verified_only_select("SELECT CAST(column AS XML).value('.', 'NVARCHAR(MAX)') AS T");
+    let _ = verified_only_select("SELECT STUFF((SELECT ',' + name FROM sys.objects FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 1, '') AS T");
+    let _ = verified_only_select("SELECT CAST(column AS XML).value('.', 'NVARCHAR(MAX)') AS T");
 
     // `CONVERT` support
-    let dialects = all_dialects_where(|d| {
-        d.supports_methods() && d.supports_try_convert() && d.convert_type_before_value()
-    });
+    let dialects =
+        all_dialects_where(|d| d.supports_try_convert() && d.convert_type_before_value());
     let _ = dialects.verified_only_select("SELECT CONVERT(XML, '<Book>abc</Book>').value('.', 'NVARCHAR(MAX)').value('.', 'NVARCHAR(MAX)') AS T");
 }
 
 #[test]
 fn parse_method_expr() {
-    let dialects = all_dialects_where(|d| d.supports_methods());
-    let expr = dialects
-        .verified_expr("LEFT('abc', 1).value('.', 'NVARCHAR(MAX)').value('.', 'NVARCHAR(MAX)')");
+    let expr =
+        verified_expr("LEFT('abc', 1).value('.', 'NVARCHAR(MAX)').value('.', 'NVARCHAR(MAX)')");
     match expr {
-        Expr::Method(Method { expr, method_chain }) => {
-            assert!(matches!(*expr, Expr::Function(_)));
+        Expr::CompoundFieldAccess { root, access_chain } => {
+            assert!(matches!(*root, Expr::Function(_)));
             assert!(matches!(
-                method_chain[..],
-                [Function { .. }, Function { .. }]
+                access_chain[..],
+                [
+                    AccessExpr::Dot(Expr::Function(_)),
+                    AccessExpr::Dot(Expr::Function(_))
+                ]
             ));
         }
         _ => unreachable!(),
     }
-    let expr = dialects.verified_expr(
+
+    let expr = verified_expr(
         "(SELECT ',' + name FROM sys.objects FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)')",
     );
     match expr {
-        Expr::Method(Method { expr, method_chain }) => {
-            assert!(matches!(*expr, Expr::Subquery(_)));
-            assert!(matches!(method_chain[..], [Function { .. }]));
+        Expr::CompoundFieldAccess { root, access_chain } => {
+            assert!(matches!(*root, Expr::Subquery(_)));
+            assert!(matches!(
+                access_chain[..],
+                [AccessExpr::Dot(Expr::Function(_))]
+            ));
         }
         _ => unreachable!(),
     }
-    let expr = dialects.verified_expr("CAST(column AS XML).value('.', 'NVARCHAR(MAX)')");
+    let expr = verified_expr("CAST(column AS XML).value('.', 'NVARCHAR(MAX)')");
     match expr {
-        Expr::Method(Method { expr, method_chain }) => {
-            assert!(matches!(*expr, Expr::Cast { .. }));
-            assert!(matches!(method_chain[..], [Function { .. }]));
+        Expr::CompoundFieldAccess { root, access_chain } => {
+            assert!(matches!(*root, Expr::Cast { .. }));
+            assert!(matches!(
+                access_chain[..],
+                [AccessExpr::Dot(Expr::Function(_))]
+            ));
         }
         _ => unreachable!(),
     }
 
     // `CONVERT` support
-    let dialects = all_dialects_where(|d| {
-        d.supports_methods() && d.supports_try_convert() && d.convert_type_before_value()
-    });
+    let dialects =
+        all_dialects_where(|d| d.supports_try_convert() && d.convert_type_before_value());
     let expr = dialects.verified_expr(
         "CONVERT(XML, '<Book>abc</Book>').value('.', 'NVARCHAR(MAX)').value('.', 'NVARCHAR(MAX)')",
     );
     match expr {
-        Expr::Method(Method { expr, method_chain }) => {
-            assert!(matches!(*expr, Expr::Convert { .. }));
+        Expr::CompoundFieldAccess { root, access_chain } => {
+            assert!(matches!(*root, Expr::Convert { .. }));
             assert!(matches!(
-                method_chain[..],
-                [Function { .. }, Function { .. }]
+                access_chain[..],
+                [
+                    AccessExpr::Dot(Expr::Function(_)),
+                    AccessExpr::Dot(Expr::Function(_))
+                ]
             ));
         }
         _ => unreachable!(),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -2988,38 +2988,45 @@ fn parse_json_table_is_not_reserved() {
 fn test_composite_value() {
     let sql = "SELECT (on_hand.item).name FROM on_hand WHERE (on_hand.item).price > 9";
     let select = pg().verified_only_select(sql);
+
+    let Expr::CompoundFieldAccess { root, access_chain } =
+        expr_from_projection(&select.projection[0])
+    else {
+        unreachable!("expected projection: got {:?}", &select.projection[0]);
+    };
     assert_eq!(
-        SelectItem::UnnamedExpr(Expr::CompositeAccess {
-            key: Ident::new("name"),
-            expr: Box::new(Expr::Nested(Box::new(Expr::CompoundIdentifier(vec![
-                Ident::new("on_hand"),
-                Ident::new("item")
-            ]))))
-        }),
-        select.projection[0]
+        root.as_ref(),
+        &Expr::Nested(Box::new(Expr::CompoundIdentifier(vec![
+            Ident::new("on_hand"),
+            Ident::new("item")
+        ])))
+    );
+    assert_eq!(
+        access_chain.as_slice(),
+        &[AccessExpr::Dot(Expr::Identifier(Ident::new("name")))]
     );
 
     assert_eq!(
-        select.selection,
-        Some(Expr::BinaryOp {
-            left: Box::new(Expr::CompositeAccess {
-                key: Ident::new("price"),
-                expr: Box::new(Expr::Nested(Box::new(Expr::CompoundIdentifier(vec![
+        select.selection.as_ref().unwrap(),
+        &Expr::BinaryOp {
+            left: Box::new(Expr::CompoundFieldAccess {
+                root: Expr::Nested(Box::new(Expr::CompoundIdentifier(vec![
                     Ident::new("on_hand"),
                     Ident::new("item")
-                ]))))
+                ])))
+                .into(),
+                access_chain: vec![AccessExpr::Dot(Expr::Identifier(Ident::new("price")))]
             }),
             op: BinaryOperator::Gt,
             right: Box::new(Expr::Value(number("9")))
-        })
+        }
     );
 
     let sql = "SELECT (information_schema._pg_expandarray(ARRAY['i', 'i'])).n";
     let select = pg().verified_only_select(sql);
     assert_eq!(
-        SelectItem::UnnamedExpr(Expr::CompositeAccess {
-            key: Ident::new("n"),
-            expr: Box::new(Expr::Nested(Box::new(Expr::Function(Function {
+        &Expr::CompoundFieldAccess {
+            root: Box::new(Expr::Nested(Box::new(Expr::Function(Function {
                 name: ObjectName::from(vec![
                     Ident::new("information_schema"),
                     Ident::new("_pg_expandarray")
@@ -3043,9 +3050,10 @@ fn test_composite_value() {
                 filter: None,
                 over: None,
                 within_group: vec![],
-            }))))
-        }),
-        select.projection[0]
+            })))),
+            access_chain: vec![AccessExpr::Dot(Expr::Identifier(Ident::new("n")))],
+        },
+        expr_from_projection(&select.projection[0])
     );
 }
 


### PR DESCRIPTION
Continuation of #1551

This moves over two of the special case compound expressions delimited by period to use the new `CompoundFieldAccess` representation.

It moves the logic to parse the various kinds of compound expression into the same function `parse_compound_expr`, where previously they were somewhat spread between individual expression parsing and the compound field access parsing.