### PR TITLE
Add support column prefix index for MySQL

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -32,8 +32,9 @@ use crate::ast::value::escape_single_quote_string;
 use crate::ast::{
     display_comma_separated, display_separated, CommentDef, CreateFunctionBody,
     CreateFunctionUsing, DataType, Expr, FunctionBehavior, FunctionCalledOnNull,
-    FunctionDeterminismSpecifier, FunctionParallel, Ident, MySQLColumnPosition, ObjectName,
-    OperateFunctionArg, OrderByExpr, ProjectionSelect, SequenceOptions, SqlOption, Tag, Value,
+    FunctionDeterminismSpecifier, FunctionParallel, Ident, IndexExpr, MySQLColumnPosition,
+    ObjectName, OperateFunctionArg, OrderByExpr, ProjectionSelect, SequenceOptions, SqlOption, Tag,
+    Value,
 };
 use crate::keywords::Keyword;
 use crate::tokenizer::Token;
@@ -833,7 +834,7 @@ pub enum TableConstraint {
         /// [1]: IndexType
         index_type: Option<IndexType>,
         /// Index expr list.
-        index_exprs: Vec<OrderByExpr>,
+        index_exprs: Vec<IndexExpr>,
         index_options: Vec<IndexOption>,
         characteristics: Option<ConstraintCharacteristics>,
         /// Optional Postgres nulls handling: `[ NULLS [ NOT ] DISTINCT ]`
@@ -869,7 +870,7 @@ pub enum TableConstraint {
         /// [1]: IndexType
         index_type: Option<IndexType>,
         /// Index expr list.
-        index_exprs: Vec<OrderByExpr>,
+        index_exprs: Vec<IndexExpr>,
         index_options: Vec<IndexOption>,
         characteristics: Option<ConstraintCharacteristics>,
     },
@@ -908,7 +909,7 @@ pub enum TableConstraint {
         /// [1]: IndexType
         index_type: Option<IndexType>,
         /// Index expr list.
-        index_exprs: Vec<OrderByExpr>,
+        index_exprs: Vec<IndexExpr>,
     },
     /// MySQLs [fulltext][1] definition. Since the [`SPATIAL`][2] definition is exactly the same,
     /// and MySQL displays both the same way, it is part of this definition as well.
@@ -931,7 +932,7 @@ pub enum TableConstraint {
         /// Optional index name.
         opt_index_name: Option<Ident>,
         /// Index expr list.
-        index_exprs: Vec<OrderByExpr>,
+        index_exprs: Vec<IndexExpr>,
     },
 }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1049,16 +1049,6 @@ pub enum Expr {
     /// [Databricks](https://docs.databricks.com/en/sql/language-manual/sql-ref-lambda-functions.html)
     /// [DuckDb](https://duckdb.org/docs/sql/functions/lambda.html)
     Lambda(LambdaFunction),
-    /// A ColumnPrefix used in MySQL indexes.
-    /// ```sql
-    /// CREATE INDEX ON tbl (col(10));
-    /// ```
-    ///
-    /// [MySQL](https://dev.mysql.com/doc/refman/8.0/en/create-index.html)
-    ColumnPrefix {
-        column: Ident,
-        length: u64,
-    },
 }
 
 /// The contents inside the `[` and `]` in a subscript expression.
@@ -1827,7 +1817,6 @@ impl fmt::Display for Expr {
             }
             Expr::Prior(expr) => write!(f, "PRIOR {expr}"),
             Expr::Lambda(lambda) => write!(f, "{lambda}"),
-            Expr::ColumnPrefix { column, length } => write!(f, "{column}({length})"),
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8690,6 +8690,61 @@ pub enum CopyIntoSnowflakeKind {
     Location,
 }
 
+/// Index Field
+///
+/// This structure used here [`MySQL` CREATE INDEX][1], [`PostgreSQL` CREATE INDEX][2], [`MySQL` CREATE TABLE][3].
+///
+/// [1]: https://dev.mysql.com/doc/refman/8.3/en/create-index.html
+/// [2]: https://www.postgresql.org/docs/17/sql-createindex.html
+/// [3]: https://dev.mysql.com/doc/refman/8.3/en/create-table.html
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct IndexField {
+    pub expr: IndexExpr,
+    /// Optional `ASC` or `DESC`
+    pub asc: Option<bool>,
+}
+
+impl fmt::Display for IndexField {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.expr)?;
+        match self.asc {
+            Some(true) => write!(f, " ASC")?,
+            Some(false) => write!(f, " DESC")?,
+            None => (),
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum IndexExpr {
+    Column(Ident),
+    /// Mysql specific syntax
+    ///
+    /// See [Mysql documentation](https://dev.mysql.com/doc/refman/8.3/en/create-index.html)
+    /// for more details.
+    ColumnPrefix {
+        column: Ident,
+        length: u64,
+    },
+    Functional(Box<Expr>),
+}
+
+impl fmt::Display for IndexExpr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            IndexExpr::Column(column) => write!(f, "{}", column),
+            IndexExpr::ColumnPrefix { column, length } => write!(f, "{column}({length})"),
+            IndexExpr::Functional(expr) => write!(f, "({expr})"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8701,6 +8701,37 @@ pub enum CopyIntoSnowflakeKind {
     Location,
 }
 
+/// Index Field
+///
+/// This structure used here [`MySQL` CREATE INDEX][1], [`PostgreSQL` CREATE INDEX][2], [`MySQL` CREATE TABLE][3].
+///
+/// [1]: https://dev.mysql.com/doc/refman/8.3/en/create-index.html
+/// [2]: https://www.postgresql.org/docs/17/sql-createindex.html
+/// [3]: https://dev.mysql.com/doc/refman/8.3/en/create-table.html
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct IndexExpr {
+    pub expr: Expr,
+    pub collation: Option<ObjectName>,
+    pub operator_class: Option<Expr>,
+    pub order_options: OrderByOptions,
+}
+
+impl fmt::Display for IndexExpr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.expr)?;
+        if let Some(collation) = &self.collation {
+            write!(f, "{collation}")?;
+        }
+        if let Some(operator) = &self.operator_class {
+            write!(f, "{operator}")?;
+        }
+        write!(f, "{}", self.order_options)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -628,7 +628,7 @@ impl Spanned for TableConstraint {
                 index_name,
                 index_type_display: _,
                 index_type: _,
-                columns,
+                index_fields: _,
                 index_options: _,
                 characteristics,
                 nulls_distinct: _,
@@ -636,21 +636,19 @@ impl Spanned for TableConstraint {
                 name.iter()
                     .map(|i| i.span)
                     .chain(index_name.iter().map(|i| i.span))
-                    .chain(columns.iter().map(|i| i.span))
                     .chain(characteristics.iter().map(|i| i.span())),
             ),
             TableConstraint::PrimaryKey {
                 name,
                 index_name,
                 index_type: _,
-                columns,
+                index_fields: _,
                 index_options: _,
                 characteristics,
             } => union_spans(
                 name.iter()
                     .map(|i| i.span)
                     .chain(index_name.iter().map(|i| i.span))
-                    .chain(columns.iter().map(|i| i.span))
                     .chain(characteristics.iter().map(|i| i.span())),
             ),
             TableConstraint::ForeignKey {
@@ -678,23 +676,14 @@ impl Spanned for TableConstraint {
                 display_as_key: _,
                 name,
                 index_type: _,
-                columns,
-            } => union_spans(
-                name.iter()
-                    .map(|i| i.span)
-                    .chain(columns.iter().map(|i| i.span)),
-            ),
+                index_fields: _,
+            } => union_spans(name.iter().map(|i| i.span)),
             TableConstraint::FulltextOrSpatial {
                 fulltext: _,
                 index_type_display: _,
                 opt_index_name,
-                columns,
-            } => union_spans(
-                opt_index_name
-                    .iter()
-                    .map(|i| i.span)
-                    .chain(columns.iter().map(|i| i.span)),
-            ),
+                index_fields: _,
+            } => union_spans(opt_index_name.iter().map(|i| i.span)),
         }
     }
 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -628,7 +628,7 @@ impl Spanned for TableConstraint {
                 index_name,
                 index_type_display: _,
                 index_type: _,
-                index_fields: _,
+                index_exprs,
                 index_options: _,
                 characteristics,
                 nulls_distinct: _,
@@ -636,19 +636,21 @@ impl Spanned for TableConstraint {
                 name.iter()
                     .map(|i| i.span)
                     .chain(index_name.iter().map(|i| i.span))
+                    .chain(index_exprs.iter().map(|i| i.span()))
                     .chain(characteristics.iter().map(|i| i.span())),
             ),
             TableConstraint::PrimaryKey {
                 name,
                 index_name,
                 index_type: _,
-                index_fields: _,
+                index_exprs,
                 index_options: _,
                 characteristics,
             } => union_spans(
                 name.iter()
                     .map(|i| i.span)
                     .chain(index_name.iter().map(|i| i.span))
+                    .chain(index_exprs.iter().map(|i| i.span()))
                     .chain(characteristics.iter().map(|i| i.span())),
             ),
             TableConstraint::ForeignKey {
@@ -676,14 +678,23 @@ impl Spanned for TableConstraint {
                 display_as_key: _,
                 name,
                 index_type: _,
-                index_fields: _,
-            } => union_spans(name.iter().map(|i| i.span)),
+                index_exprs,
+            } => union_spans(
+                name.iter()
+                    .map(|i| i.span)
+                    .chain(index_exprs.iter().map(|i| i.span())),
+            ),
             TableConstraint::FulltextOrSpatial {
                 fulltext: _,
                 index_type_display: _,
                 opt_index_name,
-                index_fields: _,
-            } => union_spans(opt_index_name.iter().map(|i| i.span)),
+                index_exprs,
+            } => union_spans(
+                opt_index_name
+                    .iter()
+                    .map(|i| i.span)
+                    .chain(index_exprs.iter().map(|i| i.span())),
+            ),
         }
     }
 }
@@ -1468,6 +1479,7 @@ impl Spanned for Expr {
             Expr::OuterJoin(expr) => expr.span(),
             Expr::Prior(expr) => expr.span(),
             Expr::Lambda(_) => Span::empty(),
+            Expr::ColumnPrefix { .. } => Span::empty(),
         }
     }
 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1479,7 +1479,6 @@ impl Spanned for Expr {
             Expr::OuterJoin(expr) => expr.span(),
             Expr::Prior(expr) => expr.span(),
             Expr::Lambda(_) => Span::empty(),
-            Expr::ColumnPrefix { .. } => Span::empty(),
         }
     }
 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -27,8 +27,8 @@ use super::{
     CopySource, CreateIndex, CreateTable, CreateTableOptions, Cte, Delete, DoUpdate,
     ExceptSelectItem, ExcludeSelectItem, Expr, ExprWithAlias, Fetch, FromTable, Function,
     FunctionArg, FunctionArgExpr, FunctionArgumentClause, FunctionArgumentList, FunctionArguments,
-    GroupByExpr, HavingBound, IlikeSelectItem, Insert, Interpolate, InterpolateExpr, Join,
-    JoinConstraint, JoinOperator, JsonPath, JsonPathElem, LateralView, MatchRecognizePattern,
+    GroupByExpr, HavingBound, IlikeSelectItem, IndexExpr, Insert, Interpolate, InterpolateExpr,
+    Join, JoinConstraint, JoinOperator, JsonPath, JsonPathElem, LateralView, MatchRecognizePattern,
     Measure, NamedWindowDefinition, ObjectName, ObjectNamePart, Offset, OnConflict,
     OnConflictAction, OnInsert, OrderBy, OrderByExpr, OrderByKind, Partition, PivotValueSource,
     ProjectionSelect, Query, ReferentialAction, RenameSelectItem, ReplaceSelectElement,
@@ -2176,6 +2176,19 @@ impl Spanned for TableObject {
             }
             TableObject::TableFunction(func) => func.span(),
         }
+    }
+}
+
+impl Spanned for IndexExpr {
+    fn span(&self) -> Span {
+        let IndexExpr {
+            expr,
+            collation: _,
+            operator_class: _,
+            order_options: _,
+        } = self;
+
+        union_spans(core::iter::once(expr.span()))
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7654,18 +7654,10 @@ impl<'a> Parser<'a> {
         let expr = self.parse_index_expr()?;
         let options = self.parse_order_by_options()?;
 
-        let with_fill = if dialect_of!(self is ClickHouseDialect | GenericDialect)
-            && self.parse_keywords(&[Keyword::WITH, Keyword::FILL])
-        {
-            Some(self.parse_with_fill()?)
-        } else {
-            None
-        };
-
         Ok(OrderByExpr {
             expr,
             options,
-            with_fill,
+            with_fill: None,
         })
     }
 

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -665,7 +665,7 @@ fn table_constraint_unique_primary_ctor(
     name: Option<Ident>,
     index_name: Option<Ident>,
     index_type: Option<IndexType>,
-    index_fields: Vec<IndexField>,
+    index_exprs: Vec<OrderByExpr>,
     index_options: Vec<IndexOption>,
     characteristics: Option<ConstraintCharacteristics>,
     unique_index_type_display: Option<KeyOrIndexDisplay>,
@@ -676,7 +676,7 @@ fn table_constraint_unique_primary_ctor(
             index_name,
             index_type_display,
             index_type,
-            index_fields,
+            index_exprs,
             index_options,
             characteristics,
             nulls_distinct: NullsDistinctOption::None,
@@ -685,7 +685,7 @@ fn table_constraint_unique_primary_ctor(
             name,
             index_name,
             index_type,
-            index_fields,
+            index_exprs,
             index_options,
             characteristics,
         },
@@ -713,9 +713,13 @@ fn parse_create_table_primary_and_unique_key() {
                     Some(Ident::new("bar_key")),
                     None,
                     None,
-                    vec![IndexField {
-                        expr: IndexExpr::Column(Ident::new("bar")),
-                        asc: None,
+                    vec![OrderByExpr {
+                        expr: Expr::Identifier(Ident::new("bar")),
+                        options: OrderByOptions {
+                            asc: None,
+                            nulls_first: None,
+                        },
+                        with_fill: None,
                     }],
                     vec![],
                     None,
@@ -780,13 +784,21 @@ fn parse_create_table_primary_and_unique_key_with_index_options() {
                     Some(Ident::new("index_name")),
                     None,
                     vec![
-                        IndexField {
-                            expr: IndexExpr::Column(Ident::new("bar")),
-                            asc: None,
+                        OrderByExpr {
+                            expr: Expr::Identifier(Ident::new("bar")),
+                            options: OrderByOptions {
+                                asc: None,
+                                nulls_first: None,
+                            },
+                            with_fill: None,
                         },
-                        IndexField {
-                            expr: IndexExpr::Column(Ident::new("var")),
-                            asc: None,
+                        OrderByExpr {
+                            expr: Expr::Identifier(Ident::new("var")),
+                            options: OrderByOptions {
+                                asc: None,
+                                nulls_first: None,
+                            },
+                            with_fill: None,
                         },
                     ],
                     vec![
@@ -826,9 +838,13 @@ fn parse_create_table_primary_and_unique_key_with_index_type() {
                     None,
                     Some(Ident::new("index_name")),
                     Some(IndexType::BTree),
-                    vec![IndexField {
-                        expr: IndexExpr::Column(Ident::new("bar")),
-                        asc: None,
+                    vec![OrderByExpr {
+                        expr: Expr::Identifier(Ident::new("bar")),
+                        options: OrderByOptions {
+                            asc: None,
+                            nulls_first: None,
+                        },
+                        with_fill: None,
                     }],
                     vec![IndexOption::Using(IndexType::Hash)],
                     None,
@@ -2270,9 +2286,13 @@ fn parse_alter_table_add_keys() {
                     AlterTableOperation::AddConstraint(TableConstraint::PrimaryKey {
                         name: None,
                         index_name: None,
-                        index_fields: vec![IndexField {
-                            expr: IndexExpr::Column(Ident::new("a")),
-                            asc: None
+                        index_exprs: vec![OrderByExpr {
+                            expr: Expr::Identifier(Ident::new("a")),
+                            options: OrderByOptions {
+                                asc: None,
+                                nulls_first: None,
+                            },
+                            with_fill: None,
                         }],
                         index_type: None,
                         index_options: vec![],
@@ -2282,18 +2302,26 @@ fn parse_alter_table_add_keys() {
                         display_as_key: true,
                         name: Some(Ident::new("b")),
                         index_type: None,
-                        index_fields: vec![
-                            IndexField {
-                                expr: IndexExpr::ColumnPrefix {
+                        index_exprs: vec![
+                            OrderByExpr {
+                                expr: Expr::ColumnPrefix {
                                     column: Ident::new("b"),
-                                    length: 20,
+                                    length: 20
                                 },
-                                asc: None,
+                                options: OrderByOptions {
+                                    asc: None,
+                                    nulls_first: None,
+                                },
+                                with_fill: None,
                             },
-                            IndexField {
-                                expr: IndexExpr::Column(Ident::new("c")),
-                                asc: None,
-                            }
+                            OrderByExpr {
+                                expr: Expr::Identifier(Ident::new("c")),
+                                options: OrderByOptions {
+                                    asc: None,
+                                    nulls_first: None,
+                                },
+                                with_fill: None,
+                            },
                         ]
                     })
                 ]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -665,7 +665,7 @@ fn table_constraint_unique_primary_ctor(
     name: Option<Ident>,
     index_name: Option<Ident>,
     index_type: Option<IndexType>,
-    index_exprs: Vec<OrderByExpr>,
+    index_exprs: Vec<IndexExpr>,
     index_options: Vec<IndexOption>,
     characteristics: Option<ConstraintCharacteristics>,
     unique_index_type_display: Option<KeyOrIndexDisplay>,
@@ -713,13 +713,14 @@ fn parse_create_table_primary_and_unique_key() {
                     Some(Ident::new("bar_key")),
                     None,
                     None,
-                    vec![OrderByExpr {
+                    vec![IndexExpr {
                         expr: Expr::Identifier(Ident::new("bar")),
-                        options: OrderByOptions {
+                        collation: None,
+                        operator_class: None,
+                        order_options: OrderByOptions {
                             asc: None,
                             nulls_first: None,
                         },
-                        with_fill: None,
                     }],
                     vec![],
                     None,
@@ -784,21 +785,23 @@ fn parse_create_table_primary_and_unique_key_with_index_options() {
                     Some(Ident::new("index_name")),
                     None,
                     vec![
-                        OrderByExpr {
+                        IndexExpr {
                             expr: Expr::Identifier(Ident::new("bar")),
-                            options: OrderByOptions {
+                            collation: None,
+                            operator_class: None,
+                            order_options: OrderByOptions {
                                 asc: None,
                                 nulls_first: None,
                             },
-                            with_fill: None,
                         },
-                        OrderByExpr {
+                        IndexExpr {
                             expr: Expr::Identifier(Ident::new("var")),
-                            options: OrderByOptions {
+                            collation: None,
+                            operator_class: None,
+                            order_options: OrderByOptions {
                                 asc: None,
                                 nulls_first: None,
                             },
-                            with_fill: None,
                         },
                     ],
                     vec![
@@ -838,13 +841,14 @@ fn parse_create_table_primary_and_unique_key_with_index_type() {
                     None,
                     Some(Ident::new("index_name")),
                     Some(IndexType::BTree),
-                    vec![OrderByExpr {
+                    vec![IndexExpr {
                         expr: Expr::Identifier(Ident::new("bar")),
-                        options: OrderByOptions {
+                        collation: None,
+                        operator_class: None,
+                        order_options: OrderByOptions {
                             asc: None,
                             nulls_first: None,
                         },
-                        with_fill: None,
                     }],
                     vec![IndexOption::Using(IndexType::Hash)],
                     None,
@@ -2286,13 +2290,14 @@ fn parse_alter_table_add_keys() {
                     AlterTableOperation::AddConstraint(TableConstraint::PrimaryKey {
                         name: None,
                         index_name: None,
-                        index_exprs: vec![OrderByExpr {
+                        index_exprs: vec![IndexExpr {
                             expr: Expr::Identifier(Ident::new("a")),
-                            options: OrderByOptions {
+                            collation: None,
+                            operator_class: None,
+                            order_options: OrderByOptions {
                                 asc: None,
                                 nulls_first: None,
                             },
-                            with_fill: None,
                         }],
                         index_type: None,
                         index_options: vec![],
@@ -2303,24 +2308,38 @@ fn parse_alter_table_add_keys() {
                         name: Some(Ident::new("b")),
                         index_type: None,
                         index_exprs: vec![
-                            OrderByExpr {
-                                expr: Expr::ColumnPrefix {
-                                    column: Ident::new("b"),
-                                    length: 20
-                                },
-                                options: OrderByOptions {
+                            IndexExpr {
+                                expr: Expr::Function(Function {
+                                    name: ObjectName::from(vec![Ident::new("b")]),
+                                    uses_odbc_syntax: false,
+                                    parameters: FunctionArguments::None,
+                                    args: FunctionArguments::List(FunctionArgumentList {
+                                        duplicate_treatment: None,
+                                        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(
+                                            Expr::Value(crate::test_utils::number("20"))
+                                        )),],
+                                        clauses: vec![],
+                                    }),
+                                    filter: None,
+                                    null_treatment: None,
+                                    over: None,
+                                    within_group: vec![],
+                                }),
+                                collation: None,
+                                operator_class: None,
+                                order_options: OrderByOptions {
                                     asc: None,
                                     nulls_first: None,
                                 },
-                                with_fill: None,
                             },
-                            OrderByExpr {
+                            IndexExpr {
                                 expr: Expr::Identifier(Ident::new("c")),
-                                options: OrderByOptions {
+                                collation: None,
+                                operator_class: None,
+                                order_options: OrderByOptions {
                                     asc: None,
                                     nulls_first: None,
                                 },
-                                with_fill: None,
                             },
                         ]
                     })


### PR DESCRIPTION
This pull request add support for column prefixe and functional indexes in MySQL's `CREATE TABLE` and `ALTER TABLE` statements.
```sql
 ALTER TABLE `tbl_1` ADD KEY `idx_1` (col_1(10) DESC, (LOWER(col_2)));
```
May fix parts of #302  .
