### PR TITLE
BigQuery: Add support for `BEGIN`

### DIFF
--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -15,9 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::ast::Statement;
 use crate::dialect::Dialect;
 use crate::keywords::Keyword;
-use crate::parser::Parser;
+use crate::parser::{Parser, ParserError};
 
 /// These keywords are disallowed as column identifiers. Such that
 /// `SELECT 5 AS <col> FROM T` is rejected by BigQuery.
@@ -44,7 +45,11 @@ const RESERVED_FOR_COLUMN_ALIAS: &[Keyword] = &[
 pub struct BigQueryDialect;
 
 impl Dialect for BigQueryDialect {
-    // See https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#identifiers
+    fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+        self.maybe_parse_statement(parser)
+    }
+
+    /// See <https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#identifiers>
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
         ch == '`'
     }
@@ -60,6 +65,9 @@ impl Dialect for BigQueryDialect {
 
     fn is_identifier_start(&self, ch: char) -> bool {
         ch.is_ascii_lowercase() || ch.is_ascii_uppercase() || ch == '_'
+            // BigQuery supports `@@foo.bar` variable syntax in its procedural language.
+            // https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#beginexceptionend
+            || ch == '@'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
@@ -127,5 +135,50 @@ impl Dialect for BigQueryDialect {
 
     fn is_column_alias(&self, kw: &Keyword, _parser: &mut Parser) -> bool {
         !RESERVED_FOR_COLUMN_ALIAS.contains(kw)
+    }
+}
+
+impl BigQueryDialect {
+    fn maybe_parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
+        if parser.peek_keyword(Keyword::BEGIN) {
+            return Some(self.parse_begin(parser));
+        }
+        None
+    }
+
+    /// Parse a `BEGIN` statement.
+    /// <https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#beginexceptionend>
+    fn parse_begin(&self, parser: &mut Parser) -> Result<Statement, ParserError> {
+        parser.expect_keyword(Keyword::BEGIN)?;
+
+        let statements = parser.parse_statement_list(&[Keyword::EXCEPTION, Keyword::END])?;
+
+        let has_exception_when_clause = parser.parse_keywords(&[
+            Keyword::EXCEPTION,
+            Keyword::WHEN,
+            Keyword::ERROR,
+            Keyword::THEN,
+        ]);
+        let exception_statements = if has_exception_when_clause {
+            if !parser.peek_keyword(Keyword::END) {
+                Some(parser.parse_statement_list(&[Keyword::END])?)
+            } else {
+                Some(Default::default())
+            }
+        } else {
+            None
+        };
+
+        parser.expect_keyword(Keyword::END)?;
+
+        Ok(Statement::StartTransaction {
+            begin: true,
+            statements,
+            exception_statements,
+            has_end_keyword: true,
+            transaction: None,
+            modifier: None,
+            modes: Default::default(),
+        })
     }
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -237,6 +237,52 @@ fn parse_big_query_non_reserved_column_alias() {
 }
 
 #[test]
+fn parse_at_at_identifier() {
+    bigquery().verified_stmt("SELECT @@error.stack_trace, @@error.message");
+}
+
+#[test]
+fn parse_begin() {
+    let sql = r#"BEGIN SELECT 1; EXCEPTION WHEN ERROR THEN SELECT 2; END"#;
+    let Statement::StartTransaction {
+        statements,
+        exception_statements,
+        has_end_keyword,
+        ..
+    } = bigquery().verified_stmt(sql)
+    else {
+        unreachable!();
+    };
+    assert_eq!(1, statements.len());
+    assert_eq!(1, exception_statements.unwrap().len());
+    assert!(has_end_keyword);
+
+    bigquery().verified_stmt(
+        "BEGIN SELECT 1; SELECT 2; EXCEPTION WHEN ERROR THEN SELECT 2; SELECT 4; END",
+    );
+    bigquery()
+        .verified_stmt("BEGIN SELECT 1; EXCEPTION WHEN ERROR THEN SELECT @@error.stack_trace; END");
+    bigquery().verified_stmt("BEGIN EXCEPTION WHEN ERROR THEN SELECT 2; END");
+    bigquery().verified_stmt("BEGIN SELECT 1; SELECT 2; EXCEPTION WHEN ERROR THEN END");
+    bigquery().verified_stmt("BEGIN EXCEPTION WHEN ERROR THEN END");
+    bigquery().verified_stmt("BEGIN SELECT 1; SELECT 2; END");
+    bigquery().verified_stmt("BEGIN END");
+
+    assert_eq!(
+        bigquery()
+            .parse_sql_statements("BEGIN SELECT 1; SELECT 2 END")
+            .unwrap_err(),
+        ParserError::ParserError("Expected: ;, found: END".to_string())
+    );
+    assert_eq!(
+        bigquery()
+            .parse_sql_statements("BEGIN SELECT 1; EXCEPTION WHEN ERROR THEN SELECT 2 END")
+            .unwrap_err(),
+        ParserError::ParserError("Expected: ;, found: END".to_string())
+    );
+}
+
+#[test]
 fn parse_delete_statement() {
     let sql = "DELETE \"table\" WHERE 1";
     match bigquery_and_generic().verified_stmt(sql) {

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -518,23 +518,6 @@ fn parse_start_transaction_with_modifier() {
     sqlite_and_generic().verified_stmt("BEGIN DEFERRED");
     sqlite_and_generic().verified_stmt("BEGIN IMMEDIATE");
     sqlite_and_generic().verified_stmt("BEGIN EXCLUSIVE");
-
-    let unsupported_dialects = all_dialects_except(|d| d.supports_start_transaction_modifier());
-    let res = unsupported_dialects.parse_sql_statements("BEGIN DEFERRED");
-    assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: DEFERRED".to_string()),
-        res.unwrap_err(),
-    );
-    let res = unsupported_dialects.parse_sql_statements("BEGIN IMMEDIATE");
-    assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: IMMEDIATE".to_string()),
-        res.unwrap_err(),
-    );
-    let res = unsupported_dialects.parse_sql_statements("BEGIN EXCLUSIVE");
-    assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: EXCLUSIVE".to_string()),
-        res.unwrap_err(),
-    );
 }
 
 #[test]


### PR DESCRIPTION
Adds support for the `BEGIN ... EXCEPTION ... END` syntax in BigQuery:

```sql
BEGIN
  SELECT 1;
  SELECT 2;
EXCEPTION WHEN ERROR THEN
  SELECT 3;
  SELECT 4;
END
```

https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#beginexceptionend