### PR TITLE
Parse casting to array using double colon operator in Redshift

### DIFF
--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -82,7 +82,7 @@ impl Dialect for DuckDbDialect {
     }
 
     // See DuckDB <https://duckdb.org/docs/sql/data_types/array.html#defining-an-array-field>
-    fn supports_array_typedef_size(&self) -> bool {
+    fn supports_array_typedef_with_brackets(&self) -> bool {
         true
     }
 

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -148,7 +148,7 @@ impl Dialect for GenericDialect {
         true
     }
 
-    fn supports_array_typedef_size(&self) -> bool {
+    fn supports_array_typedef_with_brackets(&self) -> bool {
         true
     }
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -931,9 +931,11 @@ pub trait Dialect: Debug + Any {
         false
     }
 
-    /// Returns true if the dialect supports size definition for array types.
-    /// For example: ```CREATE TABLE my_table (my_array INT[3])```.
-    fn supports_array_typedef_size(&self) -> bool {
+    /// Returns true if the dialect supports array type definition with brackets with
+    /// an optional size. For example:
+    /// ```CREATE TABLE my_table (arr1 INT[], arr2 INT[3])```
+    /// ```SELECT x::INT[]```
+    fn supports_array_typedef_with_brackets(&self) -> bool {
         false
     }
     /// Returns true if the dialect supports geometric types.

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -247,7 +247,7 @@ impl Dialect for PostgreSqlDialect {
     }
 
     /// See: <https://www.postgresql.org/docs/current/arrays.html#ARRAYS-DECLARATION>
-    fn supports_array_typedef_size(&self) -> bool {
+    fn supports_array_typedef_with_brackets(&self) -> bool {
         true
     }
 

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -117,4 +117,8 @@ impl Dialect for RedshiftSqlDialect {
     fn supports_geometric_types(&self) -> bool {
         true
     }
+
+    fn supports_array_typedef_with_brackets(&self) -> bool {
+        true
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9123,9 +9123,9 @@ impl<'a> Parser<'a> {
             _ => self.expected_at("a data type name", next_token_index),
         }?;
 
-        if self.dialect.supports_array_typedef_size() {
-            // Parse array data type size
+        if self.dialect.supports_array_typedef_with_brackets() {
             while self.consume_token(&Token::LBracket) {
+                // Parse optional array data type size
                 let size = self.maybe_parse(|p| p.parse_literal_uint())?;
                 self.expect_token(&Token::RBracket)?;
                 data = DataType::Array(ArrayElemTypeDef::SquareBracket(Box::new(data), size))

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -14218,3 +14218,10 @@ fn test_geometric_binary_operators() {
         }
     ));
 }
+
+#[test]
+fn parse_array_type_def_with_brackets() {
+    let dialects = all_dialects_where(|d| d.supports_array_typedef_with_brackets());
+    dialects.verified_stmt("SELECT x::INT[]");
+    dialects.verified_stmt("SELECT STRING_TO_ARRAY('1,2,3', ',')::INT[3]");
+}


### PR DESCRIPTION
Enabling the parsing of array-type definitions in Redshift using brackets