### PR TITLE
Treat COLLATE like any other column option

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1206,7 +1206,6 @@ impl fmt::Display for ProcedureParam {
 pub struct ColumnDef {
     pub name: Ident,
     pub data_type: DataType,
-    pub collation: Option<ObjectName>,
     pub options: Vec<ColumnOptionDef>,
 }
 
@@ -1216,9 +1215,6 @@ impl fmt::Display for ColumnDef {
             write!(f, "{}", self.name)?;
         } else {
             write!(f, "{} {}", self.name, self.data_type)?;
-        }
-        if let Some(collation) = &self.collation {
-            write!(f, " COLLATE {collation}")?;
         }
         for option in &self.options {
             write!(f, " {option}")?;
@@ -1566,6 +1562,7 @@ pub enum ColumnOption {
     /// - ...
     DialectSpecific(Vec<Token>),
     CharacterSet(ObjectName),
+    Collation(ObjectName),
     Comment(String),
     OnUpdate(Expr),
     /// `Generated`s are modifiers that follow a column definition in a `CREATE
@@ -1665,6 +1662,7 @@ impl fmt::Display for ColumnOption {
             Check(expr) => write!(f, "CHECK ({expr})"),
             DialectSpecific(val) => write!(f, "{}", display_separated(val, " ")),
             CharacterSet(n) => write!(f, "CHARACTER SET {n}"),
+            Collation(n) => write!(f, "COLLATE {n}"),
             Comment(v) => write!(f, "COMMENT '{}'", escape_single_quote_string(v)),
             OnUpdate(expr) => write!(f, "ON UPDATE {expr}"),
             Generated {

--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -47,7 +47,6 @@ use crate::parser::ParserError;
 ///    .columns(vec![ColumnDef {
 ///        name: Ident::new("c1"),
 ///        data_type: DataType::Int(None),
-///        collation: None,
 ///        options: vec![],
 /// }]);
 /// // You can access internal elements with ease

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -604,15 +604,10 @@ impl Spanned for ColumnDef {
         let ColumnDef {
             name,
             data_type: _, // enum
-            collation,
             options,
         } = self;
 
-        union_spans(
-            core::iter::once(name.span)
-                .chain(collation.iter().map(|i| i.span()))
-                .chain(options.iter().map(|i| i.span())),
-        )
+        union_spans(core::iter::once(name.span).chain(options.iter().map(|i| i.span())))
     }
 }
 
@@ -767,6 +762,7 @@ impl Spanned for ColumnOption {
             ColumnOption::Check(expr) => expr.span(),
             ColumnOption::DialectSpecific(_) => Span::empty(),
             ColumnOption::CharacterSet(object_name) => object_name.span(),
+            ColumnOption::Collation(object_name) => object_name.span(),
             ColumnOption::Comment(_) => Span::empty(),
             ColumnOption::OnUpdate(expr) => expr.span(),
             ColumnOption::Generated { .. } => Span::empty(),

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -389,7 +389,6 @@ fn parse_create_table_with_unquoted_hyphen() {
                 vec![ColumnDef {
                     name: Ident::new("x"),
                     data_type: DataType::Int64,
-                    collation: None,
                     options: vec![]
                 },],
                 columns
@@ -427,7 +426,6 @@ fn parse_create_table_with_options() {
                     ColumnDef {
                         name: Ident::new("x"),
                         data_type: DataType::Int64,
-                        collation: None,
                         options: vec![
                             ColumnOptionDef {
                                 name: None,
@@ -447,7 +445,6 @@ fn parse_create_table_with_options() {
                     ColumnDef {
                         name: Ident::new("y"),
                         data_type: DataType::Bool,
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Options(vec![SqlOption::KeyValue {
@@ -530,7 +527,6 @@ fn parse_nested_data_types() {
                             ],
                             StructBracketKind::AngleBrackets
                         ),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
@@ -544,7 +540,6 @@ fn parse_nested_data_types() {
                                 StructBracketKind::AngleBrackets
                             ),
                         ))),
-                        collation: None,
                         options: vec![],
                     },
                 ]

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -528,7 +528,6 @@ fn column_def(name: Ident, data_type: DataType) -> ColumnDef {
     ColumnDef {
         name,
         data_type,
-        collation: None,
         options: vec![],
     }
 }
@@ -617,7 +616,6 @@ fn parse_create_table_with_nullable() {
                     ColumnDef {
                         name: "d".into(),
                         data_type: DataType::Date32,
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Null
@@ -661,7 +659,6 @@ fn parse_create_table_with_nested_data_types() {
                                 DataType::LowCardinality(Box::new(DataType::String(None)))
                             )
                         ]),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
@@ -678,7 +675,6 @@ fn parse_create_table_with_nested_data_types() {
                                 }
                             ])
                         ))),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
@@ -695,7 +691,6 @@ fn parse_create_table_with_nested_data_types() {
                                 ))
                             },
                         ]),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
@@ -704,7 +699,6 @@ fn parse_create_table_with_nested_data_types() {
                             Box::new(DataType::String(None)),
                             Box::new(DataType::UInt16)
                         ),
-                        collation: None,
                         options: vec![],
                     },
                 ]
@@ -736,13 +730,11 @@ fn parse_create_table_with_primary_key() {
                     ColumnDef {
                         name: Ident::with_quote('`', "i"),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::with_quote('`', "k"),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![],
                     },
                 ],
@@ -814,7 +806,6 @@ fn parse_create_table_with_variant_default_expressions() {
                     ColumnDef {
                         name: Ident::new("a"),
                         data_type: DataType::Datetime(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Materialized(Expr::Function(Function {
@@ -836,7 +827,6 @@ fn parse_create_table_with_variant_default_expressions() {
                     ColumnDef {
                         name: Ident::new("b"),
                         data_type: DataType::Datetime(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Ephemeral(Some(Expr::Function(Function {
@@ -858,7 +848,6 @@ fn parse_create_table_with_variant_default_expressions() {
                     ColumnDef {
                         name: Ident::new("c"),
                         data_type: DataType::Datetime(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Ephemeral(None)
@@ -867,7 +856,6 @@ fn parse_create_table_with_variant_default_expressions() {
                     ColumnDef {
                         name: Ident::new("d"),
                         data_type: DataType::String(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Alias(Expr::Function(Function {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3426,7 +3426,6 @@ fn parse_create_table() {
                             length: 100,
                             unit: None,
                         })),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::NotNull,
@@ -3435,7 +3434,6 @@ fn parse_create_table() {
                     ColumnDef {
                         name: "lat".into(),
                         data_type: DataType::Double(ExactNumberInfo::None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Null,
@@ -3444,13 +3442,11 @@ fn parse_create_table() {
                     ColumnDef {
                         name: "lng".into(),
                         data_type: DataType::Double(ExactNumberInfo::None),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: "constrained".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![
                             ColumnOptionDef {
                                 name: None,
@@ -3483,7 +3479,6 @@ fn parse_create_table() {
                     ColumnDef {
                         name: "ref".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::ForeignKey {
@@ -3498,7 +3493,6 @@ fn parse_create_table() {
                     ColumnDef {
                         name: "ref2".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::ForeignKey {
@@ -3615,7 +3609,6 @@ fn parse_create_table_with_constraint_characteristics() {
                             length: 100,
                             unit: None,
                         })),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::NotNull,
@@ -3624,7 +3617,6 @@ fn parse_create_table_with_constraint_characteristics() {
                     ColumnDef {
                         name: "lat".into(),
                         data_type: DataType::Double(ExactNumberInfo::None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Null,
@@ -3633,7 +3625,6 @@ fn parse_create_table_with_constraint_characteristics() {
                     ColumnDef {
                         name: "lng".into(),
                         data_type: DataType::Double(ExactNumberInfo::None),
-                        collation: None,
                         options: vec![],
                     },
                 ]
@@ -3768,7 +3759,6 @@ fn parse_create_table_column_constraint_characteristics() {
                     vec![ColumnDef {
                         name: "a".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Unique {
@@ -3883,13 +3873,11 @@ fn parse_create_table_hive_array() {
                         ColumnDef {
                             name: Ident::new("name"),
                             data_type: DataType::Int(None),
-                            collation: None,
                             options: vec![],
                         },
                         ColumnDef {
                             name: Ident::new("val"),
                             data_type: DataType::Array(expected),
-                            collation: None,
                             options: vec![],
                         },
                     ],
@@ -4255,7 +4243,6 @@ fn parse_create_external_table() {
                             length: 100,
                             unit: None,
                         })),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::NotNull,
@@ -4264,7 +4251,6 @@ fn parse_create_external_table() {
                     ColumnDef {
                         name: "lat".into(),
                         data_type: DataType::Double(ExactNumberInfo::None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Null,
@@ -4273,7 +4259,6 @@ fn parse_create_external_table() {
                     ColumnDef {
                         name: "lng".into(),
                         data_type: DataType::Double(ExactNumberInfo::None),
-                        collation: None,
                         options: vec![],
                     },
                 ]
@@ -4326,7 +4311,6 @@ fn parse_create_or_replace_external_table() {
                         length: 100,
                         unit: None,
                     })),
-                    collation: None,
                     options: vec![ColumnOptionDef {
                         name: None,
                         option: ColumnOption::NotNull,
@@ -10818,7 +10802,14 @@ fn parse_execute_immediate() {
 
 #[test]
 fn parse_create_table_collate() {
-    pg_and_generic().verified_stmt("CREATE TABLE tbl (foo INT, bar TEXT COLLATE \"de_DE\")");
+    all_dialects().verified_stmt("CREATE TABLE tbl (foo INT, bar TEXT COLLATE \"de_DE\")");
+    // check ordering is preserved
+    all_dialects().verified_stmt(
+        "CREATE TABLE tbl (foo INT, bar TEXT CHARACTER SET utf8mb4 COLLATE \"de_DE\")",
+    );
+    all_dialects().verified_stmt(
+        "CREATE TABLE tbl (foo INT, bar TEXT COLLATE \"de_DE\" CHARACTER SET utf8mb4)",
+    );
 }
 
 #[test]
@@ -10997,7 +10988,6 @@ fn test_parse_inline_comment() {
                 vec![ColumnDef {
                     name: Ident::new("id".to_string()),
                     data_type: DataType::Int(None),
-                    collation: None,
                     options: vec![ColumnOptionDef {
                         name: None,
                         option: Comment("comment without equal".to_string()),
@@ -13584,7 +13574,6 @@ fn parse_create_table_with_enum_types() {
                             ],
                             Some(8)
                         ),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
@@ -13602,7 +13591,6 @@ fn parse_create_table_with_enum_types() {
                             ],
                             Some(16)
                         ),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
@@ -13614,7 +13602,6 @@ fn parse_create_table_with_enum_types() {
                             ],
                             None
                         ),
-                        collation: None,
                         options: vec![],
                     }
                 ],

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -60,7 +60,6 @@ fn test_struct() {
         vec![ColumnDef {
             name: "s".into(),
             data_type: struct_type1.clone(),
-            collation: None,
             options: vec![],
         }]
     );
@@ -75,7 +74,6 @@ fn test_struct() {
                 Box::new(struct_type1),
                 None
             )),
-            collation: None,
             options: vec![],
         }]
     );
@@ -120,7 +118,6 @@ fn test_struct() {
                 Box::new(struct_type2),
                 None
             )),
-            collation: None,
             options: vec![],
         }]
     );
@@ -671,7 +668,6 @@ fn test_duckdb_union_datatype() {
                         field_name: "a".into(),
                         field_type: DataType::Int(None)
                     }]),
-                    collation: Default::default(),
                     options: Default::default()
                 },
                 ColumnDef {
@@ -686,7 +682,6 @@ fn test_duckdb_union_datatype() {
                             field_type: DataType::Int(None)
                         }
                     ]),
-                    collation: Default::default(),
                     options: Default::default()
                 },
                 ColumnDef {
@@ -698,7 +693,6 @@ fn test_duckdb_union_datatype() {
                             field_type: DataType::Int(None)
                         }])
                     }]),
-                    collation: Default::default(),
                     options: Default::default()
                 }
             ],

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1496,7 +1496,6 @@ fn parse_create_table_with_valid_options() {
                             span: Span::empty(),
                         },
                         data_type: Int(None,),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
@@ -1506,7 +1505,7 @@ fn parse_create_table_with_valid_options() {
                             span: Span::empty(),
                         },
                         data_type: Int(None,),
-                        collation: None,
+
                         options: vec![],
                     },
                     ColumnDef {
@@ -1516,7 +1515,7 @@ fn parse_create_table_with_valid_options() {
                             span: Span::empty(),
                         },
                         data_type: Int(None,),
-                        collation: None,
+
                         options: vec![],
                     },
                 ],
@@ -1671,7 +1670,7 @@ fn parse_create_table_with_identity_column() {
                         span: Span::empty(),
                     },
                     data_type: Int(None,),
-                    collation: None,
+
                     options: column_options,
                 },],
                 constraints: vec![],
@@ -1815,7 +1814,7 @@ fn parse_mssql_varbinary_max_length() {
                 vec![ColumnDef {
                     name: Ident::new("var_binary_col"),
                     data_type: Varbinary(Some(BinaryLength::Max)),
-                    collation: None,
+
                     options: vec![]
                 },],
             );
@@ -1840,7 +1839,7 @@ fn parse_mssql_varbinary_max_length() {
                 vec![ColumnDef {
                     name: Ident::new("var_binary_col"),
                     data_type: Varbinary(Some(BinaryLength::IntegerLength { length: 50 })),
-                    collation: None,
+
                     options: vec![]
                 },],
             );

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -636,7 +636,6 @@ fn parse_create_table_auto_increment() {
                 vec![ColumnDef {
                     name: Ident::new("bar"),
                     data_type: DataType::Int(None),
-                    collation: None,
                     options: vec![
                         ColumnOptionDef {
                             name: None,
@@ -726,7 +725,6 @@ fn parse_create_table_primary_and_unique_key() {
                         ColumnDef {
                             name: Ident::new("id"),
                             data_type: DataType::Int(None),
-                            collation: None,
                             options: vec![
                                 ColumnOptionDef {
                                     name: None,
@@ -746,7 +744,6 @@ fn parse_create_table_primary_and_unique_key() {
                         ColumnDef {
                             name: Ident::new("bar"),
                             data_type: DataType::Int(None),
-                            collation: None,
                             options: vec![ColumnOptionDef {
                                 name: None,
                                 option: ColumnOption::NotNull,
@@ -896,7 +893,6 @@ fn parse_create_table_set_enum() {
                     ColumnDef {
                         name: Ident::new("bar"),
                         data_type: DataType::Set(vec!["a".to_string(), "b".to_string()]),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
@@ -908,7 +904,6 @@ fn parse_create_table_set_enum() {
                             ],
                             None
                         ),
-                        collation: None,
                         options: vec![],
                     }
                 ],
@@ -935,7 +930,6 @@ fn parse_create_table_engine_default_charset() {
                 vec![ColumnDef {
                     name: Ident::new("id"),
                     data_type: DataType::Int(Some(11)),
-                    collation: None,
                     options: vec![],
                 },],
                 columns
@@ -968,7 +962,6 @@ fn parse_create_table_collate() {
                 vec![ColumnDef {
                     name: Ident::new("id"),
                     data_type: DataType::Int(Some(11)),
-                    collation: None,
                     options: vec![],
                 },],
                 columns
@@ -1016,7 +1009,6 @@ fn parse_create_table_comment_character_set() {
                 vec![ColumnDef {
                     name: Ident::new("s"),
                     data_type: DataType::Text,
-                    collation: None,
                     options: vec![
                         ColumnOptionDef {
                             name: None,
@@ -1063,7 +1055,6 @@ fn parse_quote_identifiers() {
                 vec![ColumnDef {
                     name: Ident::with_quote('`', "BEGIN"),
                     data_type: DataType::Int(None),
-                    collation: None,
                     options: vec![ColumnOptionDef {
                         name: None,
                         option: ColumnOption::Unique {
@@ -1326,31 +1317,26 @@ fn parse_create_table_with_minimum_display_width() {
                     ColumnDef {
                         name: Ident::new("bar_tinyint"),
                         data_type: DataType::TinyInt(Some(3)),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_smallint"),
                         data_type: DataType::SmallInt(Some(5)),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_mediumint"),
                         data_type: DataType::MediumInt(Some(6)),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_int"),
                         data_type: DataType::Int(Some(11)),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_bigint"),
                         data_type: DataType::BigInt(Some(20)),
-                        collation: None,
                         options: vec![],
                     }
                 ],
@@ -1372,31 +1358,26 @@ fn parse_create_table_unsigned() {
                     ColumnDef {
                         name: Ident::new("bar_tinyint"),
                         data_type: DataType::UnsignedTinyInt(Some(3)),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_smallint"),
                         data_type: DataType::UnsignedSmallInt(Some(5)),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_mediumint"),
                         data_type: DataType::UnsignedMediumInt(Some(13)),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_int"),
                         data_type: DataType::UnsignedInt(Some(11)),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::new("bar_bigint"),
                         data_type: DataType::UnsignedBigInt(Some(20)),
-                        collation: None,
                         options: vec![],
                     },
                 ],
@@ -2159,7 +2140,6 @@ fn parse_alter_table_add_column() {
                     column_def: ColumnDef {
                         name: "b".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![],
                     },
                     column_position: Some(MySQLColumnPosition::First),
@@ -2189,7 +2169,6 @@ fn parse_alter_table_add_column() {
                     column_def: ColumnDef {
                         name: "b".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![],
                     },
                     column_position: Some(MySQLColumnPosition::After(Ident {
@@ -2229,7 +2208,6 @@ fn parse_alter_table_add_columns() {
                         column_def: ColumnDef {
                             name: "a".into(),
                             data_type: DataType::Text,
-                            collation: None,
                             options: vec![],
                         },
                         column_position: Some(MySQLColumnPosition::First),
@@ -2240,7 +2218,6 @@ fn parse_alter_table_add_columns() {
                         column_def: ColumnDef {
                             name: "b".into(),
                             data_type: DataType::Int(None),
-                            collation: None,
                             options: vec![],
                         },
                         column_position: Some(MySQLColumnPosition::After(Ident {
@@ -2593,7 +2570,6 @@ fn parse_table_column_option_on_update() {
                 vec![ColumnDef {
                     name: Ident::with_quote('`', "modification_time"),
                     data_type: DataType::Datetime(None),
-                    collation: None,
                     options: vec![ColumnOptionDef {
                         name: None,
                         option: ColumnOption::OnUpdate(call("CURRENT_TIMESTAMP", [])),
@@ -2878,21 +2854,27 @@ fn parse_convert_using() {
 #[test]
 fn parse_create_table_with_column_collate() {
     let sql = "CREATE TABLE tb (id TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci)";
-    let canonical = "CREATE TABLE tb (id TEXT COLLATE utf8mb4_0900_ai_ci CHARACTER SET utf8mb4)";
-    match mysql().one_statement_parses_to(sql, canonical) {
+    match mysql().verified_stmt(sql) {
         Statement::CreateTable(CreateTable { name, columns, .. }) => {
             assert_eq!(name.to_string(), "tb");
             assert_eq!(
                 vec![ColumnDef {
                     name: Ident::new("id"),
                     data_type: DataType::Text,
-                    collation: Some(ObjectName::from(vec![Ident::new("utf8mb4_0900_ai_ci")])),
-                    options: vec![ColumnOptionDef {
-                        name: None,
-                        option: ColumnOption::CharacterSet(ObjectName::from(vec![Ident::new(
-                            "utf8mb4"
-                        )]))
-                    }],
+                    options: vec![
+                        ColumnOptionDef {
+                            name: None,
+                            option: ColumnOption::CharacterSet(ObjectName::from(vec![Ident::new(
+                                "utf8mb4"
+                            )]))
+                        },
+                        ColumnOptionDef {
+                            name: None,
+                            option: ColumnOption::Collation(ObjectName::from(vec![Ident::new(
+                                "utf8mb4_0900_ai_ci"
+                            )]))
+                        }
+                    ],
                 },],
                 columns
             );

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -363,7 +363,6 @@ fn parse_create_table_with_defaults() {
                     ColumnDef {
                         name: "customer_id".into(),
                         data_type: DataType::Integer(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Default(
@@ -374,7 +373,6 @@ fn parse_create_table_with_defaults() {
                     ColumnDef {
                         name: "store_id".into(),
                         data_type: DataType::SmallInt(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::NotNull,
@@ -388,7 +386,6 @@ fn parse_create_table_with_defaults() {
                                 unit: None
                             }
                         )),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::NotNull,
@@ -402,11 +399,18 @@ fn parse_create_table_with_defaults() {
                                 unit: None
                             }
                         )),
-                        collation: Some(ObjectName::from(vec![Ident::with_quote('"', "es_ES")])),
-                        options: vec![ColumnOptionDef {
-                            name: None,
-                            option: ColumnOption::NotNull,
-                        }],
+                        options: vec![
+                            ColumnOptionDef {
+                                name: None,
+                                option: ColumnOption::Collation(ObjectName::from(vec![
+                                    Ident::with_quote('"', "es_ES")
+                                ])),
+                            },
+                            ColumnOptionDef {
+                                name: None,
+                                option: ColumnOption::NotNull,
+                            }
+                        ],
                     },
                     ColumnDef {
                         name: "email".into(),
@@ -416,13 +420,11 @@ fn parse_create_table_with_defaults() {
                                 unit: None
                             }
                         )),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: "address_id".into(),
                         data_type: DataType::SmallInt(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::NotNull
@@ -431,7 +433,6 @@ fn parse_create_table_with_defaults() {
                     ColumnDef {
                         name: "activebool".into(),
                         data_type: DataType::Boolean,
-                        collation: None,
                         options: vec![
                             ColumnOptionDef {
                                 name: None,
@@ -446,7 +447,6 @@ fn parse_create_table_with_defaults() {
                     ColumnDef {
                         name: "create_date".into(),
                         data_type: DataType::Date,
-                        collation: None,
                         options: vec![
                             ColumnOptionDef {
                                 name: None,
@@ -461,7 +461,6 @@ fn parse_create_table_with_defaults() {
                     ColumnDef {
                         name: "last_update".into(),
                         data_type: DataType::Timestamp(None, TimezoneInfo::WithoutTimeZone),
-                        collation: None,
                         options: vec![
                             ColumnOptionDef {
                                 name: None,
@@ -476,7 +475,6 @@ fn parse_create_table_with_defaults() {
                     ColumnDef {
                         name: "active".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::NotNull
@@ -842,7 +840,6 @@ fn parse_alter_table_add_columns() {
                         column_def: ColumnDef {
                             name: "a".into(),
                             data_type: DataType::Text,
-                            collation: None,
                             options: vec![],
                         },
                         column_position: None,
@@ -853,7 +850,6 @@ fn parse_alter_table_add_columns() {
                         column_def: ColumnDef {
                             name: "b".into(),
                             data_type: DataType::Int(None),
-                            collation: None,
                             options: vec![],
                         },
                         column_position: None,
@@ -4291,37 +4287,31 @@ fn parse_create_table_with_alias() {
                     ColumnDef {
                         name: "int8_col".into(),
                         data_type: DataType::Int8(None),
-                        collation: None,
                         options: vec![]
                     },
                     ColumnDef {
                         name: "int4_col".into(),
                         data_type: DataType::Int4(None),
-                        collation: None,
                         options: vec![]
                     },
                     ColumnDef {
                         name: "int2_col".into(),
                         data_type: DataType::Int2(None),
-                        collation: None,
                         options: vec![]
                     },
                     ColumnDef {
                         name: "float8_col".into(),
                         data_type: DataType::Float8,
-                        collation: None,
                         options: vec![]
                     },
                     ColumnDef {
                         name: "float4_col".into(),
                         data_type: DataType::Float4,
-                        collation: None,
                         options: vec![]
                     },
                     ColumnDef {
                         name: "bool_col".into(),
                         data_type: DataType::Bool,
-                        collation: None,
                         options: vec![]
                     },
                 ]
@@ -4343,13 +4333,11 @@ fn parse_create_table_with_partition_by() {
                     ColumnDef {
                         name: "a".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![]
                     },
                     ColumnDef {
                         name: "b".into(),
                         data_type: DataType::Text,
-                        collation: None,
                         options: vec![]
                     }
                 ],
@@ -5093,25 +5081,21 @@ fn parse_trigger_related_functions() {
                 ColumnDef {
                     name: "empname".into(),
                     data_type: DataType::Text,
-                    collation: None,
                     options: vec![],
                 },
                 ColumnDef {
                     name: "salary".into(),
                     data_type: DataType::Integer(None),
-                    collation: None,
                     options: vec![],
                 },
                 ColumnDef {
                     name: "last_date".into(),
                     data_type: DataType::Timestamp(None, TimezoneInfo::None),
-                    collation: None,
                     options: vec![],
                 },
                 ColumnDef {
                     name: "last_user".into(),
                     data_type: DataType::Text,
-                    collation: None,
                     options: vec![],
                 },
             ],
@@ -5445,13 +5429,11 @@ fn parse_varbit_datatype() {
                     ColumnDef {
                         name: "x".into(),
                         data_type: DataType::VarBit(None),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: "y".into(),
                         data_type: DataType::VarBit(Some(42)),
-                        collation: None,
                         options: vec![],
                     }
                 ]

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -346,7 +346,6 @@ fn test_snowflake_create_table_column_comment() {
                         name: None,
                         option: ColumnOption::Comment("some comment".to_string())
                     }],
-                    collation: None
                 }],
                 columns
             )
@@ -553,7 +552,6 @@ fn test_snowflake_create_table_with_autoincrement_columns() {
                     ColumnDef {
                         name: "a".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Identity(IdentityPropertyKind::Autoincrement(
@@ -567,7 +565,6 @@ fn test_snowflake_create_table_with_autoincrement_columns() {
                     ColumnDef {
                         name: "b".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Identity(IdentityPropertyKind::Autoincrement(
@@ -586,7 +583,6 @@ fn test_snowflake_create_table_with_autoincrement_columns() {
                     ColumnDef {
                         name: "c".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Identity(IdentityPropertyKind::Identity(
@@ -600,7 +596,6 @@ fn test_snowflake_create_table_with_autoincrement_columns() {
                     ColumnDef {
                         name: "d".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Identity(IdentityPropertyKind::Identity(
@@ -634,8 +629,12 @@ fn test_snowflake_create_table_with_collated_column() {
                 vec![ColumnDef {
                     name: "a".into(),
                     data_type: DataType::Text,
-                    collation: Some(ObjectName::from(vec![Ident::with_quote('\'', "de_DE")])),
-                    options: vec![]
+                    options: vec![ColumnOptionDef {
+                        name: None,
+                        option: ColumnOption::Collation(ObjectName::from(vec![Ident::with_quote(
+                            '\'', "de_DE"
+                        )])),
+                    }]
                 },]
             );
         }
@@ -674,7 +673,6 @@ fn test_snowflake_create_table_with_columns_masking_policy() {
                     vec![ColumnDef {
                         name: "a".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Policy(ColumnPolicy::MaskingPolicy(
@@ -709,7 +707,6 @@ fn test_snowflake_create_table_with_columns_projection_policy() {
                     vec![ColumnDef {
                         name: "a".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Policy(ColumnPolicy::ProjectionPolicy(
@@ -747,7 +744,6 @@ fn test_snowflake_create_table_with_columns_tags() {
                     vec![ColumnDef {
                         name: "a".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::Tags(TagsColumnOption {
@@ -782,7 +778,6 @@ fn test_snowflake_create_table_with_several_column_options() {
                     ColumnDef {
                         name: "a".into(),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![
                             ColumnOptionDef {
                                 name: None,
@@ -818,8 +813,13 @@ fn test_snowflake_create_table_with_several_column_options() {
                     ColumnDef {
                         name: "b".into(),
                         data_type: DataType::Text,
-                        collation: Some(ObjectName::from(vec![Ident::with_quote('\'', "de_DE")])),
                         options: vec![
+                            ColumnOptionDef {
+                                name: None,
+                                option: ColumnOption::Collation(ObjectName::from(vec![
+                                    Ident::with_quote('\'', "de_DE")
+                                ])),
+                            },
                             ColumnOptionDef {
                                 name: None,
                                 option: ColumnOption::Policy(ColumnPolicy::ProjectionPolicy(

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -214,7 +214,6 @@ fn parse_create_table_auto_increment() {
                 vec![ColumnDef {
                     name: "bar".into(),
                     data_type: DataType::Int(None),
-                    collation: None,
                     options: vec![
                         ColumnOptionDef {
                             name: None,
@@ -243,7 +242,6 @@ fn parse_create_table_primary_key_asc_desc() {
     let expected_column_def = |kind| ColumnDef {
         name: "bar".into(),
         data_type: DataType::Int(None),
-        collation: None,
         options: vec![
             ColumnOptionDef {
                 name: None,
@@ -286,13 +284,11 @@ fn parse_create_sqlite_quote() {
                     ColumnDef {
                         name: Ident::with_quote('"', "KEY"),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![],
                     },
                     ColumnDef {
                         name: Ident::with_quote('[', "INDEX"),
                         data_type: DataType::Int(None),
-                        collation: None,
                         options: vec![],
                     },
                 ],


### PR DESCRIPTION
This allows preserving the orderings of column options.

We also no longer hardcode a list of dialects which accept a column collation, as it's part of the SQL standard and some dialects which do support it were missing from the list (e.g. MSSQL).