### PR TITLE
Enable custom dialects to support `MATCH() AGAINST()`

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -147,4 +147,8 @@ impl Dialect for GenericDialect {
     fn supports_array_typedef_size(&self) -> bool {
         true
     }
+
+    fn supports_match_against(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -479,6 +479,11 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Does the dialect support the `MATCH() AGAINST()` syntax?
+    fn supports_match_against(&self) -> bool {
+        false
+    }
+
     /// Dialect-specific infix parser override
     ///
     /// This method is called to parse the next infix expression.

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -129,6 +129,10 @@ impl Dialect for MySqlDialect {
     fn requires_single_line_comment_whitespace(&self) -> bool {
         true
     }
+
+    fn supports_match_against(&self) -> bool {
+        false
+    }
 }
 
 /// `LOCK TABLES`

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -131,7 +131,7 @@ impl Dialect for MySqlDialect {
     }
 
     fn supports_match_against(&self) -> bool {
-        false
+        true
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1198,7 +1198,7 @@ impl<'a> Parser<'a> {
                     })))
                 }
             Keyword::NOT => Ok(Some(self.parse_not()?)),
-            Keyword::MATCH if dialect_of!(self is MySqlDialect | GenericDialect) => {
+            Keyword::MATCH if self.dialect.supports_match_against() => {
                 Ok(Some(self.parse_match_against()?))
             }
             Keyword::STRUCT if self.dialect.supports_struct_literal() => {


### PR DESCRIPTION
The logic for if a dialect supports `MATCH() AGAINST()` was coded into the parser to look for specific dialects rather than the dialects attesting they support the syntax. This meant that custom dialects were unable to take advantage of this feature.

The changes involve updating the `Dialect` trait and its implementations for the MySQL and Generic SQL dialects which support `MATCH() AGAINST()`, as well as modifying the parser to use the new method for determining support for this syntax.

Key changes include:

### Dialect Trait Updates:
* [`src/dialect/mod.rs`](diffhunk://#diff-5638cd35d93e9e77be12ed5b86d621439eb7ed698fd2eba0e8a496a9b8ba208cR482-R486): Added a new method `supports_match_against` to the `Dialect` trait to indicate whether a dialect supports the `MATCH() AGAINST()` syntax.

### Dialect Implementations:
* [`src/dialect/generic.rs`](diffhunk://#diff-12028ad78dac1e758be596e9c6a1fb5e83ffe7bfaafec9c3a0a34ef1524b2848R150-R153): Implemented the `supports_match_against` method for the `GenericDialect` to return `true`.
* [`src/dialect/mysql.rs`](diffhunk://#diff-6bb2b4fc380f143942575d505dcf8a1659b9f5812b29b2ea25483d98ae49e066R132-R135): Implemented the `supports_match_against` method for the `MySqlDialect` to return `true`.

### Parser Update:
* [`src/parser/mod.rs`](diffhunk://#diff-fc6a8d66b8cb6bd48a119a70e489cbcef82e7f551e7cf08e8e972ef4e774ef49L1201-R1201): Updated the parser to use the `supports_match_against` method to check if the dialect supports the `MATCH() AGAINST()` syntax.