### PR TITLE
Ignore escaped LIKE wildcards in MySQL

### DIFF
--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -62,6 +62,10 @@ impl Dialect for MySqlDialect {
         true
     }
 
+    fn ignores_wildcard_escapes(&self) -> bool {
+        true
+    }
+
     fn supports_numeric_prefix(&self) -> bool {
         true
     }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -2628,6 +2628,17 @@ fn parse_rlike_and_regexp() {
 }
 
 #[test]
+fn parse_like_with_escape() {
+    // verify backslash is not stripped for escaped wildcards
+    mysql().verified_only_select(r#"SELECT 'a\%c' LIKE 'a\%c'"#);
+    mysql().verified_only_select(r#"SELECT 'a\_c' LIKE 'a\_c'"#);
+    mysql().verified_only_select(r#"SELECT '%\_\%' LIKE '%\_\%'"#);
+    mysql().verified_only_select(r#"SELECT '\_\%' LIKE CONCAT('\_', '\%')"#);
+    mysql().verified_only_select(r#"SELECT 'a%c' LIKE 'a$%c' ESCAPE '$'"#);
+    mysql().verified_only_select(r#"SELECT 'a_c' LIKE 'a#_c' ESCAPE '#'"#);
+}
+
+#[test]
 fn parse_kill() {
     let stmt = mysql_and_generic().verified_stmt("KILL CONNECTION 5");
     assert_eq!(


### PR DESCRIPTION
MySQL has a special case for escaped LIKE wildcards appearing in string literals: the escaping is ignored, whereas normally for any other (non-special) character, the backslash would be stripped.

This is implemented with a new flag on dialect which gets passed into the tokenizer, because I don't know if any other dialects have similar behavior and wanted to make it easy to add them if they do. I can't currently test Snowflake, BigQuery, or Clickhouse on this point, so I'm just going off my best guess based on docs and examples.

[MySQL docs](https://dev.mysql.com/doc/refman/8.4/en/string-literals.html) (see "Table 11.1 Special Character Escape Sequences" and note following)