### PR TITLE
Add support for `EXECUTE IMMEDIATE`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3288,18 +3288,21 @@ pub enum Statement {
     /// Note: this is a PostgreSQL-specific statement.
     Deallocate { name: Ident, prepare: bool },
     /// ```sql
-    /// EXECUTE name [ ( parameter [, ...] ) ] [USING <expr>]
+    /// An `EXECUTE` statement
     /// ```
-    ///
-    /// Note: this statement is supported by Postgres and MSSQL, with slight differences in syntax.
     ///
     /// Postgres: <https://www.postgresql.org/docs/current/sql-execute.html>
     /// MSSQL: <https://learn.microsoft.com/en-us/sql/relational-databases/stored-procedures/execute-a-stored-procedure>
+    /// BigQuery: <https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#execute_immediate>
+    /// Snowflake: <https://docs.snowflake.com/en/sql-reference/sql/execute-immediate>
     Execute {
-        name: ObjectName,
+        name: Option<ObjectName>,
         parameters: Vec<Expr>,
         has_parentheses: bool,
-        using: Vec<Expr>,
+        /// Is this an `EXECUTE IMMEDIATE`
+        immediate: bool,
+        into: Vec<Ident>,
+        using: Vec<ExprWithAlias>,
     },
     /// ```sql
     /// PREPARE name [ ( data_type [, ...] ) ] AS statement
@@ -4905,6 +4908,8 @@ impl fmt::Display for Statement {
                 name,
                 parameters,
                 has_parentheses,
+                immediate,
+                into,
                 using,
             } => {
                 let (open, close) = if *has_parentheses {
@@ -4912,11 +4917,17 @@ impl fmt::Display for Statement {
                 } else {
                     (if parameters.is_empty() { "" } else { " " }, "")
                 };
-                write!(
-                    f,
-                    "EXECUTE {name}{open}{}{close}",
-                    display_comma_separated(parameters),
-                )?;
+                write!(f, "EXECUTE")?;
+                if *immediate {
+                    write!(f, " IMMEDIATE")?;
+                }
+                if let Some(name) = name {
+                    write!(f, " {name}")?;
+                }
+                write!(f, "{open}{}{close}", display_comma_separated(parameters),)?;
+                if !into.is_empty() {
+                    write!(f, " INTO {}", display_comma_separated(into))?;
+                }
                 if !using.is_empty() {
                     write!(f, " USING {}", display_comma_separated(using))?;
                 };

--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -110,6 +110,11 @@ impl Dialect for BigQueryDialect {
         true
     }
 
+    /// See <https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#execute_immediate>
+    fn supports_execute_immediate(&self) -> bool {
+        true
+    }
+
     // See <https://cloud.google.com/bigquery/docs/access-historical-data>
     fn supports_timestamp_versioning(&self) -> bool {
         true

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -250,6 +250,11 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports `EXECUTE IMMEDIATE` statements.
+    fn supports_execute_immediate(&self) -> bool {
+        false
+    }
+
     /// Returns true if the dialect supports the MATCH_RECOGNIZE operation.
     fn supports_match_recognize(&self) -> bool {
         false

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -91,6 +91,11 @@ impl Dialect for SnowflakeDialect {
         true
     }
 
+    /// See <https://docs.snowflake.com/en/sql-reference/sql/execute-immediate>
+    fn supports_execute_immediate(&self) -> bool {
+        true
+    }
+
     fn supports_match_recognize(&self) -> bool {
         true
     }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1658,10 +1658,12 @@ fn parse_execute() {
     assert_eq!(
         stmt,
         Statement::Execute {
-            name: ObjectName::from(vec!["a".into()]),
+            name: Some(ObjectName::from(vec!["a".into()])),
             parameters: vec![],
             has_parentheses: false,
-            using: vec![]
+            using: vec![],
+            immediate: false,
+            into: vec![]
         }
     );
 
@@ -1669,13 +1671,15 @@ fn parse_execute() {
     assert_eq!(
         stmt,
         Statement::Execute {
-            name: ObjectName::from(vec!["a".into()]),
+            name: Some(ObjectName::from(vec!["a".into()])),
             parameters: vec![
                 Expr::Value(number("1")),
                 Expr::Value(Value::SingleQuotedString("t".to_string()))
             ],
             has_parentheses: true,
-            using: vec![]
+            using: vec![],
+            immediate: false,
+            into: vec![]
         }
     );
 
@@ -1684,23 +1688,31 @@ fn parse_execute() {
     assert_eq!(
         stmt,
         Statement::Execute {
-            name: ObjectName::from(vec!["a".into()]),
+            name: Some(ObjectName::from(vec!["a".into()])),
             parameters: vec![],
             has_parentheses: false,
             using: vec![
-                Expr::Cast {
-                    kind: CastKind::Cast,
-                    expr: Box::new(Expr::Value(Value::Number("1337".parse().unwrap(), false))),
-                    data_type: DataType::SmallInt(None),
-                    format: None
+                ExprWithAlias {
+                    expr: Expr::Cast {
+                        kind: CastKind::Cast,
+                        expr: Box::new(Expr::Value(Value::Number("1337".parse().unwrap(), false))),
+                        data_type: DataType::SmallInt(None),
+                        format: None
+                    },
+                    alias: None
                 },
-                Expr::Cast {
-                    kind: CastKind::Cast,
-                    expr: Box::new(Expr::Value(Value::Number("7331".parse().unwrap(), false))),
-                    data_type: DataType::SmallInt(None),
-                    format: None
+                ExprWithAlias {
+                    expr: Expr::Cast {
+                        kind: CastKind::Cast,
+                        expr: Box::new(Expr::Value(Value::Number("7331".parse().unwrap(), false))),
+                        data_type: DataType::SmallInt(None),
+                        format: None
+                    },
+                    alias: None
                 },
-            ]
+            ],
+            immediate: false,
+            into: vec![]
         }
     );
 }


### PR DESCRIPTION
Adds support for the `EXECUTE IMMEDIATE` statement

```sql
EXECUTE IMMEDIATE 'SELECT 1' USING 2 AS foo;
```

[BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#execute_immediate) [Snowflake](https://docs.snowflake.com/en/sql-reference/sql/execute-immediate)