### PR TITLE
feat: adjust create and drop trigger for mysql dialect

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3204,7 +3204,7 @@ pub enum Statement {
     DropTrigger {
         if_exists: bool,
         trigger_name: ObjectName,
-        table_name: ObjectName,
+        table_name: Option<ObjectName>,
         /// `CASCADE` or `RESTRICT`
         option: Option<ReferentialAction>,
     },
@@ -4010,7 +4010,10 @@ impl fmt::Display for Statement {
                 if *if_exists {
                     write!(f, " IF EXISTS")?;
                 }
-                write!(f, " {trigger_name} ON {table_name}")?;
+                match &table_name {
+                    Some(table_name) => write!(f, " {trigger_name} ON {table_name}")?,
+                    None => write!(f, " {trigger_name}")?,
+                };
                 if let Some(option) = option {
                     write!(f, " {option}")?;
                 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3303,5 +3303,7 @@ fn parse_drop_trigger() {
         }
     );
     let sql_drop_trigger_invalid = "DROP TRIGGER emp_stamp on emp;";
-    assert!(mysql().parse_sql_statements(sql_drop_trigger_invalid).is_err());
+    assert!(mysql()
+        .parse_sql_statements(sql_drop_trigger_invalid)
+        .is_err());
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3302,8 +3302,4 @@ fn parse_drop_trigger() {
             option: None,
         }
     );
-    let sql_drop_trigger_invalid = "DROP TRIGGER emp_stamp on emp;";
-    assert!(mysql()
-        .parse_sql_statements(sql_drop_trigger_invalid)
-        .is_err());
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4958,7 +4958,7 @@ fn parse_drop_trigger() {
                 Statement::DropTrigger {
                     if_exists,
                     trigger_name: ObjectName::from(vec![Ident::new("check_update")]),
-                    table_name: ObjectName::from(vec![Ident::new("table_name")]),
+                    table_name: Some(ObjectName::from(vec![Ident::new("table_name")])),
                     option
                 }
             );
@@ -5211,7 +5211,7 @@ fn parse_trigger_related_functions() {
         Statement::DropTrigger {
             if_exists: false,
             trigger_name: ObjectName::from(vec![Ident::new("emp_stamp")]),
-            table_name: ObjectName::from(vec![Ident::new("emp")]),
+            table_name: Some(ObjectName::from(vec![Ident::new("emp")])),
             option: None
         }
     );


### PR DESCRIPTION
Hi guys!

Mysql triggers are also a thing!

Cant parse `drop trigger a;` on mysql dialect, also should be able to parse create trigger for mysql dialect.

Appreciate all the hard work!

Let me know if I need to fix or cleanup anything.