### PR TITLE
fix: make `serde` feature no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ bigdecimal = { version = "0.4.1", features = ["serde"], optional = true }
 log = "0.4"
 recursive = { version = "0.1.1", optional = true}
 
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"], optional = true }
 # serde_json is only used in examples/cli, but we have to put it outside
 # of dev-dependencies because of
 # https://github.com/rust-lang/cargo/issues/1596


### PR DESCRIPTION
Closes #1729

We use the `serde` feature of `sqlparser` in [SXT Proof of SQL](https://github.com/spaceandtimelabs/sxt-proof-of-sql) and want to ensure no_std support for some of our use cases. Hence we filed this PR.

Thanks to @JayWhite2357 for providing the fix.