### PR TITLE
Store spans for Value expressions

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -86,7 +86,7 @@ pub use self::trigger::{
 
 pub use self::value::{
     escape_double_quote_string, escape_quoted_string, DateTimeField, DollarQuotedString,
-    NormalizationForm, TrimWhereField, Value,
+    NormalizationForm, TrimWhereField, Value, ValueWrapper,
 };
 
 use crate::ast::helpers::key_value_options::KeyValueOptions;
@@ -892,7 +892,7 @@ pub enum Expr {
     /// Nested expression e.g. `(foo > bar)` or `(1)`
     Nested(Box<Expr>),
     /// A literal value, such as string, number, date or NULL
-    Value(Value),
+    Value(ValueWrapper),
     /// <https://dev.mysql.com/doc/refman/8.0/en/charset-introducer.html>
     IntroducedString {
         introducer: String,
@@ -8733,9 +8733,9 @@ mod tests {
     #[test]
     fn test_interval_display() {
         let interval = Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
-                "123:45.67",
-            )))),
+            value: Box::new(Expr::Value(
+                Value::SingleQuotedString(String::from("123:45.67")).with_empty_span(),
+            )),
             leading_field: Some(DateTimeField::Minute),
             leading_precision: Some(10),
             last_field: Some(DateTimeField::Second),
@@ -8747,7 +8747,9 @@ mod tests {
         );
 
         let interval = Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("5")))),
+            value: Box::new(Expr::Value(
+                Value::SingleQuotedString(String::from("5")).with_empty_span(),
+            )),
             leading_field: Some(DateTimeField::Second),
             leading_precision: Some(1),
             last_field: None,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1036,6 +1036,13 @@ pub enum Expr {
     Lambda(LambdaFunction),
 }
 
+impl Expr {
+    /// Creates a new [`Expr::Value`]
+    pub fn value(value: impl Into<ValueWithSpan>) -> Self {
+        Expr::Value(value.into())
+    }
+}
+
 /// The contents inside the `[` and `]` in a subscript expression.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -86,7 +86,7 @@ pub use self::trigger::{
 
 pub use self::value::{
     escape_double_quote_string, escape_quoted_string, DateTimeField, DollarQuotedString,
-    NormalizationForm, TrimWhereField, Value, ValueWrapper,
+    NormalizationForm, TrimWhereField, Value, ValueWithSpan,
 };
 
 use crate::ast::helpers::key_value_options::KeyValueOptions;
@@ -892,7 +892,7 @@ pub enum Expr {
     /// Nested expression e.g. `(foo > bar)` or `(1)`
     Nested(Box<Expr>),
     /// A literal value, such as string, number, date or NULL
-    Value(ValueWrapper),
+    Value(ValueWithSpan),
     /// <https://dev.mysql.com/doc/refman/8.0/en/charset-introducer.html>
     IntroducedString {
         introducer: String,

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -21,7 +21,7 @@ use core::iter;
 use crate::tokenizer::Span;
 
 use super::{
-    dcl::SecondaryRoles, value::ValueWrapper, AccessExpr, AlterColumnOperation, AlterIndexOperation, AlterTableOperation, Array, Assignment, AssignmentTarget, CloseCursor, ClusteredIndex, ColumnDef, ColumnOption, ColumnOptionDef, ConflictTarget, ConnectBy, ConstraintCharacteristics, CopySource, CreateIndex, CreateTable, CreateTableOptions, Cte, Delete, DoUpdate, ExceptSelectItem, ExcludeSelectItem, Expr, ExprWithAlias, Fetch, FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArgumentClause, FunctionArgumentList, FunctionArguments, GroupByExpr, HavingBound, IlikeSelectItem, Insert, Interpolate, InterpolateExpr, Join, JoinConstraint, JoinOperator, JsonPath, JsonPathElem, LateralView, MatchRecognizePattern, Measure, NamedWindowDefinition, ObjectName, ObjectNamePart, Offset, OnConflict, OnConflictAction, OnInsert, OrderBy, OrderByExpr, Partition, PivotValueSource, ProjectionSelect, Query, ReferentialAction, RenameSelectItem, ReplaceSelectElement, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SqlOption, Statement, Subscript, SymbolDefinition, TableAlias, TableAliasColumnDef, TableConstraint, TableFactor, TableObject, TableOptionsClustered, TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef, WildcardAdditionalOptions, With, WithFill
+    dcl::SecondaryRoles, value::ValueWithSpan, AccessExpr, AlterColumnOperation, AlterIndexOperation, AlterTableOperation, Array, Assignment, AssignmentTarget, CloseCursor, ClusteredIndex, ColumnDef, ColumnOption, ColumnOptionDef, ConflictTarget, ConnectBy, ConstraintCharacteristics, CopySource, CreateIndex, CreateTable, CreateTableOptions, Cte, Delete, DoUpdate, ExceptSelectItem, ExcludeSelectItem, Expr, ExprWithAlias, Fetch, FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArgumentClause, FunctionArgumentList, FunctionArguments, GroupByExpr, HavingBound, IlikeSelectItem, Insert, Interpolate, InterpolateExpr, Join, JoinConstraint, JoinOperator, JsonPath, JsonPathElem, LateralView, MatchRecognizePattern, Measure, NamedWindowDefinition, ObjectName, ObjectNamePart, Offset, OnConflict, OnConflictAction, OnInsert, OrderBy, OrderByExpr, Partition, PivotValueSource, ProjectionSelect, Query, ReferentialAction, RenameSelectItem, ReplaceSelectElement, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SqlOption, Statement, Subscript, SymbolDefinition, TableAlias, TableAliasColumnDef, TableConstraint, TableFactor, TableObject, TableOptionsClustered, TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef, WildcardAdditionalOptions, With, WithFill
 };
 
 /// Given an iterator of spans, return the [Span::union] of all spans.
@@ -1961,7 +1961,7 @@ impl Spanned for TableAliasColumnDef {
 }
 
 
-impl Spanned for ValueWrapper {
+impl Spanned for ValueWithSpan {
     fn span(&self) -> Span {
         self.span
     }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -21,21 +21,7 @@ use core::iter;
 use crate::tokenizer::Span;
 
 use super::{
-    dcl::SecondaryRoles, AccessExpr, AlterColumnOperation, AlterIndexOperation,
-    AlterTableOperation, Array, Assignment, AssignmentTarget, CloseCursor, ClusteredIndex,
-    ColumnDef, ColumnOption, ColumnOptionDef, ConflictTarget, ConnectBy, ConstraintCharacteristics,
-    CopySource, CreateIndex, CreateTable, CreateTableOptions, Cte, Delete, DoUpdate,
-    ExceptSelectItem, ExcludeSelectItem, Expr, ExprWithAlias, Fetch, FromTable, Function,
-    FunctionArg, FunctionArgExpr, FunctionArgumentClause, FunctionArgumentList, FunctionArguments,
-    GroupByExpr, HavingBound, IlikeSelectItem, Insert, Interpolate, InterpolateExpr, Join,
-    JoinConstraint, JoinOperator, JsonPath, JsonPathElem, LateralView, MatchRecognizePattern,
-    Measure, NamedWindowDefinition, ObjectName, ObjectNamePart, Offset, OnConflict,
-    OnConflictAction, OnInsert, OrderBy, OrderByExpr, Partition, PivotValueSource,
-    ProjectionSelect, Query, ReferentialAction, RenameSelectItem, ReplaceSelectElement,
-    ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SqlOption, Statement, Subscript,
-    SymbolDefinition, TableAlias, TableAliasColumnDef, TableConstraint, TableFactor, TableObject,
-    TableOptionsClustered, TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef,
-    WildcardAdditionalOptions, With, WithFill,
+    dcl::SecondaryRoles, value::ValueWrapper, AccessExpr, AlterColumnOperation, AlterIndexOperation, AlterTableOperation, Array, Assignment, AssignmentTarget, CloseCursor, ClusteredIndex, ColumnDef, ColumnOption, ColumnOptionDef, ConflictTarget, ConnectBy, ConstraintCharacteristics, CopySource, CreateIndex, CreateTable, CreateTableOptions, Cte, Delete, DoUpdate, ExceptSelectItem, ExcludeSelectItem, Expr, ExprWithAlias, Fetch, FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArgumentClause, FunctionArgumentList, FunctionArguments, GroupByExpr, HavingBound, IlikeSelectItem, Insert, Interpolate, InterpolateExpr, Join, JoinConstraint, JoinOperator, JsonPath, JsonPathElem, LateralView, MatchRecognizePattern, Measure, NamedWindowDefinition, ObjectName, ObjectNamePart, Offset, OnConflict, OnConflictAction, OnInsert, OrderBy, OrderByExpr, Partition, PivotValueSource, ProjectionSelect, Query, ReferentialAction, RenameSelectItem, ReplaceSelectElement, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SqlOption, Statement, Subscript, SymbolDefinition, TableAlias, TableAliasColumnDef, TableConstraint, TableFactor, TableObject, TableOptionsClustered, TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef, WildcardAdditionalOptions, With, WithFill
 };
 
 /// Given an iterator of spans, return the [Span::union] of all spans.
@@ -1974,10 +1960,14 @@ impl Spanned for TableAliasColumnDef {
     }
 }
 
-/// # missing span
-///
-/// The span of a `Value` is currently not implemented, as doing so
-/// requires a breaking changes, which may be done in a future release.
+
+impl Spanned for ValueWrapper {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+/// The span is stored in the `ValueWrapper` struct
 impl Spanned for Value {
     fn span(&self) -> Span {
         Span::empty() // # todo: Value needs to store spans before this is possible

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -21,7 +21,21 @@ use core::iter;
 use crate::tokenizer::Span;
 
 use super::{
-    dcl::SecondaryRoles, value::ValueWithSpan, AccessExpr, AlterColumnOperation, AlterIndexOperation, AlterTableOperation, Array, Assignment, AssignmentTarget, CloseCursor, ClusteredIndex, ColumnDef, ColumnOption, ColumnOptionDef, ConflictTarget, ConnectBy, ConstraintCharacteristics, CopySource, CreateIndex, CreateTable, CreateTableOptions, Cte, Delete, DoUpdate, ExceptSelectItem, ExcludeSelectItem, Expr, ExprWithAlias, Fetch, FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArgumentClause, FunctionArgumentList, FunctionArguments, GroupByExpr, HavingBound, IlikeSelectItem, Insert, Interpolate, InterpolateExpr, Join, JoinConstraint, JoinOperator, JsonPath, JsonPathElem, LateralView, MatchRecognizePattern, Measure, NamedWindowDefinition, ObjectName, ObjectNamePart, Offset, OnConflict, OnConflictAction, OnInsert, OrderBy, OrderByExpr, Partition, PivotValueSource, ProjectionSelect, Query, ReferentialAction, RenameSelectItem, ReplaceSelectElement, ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SqlOption, Statement, Subscript, SymbolDefinition, TableAlias, TableAliasColumnDef, TableConstraint, TableFactor, TableObject, TableOptionsClustered, TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef, WildcardAdditionalOptions, With, WithFill
+    dcl::SecondaryRoles, value::ValueWithSpan, AccessExpr, AlterColumnOperation,
+    AlterIndexOperation, AlterTableOperation, Array, Assignment, AssignmentTarget, CloseCursor,
+    ClusteredIndex, ColumnDef, ColumnOption, ColumnOptionDef, ConflictTarget, ConnectBy,
+    ConstraintCharacteristics, CopySource, CreateIndex, CreateTable, CreateTableOptions, Cte,
+    Delete, DoUpdate, ExceptSelectItem, ExcludeSelectItem, Expr, ExprWithAlias, Fetch, FromTable,
+    Function, FunctionArg, FunctionArgExpr, FunctionArgumentClause, FunctionArgumentList,
+    FunctionArguments, GroupByExpr, HavingBound, IlikeSelectItem, Insert, Interpolate,
+    InterpolateExpr, Join, JoinConstraint, JoinOperator, JsonPath, JsonPathElem, LateralView,
+    MatchRecognizePattern, Measure, NamedWindowDefinition, ObjectName, ObjectNamePart, Offset,
+    OnConflict, OnConflictAction, OnInsert, OrderBy, OrderByExpr, Partition, PivotValueSource,
+    ProjectionSelect, Query, ReferentialAction, RenameSelectItem, ReplaceSelectElement,
+    ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SqlOption, Statement, Subscript,
+    SymbolDefinition, TableAlias, TableAliasColumnDef, TableConstraint, TableFactor, TableObject,
+    TableOptionsClustered, TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef,
+    WildcardAdditionalOptions, With, WithFill,
 };
 
 /// Given an iterator of spans, return the [Span::union] of all spans.
@@ -1959,7 +1973,6 @@ impl Spanned for TableAliasColumnDef {
         name.span
     }
 }
-
 
 impl Spanned for ValueWithSpan {
     fn span(&self) -> Span {

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -31,12 +31,30 @@ use crate::{ast::Ident, tokenizer::Span};
 use sqlparser_derive::{Visit, VisitMut};
 
 /// Primitive SQL values such as number and string
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, Eq, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct ValueWithSpan {
     pub value: Value,
     pub span: Span,
+}
+
+impl PartialEq for ValueWithSpan {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl PartialOrd for ValueWithSpan {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+
+impl core::hash::Hash for ValueWithSpan {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
 }
 
 impl From<ValueWithSpan> for Value {

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -34,13 +34,13 @@ use sqlparser_derive::{Visit, VisitMut};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
-pub struct ValueWrapper {
+pub struct ValueWithSpan {
     pub value: Value,
     pub span: Span,
 }
 
-impl From<ValueWrapper> for Value {
-    fn from(value: ValueWrapper) -> Self {
+impl From<ValueWithSpan> for Value {
+    fn from(value: ValueWithSpan) -> Self {
         value.value
     }
 }
@@ -112,7 +112,7 @@ pub enum Value {
     Placeholder(String),
 }
 
-impl ValueWrapper {
+impl ValueWithSpan {
     /// If the underlying literal is a string, regardless of quote style, returns the associated string value
     pub fn into_string(self) -> Option<String> {
         self.value.into_string()
@@ -144,16 +144,16 @@ impl Value {
         }
     }
 
-    pub fn with_span(self, span: Span) -> ValueWrapper {
-        ValueWrapper { value: self, span }
+    pub fn with_span(self, span: Span) -> ValueWithSpan {
+        ValueWithSpan { value: self, span }
     }
 
-    pub fn with_empty_span(self) -> ValueWrapper {
+    pub fn with_empty_span(self) -> ValueWithSpan {
         self.with_span(Span::empty())
     }
 }
 
-impl fmt::Display for ValueWrapper {
+impl fmt::Display for ValueWithSpan {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.value)
     }

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -63,6 +63,12 @@ impl core::hash::Hash for ValueWithSpan {
     }
 }
 
+impl From<Value> for ValueWithSpan {
+    fn from(value: Value) -> Self {
+        value.with_empty_span()
+    }
+}
+
 impl From<ValueWithSpan> for Value {
     fn from(value: ValueWithSpan) -> Self {
         value.value

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -45,15 +45,15 @@ impl PartialEq for ValueWithSpan {
     }
 }
 
-impl PartialOrd for ValueWithSpan {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.value.partial_cmp(&other.value)
-    }
-}
-
 impl Ord for ValueWithSpan {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.value.cmp(&other.value)
+    }
+}
+
+impl PartialOrd for ValueWithSpan {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(Ord::cmp(self, other))
     }
 }
 

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -30,8 +30,6 @@ use crate::{ast::Ident, tokenizer::Span};
 #[cfg(feature = "visitor")]
 use sqlparser_derive::{Visit, VisitMut};
 
-
-
 /// Wraps a primitive SQL [`Value`]  with its [`Span`] location
 ///
 /// # Example: create a `ValueWithSpan` from a `Value`

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -30,7 +30,42 @@ use crate::{ast::Ident, tokenizer::Span};
 #[cfg(feature = "visitor")]
 use sqlparser_derive::{Visit, VisitMut};
 
-/// Primitive SQL values such as number and string
+
+
+/// Wraps a primitive SQL [`Value`]  with its [`Span`] location
+///
+/// # Example: create a `ValueWithSpan` from a `Value`
+/// ```
+/// # use sqlparser::ast::{Value, ValueWithSpan};
+/// # use sqlparser::tokenizer::{Location, Span};
+/// let value = Value::SingleQuotedString(String::from("endpoint"));
+/// // from line 1, column 1 to line 1, column 7
+/// let span = Span::new(Location::new(1, 1), Location::new(1, 7));
+/// let value_with_span = value.with_span(span);
+/// ```
+///
+/// # Example: create a `ValueWithSpan` from a `Value` with an empty span
+///
+/// You can call [`Value::with_empty_span`] to create a `ValueWithSpan` with an empty span
+/// ```
+/// # use sqlparser::ast::{Value, ValueWithSpan};
+/// # use sqlparser::tokenizer::{Location, Span};
+/// let value = Value::SingleQuotedString(String::from("endpoint"));
+/// let value_with_span = value.with_empty_span();
+/// assert_eq!(value_with_span.span, Span::empty());
+/// ```
+///
+/// You can also use the [`From`] trait to convert  `ValueWithSpan` to/from `Value`s
+/// ```
+/// # use sqlparser::ast::{Value, ValueWithSpan};
+/// # use sqlparser::tokenizer::{Location, Span};
+/// let value = Value::SingleQuotedString(String::from("endpoint"));
+/// // converting `Value` to `ValueWithSpan` results in an empty span
+/// let value_with_span: ValueWithSpan = value.into();
+/// assert_eq!(value_with_span.span, Span::empty());
+/// // convert back to `Value`
+/// let value: Value = value_with_span.into();
+/// ```
 #[derive(Debug, Clone, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -31,7 +31,7 @@ use crate::{ast::Ident, tokenizer::Span};
 use sqlparser_derive::{Visit, VisitMut};
 
 /// Primitive SQL values such as number and string
-#[derive(Debug, Clone, Eq, Ord)]
+#[derive(Debug, Clone, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct ValueWithSpan {
@@ -48,6 +48,12 @@ impl PartialEq for ValueWithSpan {
 impl PartialOrd for ValueWithSpan {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         self.value.partial_cmp(&other.value)
+    }
+}
+
+impl Ord for ValueWithSpan {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.value.cmp(&other.value)
     }
 }
 

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -547,7 +547,7 @@ where
 ///
 /// visit_expressions_mut(&mut statements, |expr| {
 ///   if matches!(expr, Expr::Identifier(col_name) if col_name.value == "x") {
-///     let old_expr = std::mem::replace(expr, Expr::Value(Value::Null));
+///     let old_expr = std::mem::replace(expr, Expr::value(Value::Null));
 ///     *expr = Expr::Function(Function {
 ///           name: ObjectName::from(vec![Ident::new("f")]),
 ///           uses_odbc_syntax: false,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8559,7 +8559,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a literal value (numbers, strings, date/time, booleans)
-    pub fn parse_value(&mut self) -> Result<ValueWrapper, ParserError> {
+    pub fn parse_value(&mut self) -> Result<ValueWithSpan, ParserError> {
         let next_token = self.next_token();
         let span = next_token.span;
         let ok_value = |value: Value| Ok(value.with_span(span));
@@ -8656,7 +8656,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse an unsigned numeric literal
-    pub fn parse_number_value(&mut self) -> Result<ValueWrapper, ParserError> {
+    pub fn parse_number_value(&mut self) -> Result<ValueWithSpan, ParserError> {
         let value_wrapper = self.parse_value()?;
         match &value_wrapper.value {
             Value::Number(_, _) => Ok(value_wrapper),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8628,9 +8628,15 @@ impl<'a> Parser<'a> {
             Token::TripleDoubleQuotedRawStringLiteral(ref s) => {
                 ok_value(Value::TripleDoubleQuotedRawStringLiteral(s.clone()))
             }
-            Token::NationalStringLiteral(ref s) => ok_value(Value::NationalStringLiteral(s.to_string())),
-            Token::EscapedStringLiteral(ref s) => ok_value(Value::EscapedStringLiteral(s.to_string())),
-            Token::UnicodeStringLiteral(ref s) => ok_value(Value::UnicodeStringLiteral(s.to_string())),
+            Token::NationalStringLiteral(ref s) => {
+                ok_value(Value::NationalStringLiteral(s.to_string()))
+            }
+            Token::EscapedStringLiteral(ref s) => {
+                ok_value(Value::EscapedStringLiteral(s.to_string()))
+            }
+            Token::UnicodeStringLiteral(ref s) => {
+                ok_value(Value::UnicodeStringLiteral(s.to_string()))
+            }
             Token::HexStringLiteral(ref s) => ok_value(Value::HexStringLiteral(s.to_string())),
             Token::Placeholder(ref s) => ok_value(Value::Placeholder(s.to_string())),
             tok @ Token::Colon | tok @ Token::AtSign => {
@@ -8725,9 +8731,9 @@ impl<'a> Parser<'a> {
                 self.next_token();
                 Ok(Expr::Value(Value::DollarQuotedString(s).with_span(span)))
             }
-            _ => Ok(Expr::Value(Value::SingleQuotedString(
-                self.parse_literal_string()?,
-            ).with_span(span))),
+            _ => Ok(Expr::Value(
+                Value::SingleQuotedString(self.parse_literal_string()?).with_span(span),
+            )),
         }
     }
 

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -857,7 +857,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::SingleQuotedString("2011-05-05".into()).with_empty_span()
+                Value::DoubleQuotedString("2011-05-05".into()).with_empty_span()
             )],
             fields: vec![StructField {
                 field_name: None,

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -138,13 +138,13 @@ fn parse_literal_string() {
 #[test]
 fn parse_byte_literal() {
     let sql = concat!(
-        "SELECT ",                // line 1, column 1
-        "B'abc', ",              // line 1, column 8
-        r#"B"abc", "#,           // line 1, column 15
+        "SELECT ",                   // line 1, column 1
+        "B'abc', ",                  // line 1, column 8
+        r#"B"abc", "#,               // line 1, column 15
         r#"B'f\(abc,(.*),def\)', "#, // line 1, column 22
         r#"B"f\(abc,(.*),def\)", "#, // line 1, column 42
-        r#"B'''abc''', "#,       // line 1, column 62
-        r#"B"""abc""""#,         // line 1, column 74
+        r#"B'''abc''', "#,           // line 1, column 62
+        r#"B"""abc""""#,             // line 1, column 74
     );
     let stmt = bigquery().verified_stmt(sql);
     if let Statement::Query(query) = stmt {
@@ -206,13 +206,13 @@ fn parse_byte_literal() {
 #[test]
 fn parse_raw_literal() {
     let sql = concat!(
-        "SELECT ",                // line 1, column 1
-        "R'abc', ",              // line 1, column 8
-        r#"R"abc", "#,           // line 1, column 15
+        "SELECT ",                   // line 1, column 1
+        "R'abc', ",                  // line 1, column 8
+        r#"R"abc", "#,               // line 1, column 15
         r#"R'f\(abc,(.*),def\)', "#, // line 1, column 22
         r#"R"f\(abc,(.*),def\)", "#, // line 1, column 42
-        r#"R'''abc''', "#,       // line 1, column 62
-        r#"R"""abc""""#,         // line 1, column 74
+        r#"R'''abc''', "#,           // line 1, column 62
+        r#"R"""abc""""#,             // line 1, column 74
     );
     let stmt = bigquery().verified_stmt(sql);
     if let Statement::Query(query) = stmt {
@@ -335,8 +335,9 @@ fn parse_create_view_with_options() {
                         options: Some(vec![ColumnOption::Options(vec![SqlOption::KeyValue {
                             key: Ident::new("description"),
                             value: Expr::Value(
-                                Value::DoubleQuotedString("field age".to_string())
-                                    .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                                Value::DoubleQuotedString("field age".to_string()).with_span(
+                                    Span::new(Location::new(1, 42), Location::new(1, 52))
+                                )
                             ),
                         }])]),
                     },
@@ -485,8 +486,9 @@ fn parse_create_table_with_options() {
                                 option: ColumnOption::Options(vec![SqlOption::KeyValue {
                                     key: Ident::new("description"),
                                     value: Expr::Value(
-                                        Value::DoubleQuotedString("field x".to_string())
-                                            .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                                        Value::DoubleQuotedString("field x".to_string()).with_span(
+                                            Span::new(Location::new(1, 42), Location::new(1, 52))
+                                        )
                                     ),
                                 },])
                             },
@@ -500,8 +502,9 @@ fn parse_create_table_with_options() {
                             option: ColumnOption::Options(vec![SqlOption::KeyValue {
                                 key: Ident::new("description"),
                                 value: Expr::Value(
-                                    Value::DoubleQuotedString("field y".to_string())
-                                        .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                                    Value::DoubleQuotedString("field y".to_string()).with_span(
+                                        Span::new(Location::new(1, 42), Location::new(1, 52))
+                                    )
                                 ),
                             },])
                         }]
@@ -520,14 +523,20 @@ fn parse_create_table_with_options() {
                         SqlOption::KeyValue {
                             key: Ident::new("partition_expiration_days"),
                             value: Expr::Value(
-                                number("1").with_span(Span::new(Location::new(1, 42), Location::new(1, 43)))
+                                number("1").with_span(Span::new(
+                                    Location::new(1, 42),
+                                    Location::new(1, 43)
+                                ))
                             ),
                         },
                         SqlOption::KeyValue {
                             key: Ident::new("description"),
                             value: Expr::Value(
                                 Value::DoubleQuotedString("table option description".to_string())
-                                    .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                                    .with_span(Span::new(
+                                        Location::new(1, 42),
+                                        Location::new(1, 52)
+                                    ))
                             ),
                         },
                     ])
@@ -636,23 +645,39 @@ fn parse_invalid_brackets() {
 fn parse_tuple_struct_literal() {
     // tuple syntax: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#tuple_syntax
     // syntax: (expr1, expr2 [, ... ])
-    let sql = "SELECT (1, 2, 3), (1, 1.0, '123', true)";  // line 1, column 1
+    let sql = "SELECT (1, 2, 3), (1, 1.0, '123', true)"; // line 1, column 1
     let select = bigquery().verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Tuple(vec![
-            Expr::Value(number("1").with_span(Span::new(Location::new(1, 9), Location::new(1, 10)))),
-            Expr::Value(number("2").with_span(Span::new(Location::new(1, 12), Location::new(1, 13)))),
-            Expr::Value(number("3").with_span(Span::new(Location::new(1, 15), Location::new(1, 16)))),
+            Expr::Value(
+                number("1").with_span(Span::new(Location::new(1, 9), Location::new(1, 10)))
+            ),
+            Expr::Value(
+                number("2").with_span(Span::new(Location::new(1, 12), Location::new(1, 13)))
+            ),
+            Expr::Value(
+                number("3").with_span(Span::new(Location::new(1, 15), Location::new(1, 16)))
+            ),
         ]),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
         &Expr::Tuple(vec![
-            Expr::Value(number("1").with_span(Span::new(Location::new(1, 19), Location::new(1, 20)))),
-            Expr::Value(number("1.0").with_span(Span::new(Location::new(1, 22), Location::new(1, 25)))),
-            Expr::Value(Value::SingleQuotedString("123".into()).with_span(Span::new(Location::new(1, 27), Location::new(1, 32)))),
-            Expr::Value(Value::Boolean(true).with_span(Span::new(Location::new(1, 34), Location::new(1, 38))))
+            Expr::Value(
+                number("1").with_span(Span::new(Location::new(1, 19), Location::new(1, 20)))
+            ),
+            Expr::Value(
+                number("1.0").with_span(Span::new(Location::new(1, 22), Location::new(1, 25)))
+            ),
+            Expr::Value(
+                Value::SingleQuotedString("123".into())
+                    .with_span(Span::new(Location::new(1, 27), Location::new(1, 32)))
+            ),
+            Expr::Value(
+                Value::Boolean(true)
+                    .with_span(Span::new(Location::new(1, 34), Location::new(1, 38)))
+            )
         ]),
         expr_from_projection(&select.projection[1])
     );
@@ -668,9 +693,15 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1").with_span(Span::new(Location::new(1, 15), Location::new(1, 16)))),
-                Expr::Value(number("2").with_span(Span::new(Location::new(1, 18), Location::new(1, 19)))),
-                Expr::Value(number("3").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))),
+                Expr::Value(
+                    number("1").with_span(Span::new(Location::new(1, 15), Location::new(1, 16)))
+                ),
+                Expr::Value(
+                    number("2").with_span(Span::new(Location::new(1, 18), Location::new(1, 19)))
+                ),
+                Expr::Value(
+                    number("3").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
+                ),
             ],
             fields: Default::default()
         },
@@ -679,7 +710,10 @@ fn parse_typeless_struct_syntax() {
 
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedString("abc".into()).with_span(Span::new(Location::new(1, 32), Location::new(1, 37))))],
+            values: vec![Expr::Value(
+                Value::SingleQuotedString("abc".into())
+                    .with_span(Span::new(Location::new(1, 32), Location::new(1, 37)))
+            )],
             fields: Default::default()
         },
         expr_from_projection(&select.projection[1])
@@ -688,7 +722,9 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1").with_span(Span::new(Location::new(1, 47), Location::new(1, 48)))),
+                Expr::Value(
+                    number("1").with_span(Span::new(Location::new(1, 47), Location::new(1, 48)))
+                ),
                 Expr::CompoundIdentifier(vec![Ident::from("t"), Ident::from("str_col")]),
             ],
             fields: Default::default()
@@ -700,11 +736,19 @@ fn parse_typeless_struct_syntax() {
         &Expr::Struct {
             values: vec![
                 Expr::Named {
-                    expr: Expr::Value(number("1").with_span(Span::new(Location::new(1, 66), Location::new(1, 67)))).into(),
+                    expr: Expr::Value(
+                        number("1")
+                            .with_span(Span::new(Location::new(1, 66), Location::new(1, 67)))
+                    )
+                    .into(),
                     name: Ident::from("a")
                 },
                 Expr::Named {
-                    expr: Expr::Value(Value::SingleQuotedString("abc".into()).with_span(Span::new(Location::new(1, 73), Location::new(1, 78)))).into(),
+                    expr: Expr::Value(
+                        Value::SingleQuotedString("abc".into())
+                            .with_span(Span::new(Location::new(1, 73), Location::new(1, 78)))
+                    )
+                    .into(),
                     name: Ident::from("b")
                 },
             ],
@@ -735,7 +779,9 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22))))],
+            values: vec![Expr::Value(
+                number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
@@ -746,7 +792,9 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1").with_span(Span::new(Location::new(1, 48), Location::new(1, 49)))),
+                Expr::Value(
+                    number("1").with_span(Span::new(Location::new(1, 48), Location::new(1, 49)))
+                ),
                 Expr::CompoundIdentifier(vec![
                     Ident {
                         value: "t".into(),
@@ -844,7 +892,10 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::Boolean(true).with_span(Span::new(Location::new(1, 20), Location::new(1, 24))))],
+            values: vec![Expr::Value(
+                Value::Boolean(true)
+                    .with_span(Span::new(Location::new(1, 20), Location::new(1, 24)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bool
@@ -854,7 +905,10 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedByteStringLiteral("abc".into()).with_span(Span::new(Location::new(1, 45), Location::new(1, 51))))],
+            values: vec![Expr::Value(
+                Value::SingleQuotedByteStringLiteral("abc".into())
+                    .with_span(Span::new(Location::new(1, 45), Location::new(1, 51)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bytes(Some(42))
@@ -868,7 +922,10 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(4, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedString("2011-05-05".into()).with_span(Span::new(Location::new(1, 20), Location::new(1, 32))))],
+            values: vec![Expr::Value(
+                Value::SingleQuotedString("2011-05-05".into())
+                    .with_span(Span::new(Location::new(1, 20), Location::new(1, 32)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Date
@@ -880,7 +937,8 @@ fn parse_typed_struct_syntax_bigquery() {
         &Expr::Struct {
             values: vec![Expr::TypedString {
                 data_type: DataType::Datetime(None),
-                value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into()).with_span(Span::new(Location::new(1, 57), Location::new(1, 82)))
+                value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into())
+                    .with_span(Span::new(Location::new(1, 57), Location::new(1, 82)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -891,7 +949,9 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5.0").with_span(Span::new(Location::new(1, 102), Location::new(1, 105))))],
+            values: vec![Expr::Value(
+                number("5.0").with_span(Span::new(Location::new(1, 102), Location::new(1, 105)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
@@ -901,7 +961,9 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("1").with_span(Span::new(Location::new(1, 122), Location::new(1, 123))))],
+            values: vec![Expr::Value(
+                number("1").with_span(Span::new(Location::new(1, 122), Location::new(1, 123)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
@@ -916,7 +978,10 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Interval(Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString("2".into()).with_span(Span::new(Location::new(1, 30), Location::new(1, 33))))),
+                value: Box::new(Expr::Value(
+                    Value::SingleQuotedString("2".into())
+                        .with_span(Span::new(Location::new(1, 30), Location::new(1, 33)))
+                )),
                 leading_field: Some(DateTimeField::Hour),
                 leading_precision: None,
                 last_field: None,
@@ -933,8 +998,10 @@ fn parse_typed_struct_syntax_bigquery() {
         &Expr::Struct {
             values: vec![Expr::TypedString {
                 data_type: DataType::JSON,
-                value: Value::SingleQuotedString(r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into())
-                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
+                value: Value::SingleQuotedString(
+                    r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into()
+                )
+                .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -949,7 +1016,10 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::DoubleQuotedString("foo".into()).with_span(Span::new(Location::new(1, 25), Location::new(1, 30))))],
+            values: vec![Expr::Value(
+                Value::DoubleQuotedString("foo".into())
+                    .with_span(Span::new(Location::new(1, 25), Location::new(1, 30)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::String(Some(42))
@@ -1026,8 +1096,12 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1").with_span(Span::new(Location::new(1, 38), Location::new(1, 39)))),
-                Expr::Value(number("2").with_span(Span::new(Location::new(1, 41), Location::new(1, 42)))),
+                Expr::Value(
+                    number("1").with_span(Span::new(Location::new(1, 38), Location::new(1, 39)))
+                ),
+                Expr::Value(
+                    number("2").with_span(Span::new(Location::new(1, 41), Location::new(1, 42)))
+                ),
             ],
             fields: vec![
                 StructField {
@@ -1054,7 +1128,9 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22))))],
+            values: vec![Expr::Value(
+                number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
@@ -1065,7 +1141,9 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1").with_span(Span::new(Location::new(1, 48), Location::new(1, 49)))),
+                Expr::Value(
+                    number("1").with_span(Span::new(Location::new(1, 48), Location::new(1, 49)))
+                ),
                 Expr::CompoundIdentifier(vec![
                     Ident {
                         value: "t".into(),
@@ -1135,7 +1213,10 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::Boolean(true).with_span(Span::new(Location::new(1, 20), Location::new(1, 24))))],
+            values: vec![Expr::Value(
+                Value::Boolean(true)
+                    .with_span(Span::new(Location::new(1, 20), Location::new(1, 24)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bool
@@ -1145,7 +1226,10 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedByteStringLiteral("abc".into()).with_span(Span::new(Location::new(1, 45), Location::new(1, 51))))],
+            values: vec![Expr::Value(
+                Value::SingleQuotedByteStringLiteral("abc".into())
+                    .with_span(Span::new(Location::new(1, 45), Location::new(1, 51)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bytes(Some(42))
@@ -1159,7 +1243,10 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(4, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedString("2011-05-05".into()).with_span(Span::new(Location::new(1, 20), Location::new(1, 32))))],
+            values: vec![Expr::Value(
+                Value::SingleQuotedString("2011-05-05".into())
+                    .with_span(Span::new(Location::new(1, 20), Location::new(1, 32)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Date
@@ -1171,7 +1258,8 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
         &Expr::Struct {
             values: vec![Expr::TypedString {
                 data_type: DataType::Datetime(None),
-                value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into()).with_span(Span::new(Location::new(1, 57), Location::new(1, 82)))
+                value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into())
+                    .with_span(Span::new(Location::new(1, 57), Location::new(1, 82)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1182,7 +1270,9 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5.0").with_span(Span::new(Location::new(1, 102), Location::new(1, 105))))],
+            values: vec![Expr::Value(
+                number("5.0").with_span(Span::new(Location::new(1, 102), Location::new(1, 105)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
@@ -1192,7 +1282,9 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("1").with_span(Span::new(Location::new(1, 122), Location::new(1, 123))))],
+            values: vec![Expr::Value(
+                number("1").with_span(Span::new(Location::new(1, 122), Location::new(1, 123)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
@@ -1207,7 +1299,10 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Interval(Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString("1".into()).with_span(Span::new(Location::new(1, 30), Location::new(1, 33))))),
+                value: Box::new(Expr::Value(
+                    Value::SingleQuotedString("1".into())
+                        .with_span(Span::new(Location::new(1, 30), Location::new(1, 33)))
+                )),
                 leading_field: Some(DateTimeField::Month),
                 leading_precision: None,
                 last_field: None,
@@ -1224,8 +1319,10 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
         &Expr::Struct {
             values: vec![Expr::TypedString {
                 data_type: DataType::JSON,
-                value: Value::SingleQuotedString(r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into())
-                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
+                value: Value::SingleQuotedString(
+                    r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into()
+                )
+                .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1240,7 +1337,10 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedString("foo".into()).with_span(Span::new(Location::new(1, 25), Location::new(1, 30))))],
+            values: vec![Expr::Value(
+                Value::SingleQuotedString("foo".into())
+                    .with_span(Span::new(Location::new(1, 25), Location::new(1, 30)))
+            )],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::String(Some(42))
@@ -1313,12 +1413,14 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
 
 #[test]
 fn parse_typed_struct_with_field_name_bigquery() {
-    let sql = r#"SELECT STRUCT<x INT64>(5), STRUCT<y STRING>("foo")"#;  // line 1, column 1
+    let sql = r#"SELECT STRUCT<x INT64>(5), STRUCT<y STRING>("foo")"#; // line 1, column 1
     let select = bigquery().verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22))))],
+            values: vec![Expr::Value(
+                number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
+            )],
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
@@ -1328,7 +1430,10 @@ fn parse_typed_struct_with_field_name_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::DoubleQuotedString("foo".into()).with_span(Span::new(Location::new(1, 42), Location::new(1, 47))))],
+            values: vec![Expr::Value(
+                Value::DoubleQuotedString("foo".into())
+                    .with_span(Span::new(Location::new(1, 42), Location::new(1, 47)))
+            )],
             fields: vec![StructField {
                 field_name: Some(Ident::from("y")),
                 field_type: DataType::String(None)
@@ -1337,14 +1442,18 @@ fn parse_typed_struct_with_field_name_bigquery() {
         expr_from_projection(&select.projection[1])
     );
 
-    let sql = r#"SELECT STRUCT<x INT64, y INT64>(5, 5)"#;  // line 1, column 1
+    let sql = r#"SELECT STRUCT<x INT64, y INT64>(5, 5)"#; // line 1, column 1
     let select = bigquery().verified_only_select(sql);
     assert_eq!(1, select.projection.len());
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("5").with_span(Span::new(Location::new(1, 32), Location::new(1, 33)))),
-                Expr::Value(number("5").with_span(Span::new(Location::new(1, 35), Location::new(1, 36)))),
+                Expr::Value(
+                    number("5").with_span(Span::new(Location::new(1, 32), Location::new(1, 33)))
+                ),
+                Expr::Value(
+                    number("5").with_span(Span::new(Location::new(1, 35), Location::new(1, 36)))
+                ),
             ],
             fields: vec![
                 StructField {
@@ -1363,12 +1472,14 @@ fn parse_typed_struct_with_field_name_bigquery() {
 
 #[test]
 fn parse_typed_struct_with_field_name_bigquery_and_generic() {
-    let sql = r#"SELECT STRUCT<x INT64>(5), STRUCT<y STRING>('foo')"#;  // line 1, column 1
+    let sql = r#"SELECT STRUCT<x INT64>(5), STRUCT<y STRING>('foo')"#; // line 1, column 1
     let select = bigquery().verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22))))],
+            values: vec![Expr::Value(
+                number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
+            )],
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
@@ -1378,7 +1489,10 @@ fn parse_typed_struct_with_field_name_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedString("foo".into()).with_span(Span::new(Location::new(1, 42), Location::new(1, 47))))],
+            values: vec![Expr::Value(
+                Value::SingleQuotedString("foo".into())
+                    .with_span(Span::new(Location::new(1, 42), Location::new(1, 47)))
+            )],
             fields: vec![StructField {
                 field_name: Some(Ident::from("y")),
                 field_type: DataType::String(None)
@@ -1387,14 +1501,18 @@ fn parse_typed_struct_with_field_name_bigquery_and_generic() {
         expr_from_projection(&select.projection[1])
     );
 
-    let sql = r#"SELECT STRUCT<x INT64, y INT64>(5, 5)"#;  // line 1, column 1
+    let sql = r#"SELECT STRUCT<x INT64, y INT64>(5, 5)"#; // line 1, column 1
     let select = bigquery_and_generic().verified_only_select(sql);
     assert_eq!(1, select.projection.len());
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("5").with_span(Span::new(Location::new(1, 32), Location::new(1, 33)))),
-                Expr::Value(number("5").with_span(Span::new(Location::new(1, 35), Location::new(1, 36)))),
+                Expr::Value(
+                    number("5").with_span(Span::new(Location::new(1, 32), Location::new(1, 33)))
+                ),
+                Expr::Value(
+                    number("5").with_span(Span::new(Location::new(1, 35), Location::new(1, 36)))
+                ),
             ],
             fields: vec![
                 StructField {
@@ -1603,7 +1721,7 @@ fn parse_hyphenated_table_identifiers() {
 #[test]
 fn parse_table_time_travel() {
     let version = "2023-08-18 23:08:18".to_string();
-    let sql = format!("SELECT 1 FROM t1 FOR SYSTEM_TIME AS OF '{version}'");  // line 1, column 1
+    let sql = format!("SELECT 1 FROM t1 FOR SYSTEM_TIME AS OF '{version}'"); // line 1, column 1
     let select = bigquery().verified_only_select(&sql);
     assert_eq!(
         select.from,
@@ -1614,7 +1732,8 @@ fn parse_table_time_travel() {
                 args: None,
                 with_hints: vec![],
                 version: Some(TableVersion::ForSystemTimeAsOf(Expr::Value(
-                    Value::SingleQuotedString(version).with_span(Span::new(Location::new(1, 35), Location::new(1, 54)))
+                    Value::SingleQuotedString(version)
+                        .with_span(Span::new(Location::new(1, 35), Location::new(1, 54)))
                 ))),
                 partitions: vec![],
                 with_ordinality: false,
@@ -1956,7 +2075,7 @@ fn parse_array_agg_func() {
 fn parse_big_query_declare() {
     for (sql, expected_names, expected_data_type, expected_assigned_expr) in [
         (
-            "DECLARE x INT64",  // line 1, column 1
+            "DECLARE x INT64", // line 1, column 1
             vec![Ident::new("x")],
             Some(DataType::Int64),
             None,

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -624,16 +624,16 @@ fn parse_tuple_struct_literal() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Tuple(vec![
-            Expr::Value(number("1").with_empty_span()),
-            Expr::Value(number("2").with_empty_span()),
-            Expr::Value(number("3").with_empty_span()),
+            Expr::value(number("1")),
+            Expr::value(number("2")),
+            Expr::value(number("3")),
         ]),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
         &Expr::Tuple(vec![
-            Expr::Value(number("1").with_empty_span()),
-            Expr::Value(number("1.0").with_empty_span()),
+            Expr::value(number("1")),
+            Expr::value(number("1.0")),
             Expr::Value(Value::SingleQuotedString("123".into()).with_empty_span()),
             Expr::Value(Value::Boolean(true).with_empty_span())
         ]),
@@ -651,9 +651,9 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1").with_empty_span()),
-                Expr::Value(number("2").with_empty_span()),
-                Expr::Value(number("3").with_empty_span()),
+                Expr::value(number("1")),
+                Expr::value(number("2")),
+                Expr::value(number("3")),
             ],
             fields: Default::default()
         },
@@ -673,7 +673,7 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1").with_empty_span()),
+                Expr::value(number("1")),
                 Expr::CompoundIdentifier(vec![Ident::from("t"), Ident::from("str_col")]),
             ],
             fields: Default::default()
@@ -685,7 +685,7 @@ fn parse_typeless_struct_syntax() {
         &Expr::Struct {
             values: vec![
                 Expr::Named {
-                    expr: Expr::Value(number("1").with_empty_span()).into(),
+                    expr: Expr::value(number("1")).into(),
                     name: Ident::from("a")
                 },
                 Expr::Named {
@@ -721,7 +721,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5").with_empty_span())],
+            values: vec![Expr::value(number("5"))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
@@ -732,7 +732,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1").with_empty_span()),
+                Expr::value(number("1")),
                 Expr::CompoundIdentifier(vec![
                     Ident {
                         value: "t".into(),
@@ -881,7 +881,7 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5.0").with_empty_span())],
+            values: vec![Expr::value(number("5.0"))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
@@ -891,7 +891,7 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("1").with_empty_span())],
+            values: vec![Expr::value(number("1"))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
@@ -1016,10 +1016,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(1, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![
-                Expr::Value(number("1").with_empty_span()),
-                Expr::Value(number("2").with_empty_span()),
-            ],
+            values: vec![Expr::value(number("1")), Expr::value(number("2")),],
             fields: vec![
                 StructField {
                     field_name: Some("key".into()),
@@ -1045,7 +1042,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5").with_empty_span())],
+            values: vec![Expr::value(number("5"))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
@@ -1056,7 +1053,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1").with_empty_span()),
+                Expr::value(number("1")),
                 Expr::CompoundIdentifier(vec![
                     Ident {
                         value: "t".into(),
@@ -1177,7 +1174,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5.0").with_empty_span())],
+            values: vec![Expr::value(number("5.0"))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
@@ -1187,7 +1184,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("1").with_empty_span())],
+            values: vec![Expr::value(number("1"))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
@@ -1314,7 +1311,7 @@ fn parse_typed_struct_with_field_name_bigquery() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5").with_empty_span())],
+            values: vec![Expr::value(number("5"))],
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
@@ -1340,10 +1337,7 @@ fn parse_typed_struct_with_field_name_bigquery() {
     assert_eq!(1, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![
-                Expr::Value(number("5").with_empty_span()),
-                Expr::Value(number("5").with_empty_span()),
-            ],
+            values: vec![Expr::value(number("5")), Expr::value(number("5")),],
             fields: vec![
                 StructField {
                     field_name: Some(Ident::from("x")),
@@ -1366,7 +1360,7 @@ fn parse_typed_struct_with_field_name_bigquery_and_generic() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5").with_empty_span())],
+            values: vec![Expr::value(number("5"))],
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
@@ -1392,10 +1386,7 @@ fn parse_typed_struct_with_field_name_bigquery_and_generic() {
     assert_eq!(1, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![
-                Expr::Value(number("5").with_empty_span()),
-                Expr::Value(number("5").with_empty_span()),
-            ],
+            values: vec![Expr::value(number("5")), Expr::value(number("5")),],
             fields: vec![
                 StructField {
                     field_name: Some(Ident::from("x")),
@@ -1683,21 +1674,18 @@ fn parse_merge() {
         columns: vec![Ident::new("product"), Ident::new("quantity")],
         kind: MergeInsertKind::Values(Values {
             explicit_row: false,
-            rows: vec![vec![
-                Expr::Value(number("1").with_empty_span()),
-                Expr::Value(number("2").with_empty_span()),
-            ]],
+            rows: vec![vec![Expr::value(number("1")), Expr::value(number("2"))]],
         }),
     });
     let update_action = MergeAction::Update {
         assignments: vec![
             Assignment {
                 target: AssignmentTarget::ColumnName(ObjectName::from(vec![Ident::new("a")])),
-                value: Expr::Value(number("1").with_empty_span()),
+                value: Expr::value(number("1")),
             },
             Assignment {
                 target: AssignmentTarget::ColumnName(ObjectName::from(vec![Ident::new("b")])),
-                value: Expr::Value(number("2").with_empty_span()),
+                value: Expr::value(number("2")),
             },
         ],
     };
@@ -1751,12 +1739,12 @@ fn parse_merge() {
                 vec![
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatched,
-                        predicate: Some(Expr::Value(number("1").with_empty_span())),
+                        predicate: Some(Expr::value(number("1"))),
                         action: insert_action.clone(),
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatchedByTarget,
-                        predicate: Some(Expr::Value(number("1").with_empty_span())),
+                        predicate: Some(Expr::value(number("1"))),
                         action: insert_action.clone(),
                     },
                     MergeClause {
@@ -1766,7 +1754,7 @@ fn parse_merge() {
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatchedBySource,
-                        predicate: Some(Expr::Value(number("2").with_empty_span())),
+                        predicate: Some(Expr::value(number("2"))),
                         action: MergeAction::Delete
                     },
                     MergeClause {
@@ -1776,12 +1764,12 @@ fn parse_merge() {
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatchedBySource,
-                        predicate: Some(Expr::Value(number("1").with_empty_span())),
+                        predicate: Some(Expr::value(number("1"))),
                         action: update_action.clone(),
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatched,
-                        predicate: Some(Expr::Value(number("1").with_empty_span())),
+                        predicate: Some(Expr::value(number("1"))),
                         action: MergeAction::Insert(MergeInsertExpr {
                             columns: vec![Ident::new("product"), Ident::new("quantity"),],
                             kind: MergeInsertKind::Row,
@@ -1797,7 +1785,7 @@ fn parse_merge() {
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatched,
-                        predicate: Some(Expr::Value(number("1").with_empty_span())),
+                        predicate: Some(Expr::value(number("1"))),
                         action: MergeAction::Insert(MergeInsertExpr {
                             columns: vec![],
                             kind: MergeInsertKind::Row
@@ -1813,7 +1801,7 @@ fn parse_merge() {
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::Matched,
-                        predicate: Some(Expr::Value(number("1").with_empty_span())),
+                        predicate: Some(Expr::value(number("1"))),
                         action: MergeAction::Delete,
                     },
                     MergeClause {
@@ -1829,7 +1817,7 @@ fn parse_merge() {
                             kind: MergeInsertKind::Values(Values {
                                 explicit_row: false,
                                 rows: vec![vec![
-                                    Expr::Value(number("1").with_empty_span()),
+                                    Expr::value(number("1")),
                                     Expr::Identifier(Ident::new("DEFAULT")),
                                 ]]
                             })
@@ -1843,7 +1831,7 @@ fn parse_merge() {
                             kind: MergeInsertKind::Values(Values {
                                 explicit_row: false,
                                 rows: vec![vec![
-                                    Expr::Value(number("1").with_empty_span()),
+                                    Expr::value(number("1")),
                                     Expr::Identifier(Ident::new("DEFAULT")),
                                 ]]
                             })
@@ -2044,7 +2032,7 @@ fn parse_map_access_expr() {
             AccessExpr::Subscript(Subscript::Index {
                 index: Expr::UnaryOp {
                     op: UnaryOperator::Minus,
-                    expr: Expr::Value(number("1").with_empty_span()).into(),
+                    expr: Expr::value(number("1")).into(),
                 },
             }),
             AccessExpr::Subscript(Subscript::Index {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1968,25 +1968,19 @@ fn parse_big_query_declare() {
             "DECLARE x INT64 DEFAULT 42",
             vec![Ident::new("x")],
             Some(DataType::Int64),
-            Some(DeclareAssignment::Default(Box::new(Expr::Value(
-                number("42").with_empty_span(),
-            )))),
+            Some(DeclareAssignment::Default(Box::new(Expr::Value(number("42").with_empty_span().with_empty_span())))),
         ),
         (
             "DECLARE x, y, z INT64 DEFAULT 42",
             vec![Ident::new("x"), Ident::new("y"), Ident::new("z")],
             Some(DataType::Int64),
-            Some(DeclareAssignment::Default(Box::new(Expr::Value(
-                number("42").with_empty_span(),
-            )))),
+            Some(DeclareAssignment::Default(Box::new(Expr::Value(number("42").with_empty_span().with_empty_span())))),
         ),
         (
             "DECLARE x DEFAULT 42",
             vec![Ident::new("x")],
             None,
-            Some(DeclareAssignment::Default(Box::new(Expr::Value(
-                number("42").with_empty_span(),
-            )))),
+            Some(DeclareAssignment::Default(Box::new(Expr::Value(number("42").with_empty_span().with_empty_span())))),
         ),
     ] {
         match bigquery().verified_stmt(sql) {

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -50,86 +50,66 @@ fn parse_literal_string() {
     let select = dialect.verified_only_select(sql);
     assert_eq!(12, select.projection.len());
     assert_eq!(
-        &Expr::Value(
-            Value::SingleQuotedString("single".into())
-                .with_span(Span::new(Location::new(1, 7), Location::new(1, 12)))
-        ),
+        &Expr::Value(Value::SingleQuotedString("single".into()).with_empty_span()),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
-        &Expr::Value(
-            Value::DoubleQuotedString("double".into())
-                .with_span(Span::new(Location::new(1, 14), Location::new(1, 20)))
-        ),
+        &Expr::Value(Value::DoubleQuotedString("double".into()).with_empty_span()),
         expr_from_projection(&select.projection[1])
     );
     assert_eq!(
-        &Expr::Value(
-            Value::TripleSingleQuotedString("triple-single".into())
-                .with_span(Span::new(Location::new(1, 22), Location::new(1, 33)))
-        ),
+        &Expr::Value(Value::TripleSingleQuotedString("triple-single".into()).with_empty_span()),
         expr_from_projection(&select.projection[2])
     );
     assert_eq!(
-        &Expr::Value(
-            Value::TripleDoubleQuotedString("triple-double".into())
-                .with_span(Span::new(Location::new(1, 33), Location::new(1, 39)))
-        ),
+        &Expr::Value(Value::TripleDoubleQuotedString("triple-double".into()).with_empty_span()),
         expr_from_projection(&select.projection[3])
     );
     assert_eq!(
-        &Expr::Value(
-            Value::SingleQuotedString(r#"single\'escaped"#.into())
-                .with_span(Span::new(Location::new(1, 43), Location::new(1, 54)))
-        ),
+        &Expr::Value(Value::SingleQuotedString(r#"single\'escaped"#.into()).with_empty_span()),
         expr_from_projection(&select.projection[4])
     );
     assert_eq!(
         &Expr::Value(
-            Value::TripleSingleQuotedString(r#"triple-single\'escaped"#.into())
-                .with_span(Span::new(Location::new(1, 55), Location::new(1, 66)))
+            Value::TripleSingleQuotedString(r#"triple-single\'escaped"#.into()).with_empty_span()
         ),
         expr_from_projection(&select.projection[5])
     );
     assert_eq!(
         &Expr::Value(
-            Value::TripleSingleQuotedString(r#"triple-single'unescaped"#.into())
-                .with_span(Span::new(Location::new(1, 68), Location::new(1, 79)))
+            Value::TripleSingleQuotedString(r#"triple-single'unescaped"#.into()).with_empty_span()
         ),
         expr_from_projection(&select.projection[6])
     );
     assert_eq!(
-        &Expr::Value(
-            Value::DoubleQuotedString(r#"double\"escaped"#.to_string())
-                .with_span(Span::new(Location::new(1, 83), Location::new(1, 92)))
-        ),
+        &Expr::Value(Value::DoubleQuotedString(r#"double\"escaped"#.to_string()).with_empty_span()),
         expr_from_projection(&select.projection[7])
     );
     assert_eq!(
         &Expr::Value(
             Value::TripleDoubleQuotedString(r#"triple-double\"escaped"#.to_string())
-                .with_span(Span::new(Location::new(1, 92), Location::new(1, 101)))
+                .with_empty_span()
         ),
         expr_from_projection(&select.projection[8])
     );
     assert_eq!(
         &Expr::Value(
             Value::TripleDoubleQuotedString(r#"triple-double"unescaped"#.to_string())
-                .with_span(Span::new(Location::new(1, 105), Location::new(1, 114)))
+                .with_empty_span()
         ),
         expr_from_projection(&select.projection[9])
     );
     assert_eq!(
         &Expr::Value(
             Value::TripleDoubleQuotedString(r#"triple-double'unescaped"#.to_string())
-                .with_span(Span::new(Location::new(1, 118), Location::new(1, 127)))
+                .with_empty_span()
         ),
         expr_from_projection(&select.projection[10])
     );
     assert_eq!(
         &Expr::Value(
             Value::TripleSingleQuotedString(r#"triple-single"unescaped"#.to_string())
-                .with_span(Span::new(Location::new(1, 131), Location::new(1, 140)))
+                .with_empty_span()
         ),
         expr_from_projection(&select.projection[11])
     );
@@ -152,43 +132,41 @@ fn parse_byte_literal() {
             assert_eq!(6, select.projection.len());
             assert_eq!(
                 &Expr::Value(
-                    Value::SingleQuotedByteStringLiteral("abc".to_string())
-                        .with_span(Span::new(Location::new(1, 8), Location::new(1, 14)))
+                    Value::SingleQuotedByteStringLiteral("abc".to_string()).with_empty_span()
                 ),
                 expr_from_projection(&select.projection[0])
             );
             assert_eq!(
                 &Expr::Value(
-                    Value::DoubleQuotedByteStringLiteral("abc".to_string())
-                        .with_span(Span::new(Location::new(1, 15), Location::new(1, 21)))
+                    Value::DoubleQuotedByteStringLiteral("abc".to_string()).with_empty_span()
                 ),
                 expr_from_projection(&select.projection[1])
             );
             assert_eq!(
                 &Expr::Value(
                     Value::SingleQuotedByteStringLiteral(r"f\(abc,(.*),def\)".to_string())
-                        .with_span(Span::new(Location::new(1, 22), Location::new(1, 41)))
+                        .with_empty_span()
                 ),
                 expr_from_projection(&select.projection[2])
             );
             assert_eq!(
                 &Expr::Value(
                     Value::DoubleQuotedByteStringLiteral(r"f\(abc,(.*),def\)".to_string())
-                        .with_span(Span::new(Location::new(1, 42), Location::new(1, 61)))
+                        .with_empty_span()
                 ),
                 expr_from_projection(&select.projection[3])
             );
             assert_eq!(
                 &Expr::Value(
                     Value::TripleSingleQuotedByteStringLiteral(r"abc".to_string())
-                        .with_span(Span::new(Location::new(1, 62), Location::new(1, 73)))
+                        .with_empty_span()
                 ),
                 expr_from_projection(&select.projection[4])
             );
             assert_eq!(
                 &Expr::Value(
                     Value::TripleDoubleQuotedByteStringLiteral(r"abc".to_string())
-                        .with_span(Span::new(Location::new(1, 74), Location::new(1, 85)))
+                        .with_empty_span()
                 ),
                 expr_from_projection(&select.projection[5])
             );
@@ -220,43 +198,39 @@ fn parse_raw_literal() {
             assert_eq!(6, select.projection.len());
             assert_eq!(
                 &Expr::Value(
-                    Value::SingleQuotedRawStringLiteral("abc".to_string())
-                        .with_span(Span::new(Location::new(1, 8), Location::new(1, 14)))
+                    Value::SingleQuotedRawStringLiteral("abc".to_string()).with_empty_span()
                 ),
                 expr_from_projection(&select.projection[0])
             );
             assert_eq!(
                 &Expr::Value(
-                    Value::DoubleQuotedRawStringLiteral("abc".to_string())
-                        .with_span(Span::new(Location::new(1, 15), Location::new(1, 21)))
+                    Value::DoubleQuotedRawStringLiteral("abc".to_string()).with_empty_span()
                 ),
                 expr_from_projection(&select.projection[1])
             );
             assert_eq!(
                 &Expr::Value(
                     Value::SingleQuotedRawStringLiteral(r"f\(abc,(.*),def\)".to_string())
-                        .with_span(Span::new(Location::new(1, 22), Location::new(1, 41)))
+                        .with_empty_span()
                 ),
                 expr_from_projection(&select.projection[2])
             );
             assert_eq!(
                 &Expr::Value(
                     Value::DoubleQuotedRawStringLiteral(r"f\(abc,(.*),def\)".to_string())
-                        .with_span(Span::new(Location::new(1, 42), Location::new(1, 61)))
+                        .with_empty_span()
                 ),
                 expr_from_projection(&select.projection[3])
             );
             assert_eq!(
                 &Expr::Value(
-                    Value::TripleSingleQuotedRawStringLiteral(r"abc".to_string())
-                        .with_span(Span::new(Location::new(1, 62), Location::new(1, 73)))
+                    Value::TripleSingleQuotedRawStringLiteral(r"abc".to_string()).with_empty_span()
                 ),
                 expr_from_projection(&select.projection[4])
             );
             assert_eq!(
                 &Expr::Value(
-                    Value::TripleDoubleQuotedRawStringLiteral(r"abc".to_string())
-                        .with_span(Span::new(Location::new(1, 74), Location::new(1, 85)))
+                    Value::TripleDoubleQuotedRawStringLiteral(r"abc".to_string()).with_empty_span()
                 ),
                 expr_from_projection(&select.projection[5])
             );
@@ -360,7 +334,7 @@ fn parse_create_view_with_options() {
                     key: Ident::new("description"),
                     value: Expr::Value(
                         Value::DoubleQuotedString("a view that expires in 2 days".to_string())
-                            .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                            .with_empty_span()
                     ),
                 },
                 &options[2],
@@ -650,34 +624,18 @@ fn parse_tuple_struct_literal() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Tuple(vec![
-            Expr::Value(
-                number("1").with_span(Span::new(Location::new(1, 9), Location::new(1, 10)))
-            ),
-            Expr::Value(
-                number("2").with_span(Span::new(Location::new(1, 12), Location::new(1, 13)))
-            ),
-            Expr::Value(
-                number("3").with_span(Span::new(Location::new(1, 15), Location::new(1, 16)))
-            ),
+            Expr::Value(number("1").with_empty_span()),
+            Expr::Value(number("2").with_empty_span()),
+            Expr::Value(number("3").with_empty_span()),
         ]),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
         &Expr::Tuple(vec![
-            Expr::Value(
-                number("1").with_span(Span::new(Location::new(1, 19), Location::new(1, 20)))
-            ),
-            Expr::Value(
-                number("1.0").with_span(Span::new(Location::new(1, 22), Location::new(1, 25)))
-            ),
-            Expr::Value(
-                Value::SingleQuotedString("123".into())
-                    .with_span(Span::new(Location::new(1, 27), Location::new(1, 32)))
-            ),
-            Expr::Value(
-                Value::Boolean(true)
-                    .with_span(Span::new(Location::new(1, 34), Location::new(1, 38)))
-            )
+            Expr::Value(number("1").with_empty_span()),
+            Expr::Value(number("1.0").with_empty_span()),
+            Expr::Value(Value::SingleQuotedString("123".into()).with_empty_span()),
+            Expr::Value(Value::Boolean(true).with_empty_span())
         ]),
         expr_from_projection(&select.projection[1])
     );
@@ -693,15 +651,9 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(
-                    number("1").with_span(Span::new(Location::new(1, 15), Location::new(1, 16)))
-                ),
-                Expr::Value(
-                    number("2").with_span(Span::new(Location::new(1, 18), Location::new(1, 19)))
-                ),
-                Expr::Value(
-                    number("3").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
-                ),
+                Expr::Value(number("1").with_empty_span()),
+                Expr::Value(number("2").with_empty_span()),
+                Expr::Value(number("3").with_empty_span()),
             ],
             fields: Default::default()
         },
@@ -711,8 +663,7 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::SingleQuotedString("abc".into())
-                    .with_span(Span::new(Location::new(1, 32), Location::new(1, 37)))
+                Value::SingleQuotedString("abc".into()).with_empty_span()
             )],
             fields: Default::default()
         },
@@ -722,9 +673,7 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(
-                    number("1").with_span(Span::new(Location::new(1, 47), Location::new(1, 48)))
-                ),
+                Expr::Value(number("1").with_empty_span()),
                 Expr::CompoundIdentifier(vec![Ident::from("t"), Ident::from("str_col")]),
             ],
             fields: Default::default()
@@ -736,19 +685,12 @@ fn parse_typeless_struct_syntax() {
         &Expr::Struct {
             values: vec![
                 Expr::Named {
-                    expr: Expr::Value(
-                        number("1")
-                            .with_span(Span::new(Location::new(1, 66), Location::new(1, 67)))
-                    )
-                    .into(),
+                    expr: Expr::Value(number("1").with_empty_span()).into(),
                     name: Ident::from("a")
                 },
                 Expr::Named {
-                    expr: Expr::Value(
-                        Value::SingleQuotedString("abc".into())
-                            .with_span(Span::new(Location::new(1, 73), Location::new(1, 78)))
-                    )
-                    .into(),
+                    expr: Expr::Value(Value::SingleQuotedString("abc".into()).with_empty_span())
+                        .into(),
                     name: Ident::from("b")
                 },
             ],
@@ -779,9 +721,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
-            )],
+            values: vec![Expr::Value(number("5").with_empty_span())],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
@@ -792,9 +732,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(
-                    number("1").with_span(Span::new(Location::new(1, 48), Location::new(1, 49)))
-                ),
+                Expr::Value(number("1").with_empty_span()),
                 Expr::CompoundIdentifier(vec![
                     Ident {
                         value: "t".into(),
@@ -892,10 +830,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                Value::Boolean(true)
-                    .with_span(Span::new(Location::new(1, 20), Location::new(1, 24)))
-            )],
+            values: vec![Expr::Value(Value::Boolean(true).with_empty_span())],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bool
@@ -906,8 +841,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::SingleQuotedByteStringLiteral("abc".into())
-                    .with_span(Span::new(Location::new(1, 45), Location::new(1, 51)))
+                Value::SingleQuotedByteStringLiteral("abc".into()).with_empty_span()
             )],
             fields: vec![StructField {
                 field_name: None,
@@ -923,8 +857,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::SingleQuotedString("2011-05-05".into())
-                    .with_span(Span::new(Location::new(1, 20), Location::new(1, 32)))
+                Value::SingleQuotedString("2011-05-05".into()).with_empty_span()
             )],
             fields: vec![StructField {
                 field_name: None,
@@ -938,7 +871,6 @@ fn parse_typed_struct_syntax_bigquery() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Datetime(None),
                 value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into())
-                    .with_span(Span::new(Location::new(1, 57), Location::new(1, 82)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -949,9 +881,7 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                number("5.0").with_span(Span::new(Location::new(1, 102), Location::new(1, 105)))
-            )],
+            values: vec![Expr::Value(number("5.0").with_empty_span())],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
@@ -961,9 +891,7 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                number("1").with_span(Span::new(Location::new(1, 122), Location::new(1, 123)))
-            )],
+            values: vec![Expr::Value(number("1").with_empty_span())],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
@@ -979,8 +907,7 @@ fn parse_typed_struct_syntax_bigquery() {
         &Expr::Struct {
             values: vec![Expr::Interval(Interval {
                 value: Box::new(Expr::Value(
-                    Value::SingleQuotedString("2".into())
-                        .with_span(Span::new(Location::new(1, 30), Location::new(1, 33)))
+                    Value::SingleQuotedString("2".into()).with_empty_span()
                 )),
                 leading_field: Some(DateTimeField::Hour),
                 leading_precision: None,
@@ -1001,7 +928,6 @@ fn parse_typed_struct_syntax_bigquery() {
                 value: Value::SingleQuotedString(
                     r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into()
                 )
-                .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1017,8 +943,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::DoubleQuotedString("foo".into())
-                    .with_span(Span::new(Location::new(1, 25), Location::new(1, 30)))
+                Value::DoubleQuotedString("foo".into()).with_empty_span()
             )],
             fields: vec![StructField {
                 field_name: None,
@@ -1032,7 +957,6 @@ fn parse_typed_struct_syntax_bigquery() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Timestamp(None, TimezoneInfo::None),
                 value: Value::SingleQuotedString("2008-12-25 15:30:00 America/Los_Angeles".into())
-                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1047,7 +971,6 @@ fn parse_typed_struct_syntax_bigquery() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Time(None, TimezoneInfo::None),
                 value: Value::SingleQuotedString("15:30:00".into())
-                    .with_span(Span::new(Location::new(1, 115), Location::new(1, 125)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1065,7 +988,6 @@ fn parse_typed_struct_syntax_bigquery() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Numeric(ExactNumberInfo::None),
                 value: Value::SingleQuotedString("1".into())
-                    .with_span(Span::new(Location::new(1, 30), Location::new(1, 33)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1079,7 +1001,6 @@ fn parse_typed_struct_syntax_bigquery() {
             values: vec![Expr::TypedString {
                 data_type: DataType::BigNumeric(ExactNumberInfo::None),
                 value: Value::SingleQuotedString("1".into())
-                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 58)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1096,12 +1017,8 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(
-                    number("1").with_span(Span::new(Location::new(1, 38), Location::new(1, 39)))
-                ),
-                Expr::Value(
-                    number("2").with_span(Span::new(Location::new(1, 41), Location::new(1, 42)))
-                ),
+                Expr::Value(number("1").with_empty_span()),
+                Expr::Value(number("2").with_empty_span()),
             ],
             fields: vec![
                 StructField {
@@ -1128,9 +1045,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
-            )],
+            values: vec![Expr::Value(number("5").with_empty_span())],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
@@ -1141,9 +1056,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(
-                    number("1").with_span(Span::new(Location::new(1, 48), Location::new(1, 49)))
-                ),
+                Expr::Value(number("1").with_empty_span()),
                 Expr::CompoundIdentifier(vec![
                     Ident {
                         value: "t".into(),
@@ -1213,10 +1126,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                Value::Boolean(true)
-                    .with_span(Span::new(Location::new(1, 20), Location::new(1, 24)))
-            )],
+            values: vec![Expr::Value(Value::Boolean(true).with_empty_span())],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bool
@@ -1227,8 +1137,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::SingleQuotedByteStringLiteral("abc".into())
-                    .with_span(Span::new(Location::new(1, 45), Location::new(1, 51)))
+                Value::SingleQuotedByteStringLiteral("abc".into()).with_empty_span()
             )],
             fields: vec![StructField {
                 field_name: None,
@@ -1244,8 +1153,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::SingleQuotedString("2011-05-05".into())
-                    .with_span(Span::new(Location::new(1, 20), Location::new(1, 32)))
+                Value::SingleQuotedString("2011-05-05".into()).with_empty_span()
             )],
             fields: vec![StructField {
                 field_name: None,
@@ -1259,7 +1167,6 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Datetime(None),
                 value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into())
-                    .with_span(Span::new(Location::new(1, 57), Location::new(1, 82)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1270,9 +1177,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                number("5.0").with_span(Span::new(Location::new(1, 102), Location::new(1, 105)))
-            )],
+            values: vec![Expr::Value(number("5.0").with_empty_span())],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
@@ -1282,9 +1187,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                number("1").with_span(Span::new(Location::new(1, 122), Location::new(1, 123)))
-            )],
+            values: vec![Expr::Value(number("1").with_empty_span())],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
@@ -1300,8 +1203,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
         &Expr::Struct {
             values: vec![Expr::Interval(Interval {
                 value: Box::new(Expr::Value(
-                    Value::SingleQuotedString("1".into())
-                        .with_span(Span::new(Location::new(1, 30), Location::new(1, 33)))
+                    Value::SingleQuotedString("1".into()).with_empty_span()
                 )),
                 leading_field: Some(DateTimeField::Month),
                 leading_precision: None,
@@ -1322,7 +1224,6 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
                 value: Value::SingleQuotedString(
                     r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into()
                 )
-                .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1338,8 +1239,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::SingleQuotedString("foo".into())
-                    .with_span(Span::new(Location::new(1, 25), Location::new(1, 30)))
+                Value::SingleQuotedString("foo".into()).with_empty_span()
             )],
             fields: vec![StructField {
                 field_name: None,
@@ -1353,7 +1253,6 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Timestamp(None, TimezoneInfo::None),
                 value: Value::SingleQuotedString("2008-12-25 15:30:00 America/Los_Angeles".into())
-                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1368,7 +1267,6 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Time(None, TimezoneInfo::None),
                 value: Value::SingleQuotedString("15:30:00".into())
-                    .with_span(Span::new(Location::new(1, 115), Location::new(1, 125)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1386,7 +1284,6 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Numeric(ExactNumberInfo::None),
                 value: Value::SingleQuotedString("1".into())
-                    .with_span(Span::new(Location::new(1, 30), Location::new(1, 33)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1400,7 +1297,6 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             values: vec![Expr::TypedString {
                 data_type: DataType::BigNumeric(ExactNumberInfo::None),
                 value: Value::SingleQuotedString("1".into())
-                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 58)))
             }],
             fields: vec![StructField {
                 field_name: None,
@@ -1418,9 +1314,7 @@ fn parse_typed_struct_with_field_name_bigquery() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
-            )],
+            values: vec![Expr::Value(number("5").with_empty_span())],
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
@@ -1431,8 +1325,7 @@ fn parse_typed_struct_with_field_name_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::DoubleQuotedString("foo".into())
-                    .with_span(Span::new(Location::new(1, 42), Location::new(1, 47)))
+                Value::DoubleQuotedString("foo".into()).with_empty_span()
             )],
             fields: vec![StructField {
                 field_name: Some(Ident::from("y")),
@@ -1448,12 +1341,8 @@ fn parse_typed_struct_with_field_name_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(
-                    number("5").with_span(Span::new(Location::new(1, 32), Location::new(1, 33)))
-                ),
-                Expr::Value(
-                    number("5").with_span(Span::new(Location::new(1, 35), Location::new(1, 36)))
-                ),
+                Expr::Value(number("5").with_empty_span()),
+                Expr::Value(number("5").with_empty_span()),
             ],
             fields: vec![
                 StructField {
@@ -1477,9 +1366,7 @@ fn parse_typed_struct_with_field_name_bigquery_and_generic() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(
-                number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))
-            )],
+            values: vec![Expr::Value(number("5").with_empty_span())],
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
@@ -1490,8 +1377,7 @@ fn parse_typed_struct_with_field_name_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Value(
-                Value::SingleQuotedString("foo".into())
-                    .with_span(Span::new(Location::new(1, 42), Location::new(1, 47)))
+                Value::SingleQuotedString("foo".into()).with_empty_span()
             )],
             fields: vec![StructField {
                 field_name: Some(Ident::from("y")),
@@ -1507,12 +1393,8 @@ fn parse_typed_struct_with_field_name_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(
-                    number("5").with_span(Span::new(Location::new(1, 32), Location::new(1, 33)))
-                ),
-                Expr::Value(
-                    number("5").with_span(Span::new(Location::new(1, 35), Location::new(1, 36)))
-                ),
+                Expr::Value(number("5").with_empty_span()),
+                Expr::Value(number("5").with_empty_span()),
             ],
             fields: vec![
                 StructField {
@@ -1732,8 +1614,7 @@ fn parse_table_time_travel() {
                 args: None,
                 with_hints: vec![],
                 version: Some(TableVersion::ForSystemTimeAsOf(Expr::Value(
-                    Value::SingleQuotedString(version)
-                        .with_span(Span::new(Location::new(1, 35), Location::new(1, 54)))
+                    Value::SingleQuotedString(version).with_empty_span()
                 ))),
                 partitions: vec![],
                 with_ordinality: false,
@@ -1802,18 +1683,21 @@ fn parse_merge() {
         columns: vec![Ident::new("product"), Ident::new("quantity")],
         kind: MergeInsertKind::Values(Values {
             explicit_row: false,
-            rows: vec![vec![Expr::Value(number("1")), Expr::Value(number("2"))]],
+            rows: vec![vec![
+                Expr::Value(number("1").with_empty_span()),
+                Expr::Value(number("2").with_empty_span()),
+            ]],
         }),
     });
     let update_action = MergeAction::Update {
         assignments: vec![
             Assignment {
                 target: AssignmentTarget::ColumnName(ObjectName::from(vec![Ident::new("a")])),
-                value: Expr::Value(number("1")),
+                value: Expr::Value(number("1").with_empty_span()),
             },
             Assignment {
                 target: AssignmentTarget::ColumnName(ObjectName::from(vec![Ident::new("b")])),
-                value: Expr::Value(number("2")),
+                value: Expr::Value(number("2").with_empty_span()),
             },
         ],
     };
@@ -1862,17 +1746,17 @@ fn parse_merge() {
                 },
                 source
             );
-            assert_eq!(Expr::Value(Value::Boolean(false)), *on);
+            assert_eq!(Expr::Value(Value::Boolean(false).with_empty_span()), *on);
             assert_eq!(
                 vec![
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatched,
-                        predicate: Some(Expr::Value(number("1"))),
+                        predicate: Some(Expr::Value(number("1").with_empty_span())),
                         action: insert_action.clone(),
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatchedByTarget,
-                        predicate: Some(Expr::Value(number("1"))),
+                        predicate: Some(Expr::Value(number("1").with_empty_span())),
                         action: insert_action.clone(),
                     },
                     MergeClause {
@@ -1882,7 +1766,7 @@ fn parse_merge() {
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatchedBySource,
-                        predicate: Some(Expr::Value(number("2"))),
+                        predicate: Some(Expr::Value(number("2").with_empty_span())),
                         action: MergeAction::Delete
                     },
                     MergeClause {
@@ -1892,12 +1776,12 @@ fn parse_merge() {
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatchedBySource,
-                        predicate: Some(Expr::Value(number("1"))),
+                        predicate: Some(Expr::Value(number("1").with_empty_span())),
                         action: update_action.clone(),
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatched,
-                        predicate: Some(Expr::Value(number("1"))),
+                        predicate: Some(Expr::Value(number("1").with_empty_span())),
                         action: MergeAction::Insert(MergeInsertExpr {
                             columns: vec![Ident::new("product"), Ident::new("quantity"),],
                             kind: MergeInsertKind::Row,
@@ -1913,7 +1797,7 @@ fn parse_merge() {
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::NotMatched,
-                        predicate: Some(Expr::Value(number("1"))),
+                        predicate: Some(Expr::Value(number("1").with_empty_span())),
                         action: MergeAction::Insert(MergeInsertExpr {
                             columns: vec![],
                             kind: MergeInsertKind::Row
@@ -1929,7 +1813,7 @@ fn parse_merge() {
                     },
                     MergeClause {
                         clause_kind: MergeClauseKind::Matched,
-                        predicate: Some(Expr::Value(number("1"))),
+                        predicate: Some(Expr::Value(number("1").with_empty_span())),
                         action: MergeAction::Delete,
                     },
                     MergeClause {
@@ -1945,7 +1829,7 @@ fn parse_merge() {
                             kind: MergeInsertKind::Values(Values {
                                 explicit_row: false,
                                 rows: vec![vec![
-                                    Expr::Value(number("1")),
+                                    Expr::Value(number("1").with_empty_span()),
                                     Expr::Identifier(Ident::new("DEFAULT")),
                                 ]]
                             })
@@ -1959,7 +1843,7 @@ fn parse_merge() {
                             kind: MergeInsertKind::Values(Values {
                                 explicit_row: false,
                                 rows: vec![vec![
-                                    Expr::Value(number("1")),
+                                    Expr::Value(number("1").with_empty_span()),
                                     Expr::Identifier(Ident::new("DEFAULT")),
                                 ]]
                             })
@@ -2084,25 +1968,25 @@ fn parse_big_query_declare() {
             "DECLARE x INT64 DEFAULT 42",
             vec![Ident::new("x")],
             Some(DataType::Int64),
-            Some(DeclareAssignment::Default(Box::new(Expr::Value(number(
-                "42",
-            ))))),
+            Some(DeclareAssignment::Default(Box::new(Expr::Value(
+                number("42").with_empty_span(),
+            )))),
         ),
         (
             "DECLARE x, y, z INT64 DEFAULT 42",
             vec![Ident::new("x"), Ident::new("y"), Ident::new("z")],
             Some(DataType::Int64),
-            Some(DeclareAssignment::Default(Box::new(Expr::Value(number(
-                "42",
-            ))))),
+            Some(DeclareAssignment::Default(Box::new(Expr::Value(
+                number("42").with_empty_span(),
+            )))),
         ),
         (
             "DECLARE x DEFAULT 42",
             vec![Ident::new("x")],
             None,
-            Some(DeclareAssignment::Default(Box::new(Expr::Value(number(
-                "42",
-            ))))),
+            Some(DeclareAssignment::Default(Box::new(Expr::Value(
+                number("42").with_empty_span(),
+            )))),
         ),
     ] {
         match bigquery().verified_stmt(sql) {
@@ -2160,7 +2044,7 @@ fn parse_map_access_expr() {
             AccessExpr::Subscript(Subscript::Index {
                 index: Expr::UnaryOp {
                     op: UnaryOperator::Minus,
-                    expr: Expr::Value(number("1")).into(),
+                    expr: Expr::Value(number("1").with_empty_span()).into(),
                 },
             }),
             AccessExpr::Subscript(Subscript::Index {
@@ -2173,7 +2057,7 @@ fn parse_map_access_expr() {
                     args: FunctionArguments::List(FunctionArgumentList {
                         duplicate_treatment: None,
                         args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
-                            number("2"),
+                            number("2").with_empty_span(),
                         )))],
                         clauses: vec![],
                     }),
@@ -2224,12 +2108,12 @@ fn test_bigquery_create_function() {
             ]),
             args: Some(vec![OperateFunctionArg::with_name("x", DataType::Float64),]),
             return_type: Some(DataType::Float64),
-            function_body: Some(CreateFunctionBody::AsAfterOptions(Expr::Value(number(
-                "42"
-            )))),
+            function_body: Some(CreateFunctionBody::AsAfterOptions(Expr::Value(
+                number("42").with_empty_span()
+            ))),
             options: Some(vec![SqlOption::KeyValue {
                 key: Ident::new("x"),
-                value: Expr::Value(Value::SingleQuotedString("y".into())),
+                value: Expr::Value(Value::SingleQuotedString("y".into()).with_empty_span()),
             }]),
             behavior: None,
             using: None,
@@ -2348,10 +2232,14 @@ fn test_bigquery_trim() {
     let select = bigquery().verified_only_select(sql_only_select);
     assert_eq!(
         &Expr::Trim {
-            expr: Box::new(Expr::Value(Value::SingleQuotedString("xyz".to_owned()))),
+            expr: Box::new(Expr::Value(
+                Value::SingleQuotedString("xyz".to_owned()).with_empty_span()
+            )),
             trim_where: None,
             trim_what: None,
-            trim_characters: Some(vec![Expr::Value(Value::SingleQuotedString("a".to_owned()))]),
+            trim_characters: Some(vec![Expr::Value(
+                Value::SingleQuotedString("a".to_owned()).with_empty_span()
+            )]),
         },
         expr_from_projection(only(&select.projection))
     );

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -29,19 +29,19 @@ use test_utils::*;
 #[test]
 fn parse_literal_string() {
     let sql = concat!(
-        "SELECT ",
-        "'single', ",
-        r#""double", "#,
-        "'''triple-single''', ",
-        r#""""triple-double""", "#,
-        r#"'single\'escaped', "#,
-        r#"'''triple-single\'escaped''', "#,
-        r#"'''triple-single'unescaped''', "#,
-        r#""double\"escaped", "#,
-        r#""""triple-double\"escaped""", "#,
-        r#""""triple-double"unescaped""", "#,
-        r#""""triple-double'unescaped""", "#,
-        r#"'''triple-single"unescaped'''"#,
+        "SELECT ",                            // line 1, column 1
+        "'single', ",                         // line 1, column 7
+        r#""double", "#,                      // line 1, column 14
+        "'''triple-single''', ",              // line 1, column 22
+        r#""""triple-double""", "#,           // line 1, column 33
+        r#"'single\'escaped', "#,             // line 1, column 43
+        r#"'''triple-single\'escaped''', "#,  // line 1, column 55
+        r#"'''triple-single'unescaped''', "#, // line 1, column 68
+        r#""double\"escaped", "#,             // line 1, column 83
+        r#""""triple-double\"escaped""", "#,  // line 1, column 92
+        r#""""triple-double"unescaped""", "#, // line 1, column 105
+        r#""""triple-double'unescaped""", "#, // line 1, column 118
+        r#"'''triple-single"unescaped'''"#,   // line 1, column 131
     );
     let dialect = TestedDialects::new_with_options(
         vec![Box::new(BigQueryDialect {})],
@@ -50,63 +50,87 @@ fn parse_literal_string() {
     let select = dialect.verified_only_select(sql);
     assert_eq!(12, select.projection.len());
     assert_eq!(
-        &Expr::Value(Value::SingleQuotedString("single".into())),
+        &Expr::Value(
+            Value::SingleQuotedString("single".into())
+                .with_span(Span::new(Location::new(1, 7), Location::new(1, 12)))
+        ),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
-        &Expr::Value(Value::DoubleQuotedString("double".into())),
+        &Expr::Value(
+            Value::DoubleQuotedString("double".into())
+                .with_span(Span::new(Location::new(1, 14), Location::new(1, 20)))
+        ),
         expr_from_projection(&select.projection[1])
     );
     assert_eq!(
-        &Expr::Value(Value::TripleSingleQuotedString("triple-single".into())),
+        &Expr::Value(
+            Value::TripleSingleQuotedString("triple-single".into())
+                .with_span(Span::new(Location::new(1, 22), Location::new(1, 33)))
+        ),
         expr_from_projection(&select.projection[2])
     );
     assert_eq!(
-        &Expr::Value(Value::TripleDoubleQuotedString("triple-double".into())),
+        &Expr::Value(
+            Value::TripleDoubleQuotedString("triple-double".into())
+                .with_span(Span::new(Location::new(1, 33), Location::new(1, 39)))
+        ),
         expr_from_projection(&select.projection[3])
     );
     assert_eq!(
-        &Expr::Value(Value::SingleQuotedString(r#"single\'escaped"#.into())),
+        &Expr::Value(
+            Value::SingleQuotedString(r#"single\'escaped"#.into())
+                .with_span(Span::new(Location::new(1, 43), Location::new(1, 54)))
+        ),
         expr_from_projection(&select.projection[4])
     );
     assert_eq!(
-        &Expr::Value(Value::TripleSingleQuotedString(
-            r#"triple-single\'escaped"#.into()
-        )),
+        &Expr::Value(
+            Value::TripleSingleQuotedString(r#"triple-single\'escaped"#.into())
+                .with_span(Span::new(Location::new(1, 55), Location::new(1, 66)))
+        ),
         expr_from_projection(&select.projection[5])
     );
     assert_eq!(
-        &Expr::Value(Value::TripleSingleQuotedString(
-            r#"triple-single'unescaped"#.into()
-        )),
+        &Expr::Value(
+            Value::TripleSingleQuotedString(r#"triple-single'unescaped"#.into())
+                .with_span(Span::new(Location::new(1, 68), Location::new(1, 79)))
+        ),
         expr_from_projection(&select.projection[6])
     );
     assert_eq!(
-        &Expr::Value(Value::DoubleQuotedString(r#"double\"escaped"#.to_string())),
+        &Expr::Value(
+            Value::DoubleQuotedString(r#"double\"escaped"#.to_string())
+                .with_span(Span::new(Location::new(1, 83), Location::new(1, 92)))
+        ),
         expr_from_projection(&select.projection[7])
     );
     assert_eq!(
-        &Expr::Value(Value::TripleDoubleQuotedString(
-            r#"triple-double\"escaped"#.to_string()
-        )),
+        &Expr::Value(
+            Value::TripleDoubleQuotedString(r#"triple-double\"escaped"#.to_string())
+                .with_span(Span::new(Location::new(1, 92), Location::new(1, 101)))
+        ),
         expr_from_projection(&select.projection[8])
     );
     assert_eq!(
-        &Expr::Value(Value::TripleDoubleQuotedString(
-            r#"triple-double"unescaped"#.to_string()
-        )),
+        &Expr::Value(
+            Value::TripleDoubleQuotedString(r#"triple-double"unescaped"#.to_string())
+                .with_span(Span::new(Location::new(1, 105), Location::new(1, 114)))
+        ),
         expr_from_projection(&select.projection[9])
     );
     assert_eq!(
-        &Expr::Value(Value::TripleDoubleQuotedString(
-            r#"triple-double'unescaped"#.to_string()
-        )),
+        &Expr::Value(
+            Value::TripleDoubleQuotedString(r#"triple-double'unescaped"#.to_string())
+                .with_span(Span::new(Location::new(1, 118), Location::new(1, 127)))
+        ),
         expr_from_projection(&select.projection[10])
     );
     assert_eq!(
-        &Expr::Value(Value::TripleSingleQuotedString(
-            r#"triple-single"unescaped"#.to_string()
-        )),
+        &Expr::Value(
+            Value::TripleSingleQuotedString(r#"triple-single"unescaped"#.to_string())
+                .with_span(Span::new(Location::new(1, 131), Location::new(1, 140)))
+        ),
         expr_from_projection(&select.projection[11])
     );
 }
@@ -114,48 +138,58 @@ fn parse_literal_string() {
 #[test]
 fn parse_byte_literal() {
     let sql = concat!(
-        "SELECT ",
-        "B'abc', ",
-        r#"B"abc", "#,
-        r#"B'f\(abc,(.*),def\)', "#,
-        r#"B"f\(abc,(.*),def\)", "#,
-        r#"B'''abc''', "#,
-        r#"B"""abc""""#,
+        "SELECT ",                // line 1, column 1
+        "B'abc', ",              // line 1, column 8
+        r#"B"abc", "#,           // line 1, column 15
+        r#"B'f\(abc,(.*),def\)', "#, // line 1, column 22
+        r#"B"f\(abc,(.*),def\)", "#, // line 1, column 42
+        r#"B'''abc''', "#,       // line 1, column 62
+        r#"B"""abc""""#,         // line 1, column 74
     );
     let stmt = bigquery().verified_stmt(sql);
     if let Statement::Query(query) = stmt {
         if let SetExpr::Select(select) = *query.body {
             assert_eq!(6, select.projection.len());
             assert_eq!(
-                &Expr::Value(Value::SingleQuotedByteStringLiteral("abc".to_string())),
+                &Expr::Value(
+                    Value::SingleQuotedByteStringLiteral("abc".to_string())
+                        .with_span(Span::new(Location::new(1, 8), Location::new(1, 14)))
+                ),
                 expr_from_projection(&select.projection[0])
             );
             assert_eq!(
-                &Expr::Value(Value::DoubleQuotedByteStringLiteral("abc".to_string())),
+                &Expr::Value(
+                    Value::DoubleQuotedByteStringLiteral("abc".to_string())
+                        .with_span(Span::new(Location::new(1, 15), Location::new(1, 21)))
+                ),
                 expr_from_projection(&select.projection[1])
             );
             assert_eq!(
-                &Expr::Value(Value::SingleQuotedByteStringLiteral(
-                    r"f\(abc,(.*),def\)".to_string()
-                )),
+                &Expr::Value(
+                    Value::SingleQuotedByteStringLiteral(r"f\(abc,(.*),def\)".to_string())
+                        .with_span(Span::new(Location::new(1, 22), Location::new(1, 41)))
+                ),
                 expr_from_projection(&select.projection[2])
             );
             assert_eq!(
-                &Expr::Value(Value::DoubleQuotedByteStringLiteral(
-                    r"f\(abc,(.*),def\)".to_string()
-                )),
+                &Expr::Value(
+                    Value::DoubleQuotedByteStringLiteral(r"f\(abc,(.*),def\)".to_string())
+                        .with_span(Span::new(Location::new(1, 42), Location::new(1, 61)))
+                ),
                 expr_from_projection(&select.projection[3])
             );
             assert_eq!(
-                &Expr::Value(Value::TripleSingleQuotedByteStringLiteral(
-                    r"abc".to_string()
-                )),
+                &Expr::Value(
+                    Value::TripleSingleQuotedByteStringLiteral(r"abc".to_string())
+                        .with_span(Span::new(Location::new(1, 62), Location::new(1, 73)))
+                ),
                 expr_from_projection(&select.projection[4])
             );
             assert_eq!(
-                &Expr::Value(Value::TripleDoubleQuotedByteStringLiteral(
-                    r"abc".to_string()
-                )),
+                &Expr::Value(
+                    Value::TripleDoubleQuotedByteStringLiteral(r"abc".to_string())
+                        .with_span(Span::new(Location::new(1, 74), Location::new(1, 85)))
+                ),
                 expr_from_projection(&select.projection[5])
             );
         }
@@ -172,48 +206,58 @@ fn parse_byte_literal() {
 #[test]
 fn parse_raw_literal() {
     let sql = concat!(
-        "SELECT ",
-        "R'abc', ",
-        r#"R"abc", "#,
-        r#"R'f\(abc,(.*),def\)', "#,
-        r#"R"f\(abc,(.*),def\)", "#,
-        r#"R'''abc''', "#,
-        r#"R"""abc""""#,
+        "SELECT ",                // line 1, column 1
+        "R'abc', ",              // line 1, column 8
+        r#"R"abc", "#,           // line 1, column 15
+        r#"R'f\(abc,(.*),def\)', "#, // line 1, column 22
+        r#"R"f\(abc,(.*),def\)", "#, // line 1, column 42
+        r#"R'''abc''', "#,       // line 1, column 62
+        r#"R"""abc""""#,         // line 1, column 74
     );
     let stmt = bigquery().verified_stmt(sql);
     if let Statement::Query(query) = stmt {
         if let SetExpr::Select(select) = *query.body {
             assert_eq!(6, select.projection.len());
             assert_eq!(
-                &Expr::Value(Value::SingleQuotedRawStringLiteral("abc".to_string())),
+                &Expr::Value(
+                    Value::SingleQuotedRawStringLiteral("abc".to_string())
+                        .with_span(Span::new(Location::new(1, 8), Location::new(1, 14)))
+                ),
                 expr_from_projection(&select.projection[0])
             );
             assert_eq!(
-                &Expr::Value(Value::DoubleQuotedRawStringLiteral("abc".to_string())),
+                &Expr::Value(
+                    Value::DoubleQuotedRawStringLiteral("abc".to_string())
+                        .with_span(Span::new(Location::new(1, 15), Location::new(1, 21)))
+                ),
                 expr_from_projection(&select.projection[1])
             );
             assert_eq!(
-                &Expr::Value(Value::SingleQuotedRawStringLiteral(
-                    r"f\(abc,(.*),def\)".to_string()
-                )),
+                &Expr::Value(
+                    Value::SingleQuotedRawStringLiteral(r"f\(abc,(.*),def\)".to_string())
+                        .with_span(Span::new(Location::new(1, 22), Location::new(1, 41)))
+                ),
                 expr_from_projection(&select.projection[2])
             );
             assert_eq!(
-                &Expr::Value(Value::DoubleQuotedRawStringLiteral(
-                    r"f\(abc,(.*),def\)".to_string()
-                )),
+                &Expr::Value(
+                    Value::DoubleQuotedRawStringLiteral(r"f\(abc,(.*),def\)".to_string())
+                        .with_span(Span::new(Location::new(1, 42), Location::new(1, 61)))
+                ),
                 expr_from_projection(&select.projection[3])
             );
             assert_eq!(
-                &Expr::Value(Value::TripleSingleQuotedRawStringLiteral(
-                    r"abc".to_string()
-                )),
+                &Expr::Value(
+                    Value::TripleSingleQuotedRawStringLiteral(r"abc".to_string())
+                        .with_span(Span::new(Location::new(1, 62), Location::new(1, 73)))
+                ),
                 expr_from_projection(&select.projection[4])
             );
             assert_eq!(
-                &Expr::Value(Value::TripleDoubleQuotedRawStringLiteral(
-                    r"abc".to_string()
-                )),
+                &Expr::Value(
+                    Value::TripleDoubleQuotedRawStringLiteral(r"abc".to_string())
+                        .with_span(Span::new(Location::new(1, 74), Location::new(1, 85)))
+                ),
                 expr_from_projection(&select.projection[5])
             );
         }
@@ -290,7 +334,10 @@ fn parse_create_view_with_options() {
                         data_type: None,
                         options: Some(vec![ColumnOption::Options(vec![SqlOption::KeyValue {
                             key: Ident::new("description"),
-                            value: Expr::Value(Value::DoubleQuotedString("field age".to_string())),
+                            value: Expr::Value(
+                                Value::DoubleQuotedString("field age".to_string())
+                                    .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                            ),
                         }])]),
                     },
                 ],
@@ -310,9 +357,10 @@ fn parse_create_view_with_options() {
             assert_eq!(
                 &SqlOption::KeyValue {
                     key: Ident::new("description"),
-                    value: Expr::Value(Value::DoubleQuotedString(
-                        "a view that expires in 2 days".to_string()
-                    )),
+                    value: Expr::Value(
+                        Value::DoubleQuotedString("a view that expires in 2 days".to_string())
+                            .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                    ),
                 },
                 &options[2],
             );
@@ -320,6 +368,7 @@ fn parse_create_view_with_options() {
         _ => unreachable!(),
     }
 }
+
 #[test]
 fn parse_create_view_if_not_exists() {
     let sql = "CREATE VIEW IF NOT EXISTS mydataset.newview AS SELECT foo FROM bar";
@@ -435,9 +484,10 @@ fn parse_create_table_with_options() {
                                 name: None,
                                 option: ColumnOption::Options(vec![SqlOption::KeyValue {
                                     key: Ident::new("description"),
-                                    value: Expr::Value(Value::DoubleQuotedString(
-                                        "field x".to_string()
-                                    )),
+                                    value: Expr::Value(
+                                        Value::DoubleQuotedString("field x".to_string())
+                                            .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                                    ),
                                 },])
                             },
                         ]
@@ -449,9 +499,10 @@ fn parse_create_table_with_options() {
                             name: None,
                             option: ColumnOption::Options(vec![SqlOption::KeyValue {
                                 key: Ident::new("description"),
-                                value: Expr::Value(Value::DoubleQuotedString(
-                                    "field y".to_string()
-                                )),
+                                value: Expr::Value(
+                                    Value::DoubleQuotedString("field y".to_string())
+                                        .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                                ),
                             },])
                         }]
                     },
@@ -468,13 +519,16 @@ fn parse_create_table_with_options() {
                     Some(vec![
                         SqlOption::KeyValue {
                             key: Ident::new("partition_expiration_days"),
-                            value: Expr::Value(number("1")),
+                            value: Expr::Value(
+                                number("1").with_span(Span::new(Location::new(1, 42), Location::new(1, 43)))
+                            ),
                         },
                         SqlOption::KeyValue {
                             key: Ident::new("description"),
-                            value: Expr::Value(Value::DoubleQuotedString(
-                                "table option description".to_string()
-                            )),
+                            value: Expr::Value(
+                                Value::DoubleQuotedString("table option description".to_string())
+                                    .with_span(Span::new(Location::new(1, 42), Location::new(1, 52)))
+                            ),
                         },
                     ])
                 ),
@@ -582,23 +636,23 @@ fn parse_invalid_brackets() {
 fn parse_tuple_struct_literal() {
     // tuple syntax: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#tuple_syntax
     // syntax: (expr1, expr2 [, ... ])
-    let sql = "SELECT (1, 2, 3), (1, 1.0, '123', true)";
+    let sql = "SELECT (1, 2, 3), (1, 1.0, '123', true)";  // line 1, column 1
     let select = bigquery().verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Tuple(vec![
-            Expr::Value(number("1")),
-            Expr::Value(number("2")),
-            Expr::Value(number("3")),
+            Expr::Value(number("1").with_span(Span::new(Location::new(1, 9), Location::new(1, 10)))),
+            Expr::Value(number("2").with_span(Span::new(Location::new(1, 12), Location::new(1, 13)))),
+            Expr::Value(number("3").with_span(Span::new(Location::new(1, 15), Location::new(1, 16)))),
         ]),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
         &Expr::Tuple(vec![
-            Expr::Value(number("1")),
-            Expr::Value(number("1.0")),
-            Expr::Value(Value::SingleQuotedString("123".into())),
-            Expr::Value(Value::Boolean(true))
+            Expr::Value(number("1").with_span(Span::new(Location::new(1, 19), Location::new(1, 20)))),
+            Expr::Value(number("1.0").with_span(Span::new(Location::new(1, 22), Location::new(1, 25)))),
+            Expr::Value(Value::SingleQuotedString("123".into()).with_span(Span::new(Location::new(1, 27), Location::new(1, 32)))),
+            Expr::Value(Value::Boolean(true).with_span(Span::new(Location::new(1, 34), Location::new(1, 38))))
         ]),
         expr_from_projection(&select.projection[1])
     );
@@ -614,9 +668,9 @@ fn parse_typeless_struct_syntax() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1")),
-                Expr::Value(number("2")),
-                Expr::Value(number("3")),
+                Expr::Value(number("1").with_span(Span::new(Location::new(1, 15), Location::new(1, 16)))),
+                Expr::Value(number("2").with_span(Span::new(Location::new(1, 18), Location::new(1, 19)))),
+                Expr::Value(number("3").with_span(Span::new(Location::new(1, 21), Location::new(1, 22)))),
             ],
             fields: Default::default()
         },
@@ -625,30 +679,32 @@ fn parse_typeless_struct_syntax() {
 
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedString("abc".into())),],
+            values: vec![Expr::Value(Value::SingleQuotedString("abc".into()).with_span(Span::new(Location::new(1, 32), Location::new(1, 37))))],
             fields: Default::default()
         },
         expr_from_projection(&select.projection[1])
     );
+
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1")),
+                Expr::Value(number("1").with_span(Span::new(Location::new(1, 47), Location::new(1, 48)))),
                 Expr::CompoundIdentifier(vec![Ident::from("t"), Ident::from("str_col")]),
             ],
             fields: Default::default()
         },
         expr_from_projection(&select.projection[2])
     );
+
     assert_eq!(
         &Expr::Struct {
             values: vec![
                 Expr::Named {
-                    expr: Expr::Value(number("1")).into(),
+                    expr: Expr::Value(number("1").with_span(Span::new(Location::new(1, 66), Location::new(1, 67)))).into(),
                     name: Ident::from("a")
                 },
                 Expr::Named {
-                    expr: Expr::Value(Value::SingleQuotedString("abc".into())).into(),
+                    expr: Expr::Value(Value::SingleQuotedString("abc".into()).with_span(Span::new(Location::new(1, 73), Location::new(1, 78)))).into(),
                     name: Ident::from("b")
                 },
             ],
@@ -656,6 +712,7 @@ fn parse_typeless_struct_syntax() {
         },
         expr_from_projection(&select.projection[3])
     );
+
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Named {
@@ -678,7 +735,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5")),],
+            values: vec![Expr::Value(number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
@@ -689,7 +746,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1")),
+                Expr::Value(number("1").with_span(Span::new(Location::new(1, 48), Location::new(1, 49)))),
                 Expr::CompoundIdentifier(vec![
                     Ident {
                         value: "t".into(),
@@ -730,7 +787,7 @@ fn parse_typed_struct_syntax_bigquery() {
                 value: "nested_col".into(),
                 quote_style: None,
                 span: Span::empty(),
-            }),],
+            })],
             fields: vec![
                 StructField {
                     field_name: Some("arr".into()),
@@ -762,7 +819,7 @@ fn parse_typed_struct_syntax_bigquery() {
                 value: "nested_col".into(),
                 quote_style: None,
                 span: Span::empty(),
-            }),],
+            })],
             fields: vec![
                 StructField {
                     field_name: Some("x".into()),
@@ -787,7 +844,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::Boolean(true)),],
+            values: vec![Expr::Value(Value::Boolean(true).with_span(Span::new(Location::new(1, 20), Location::new(1, 24))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bool
@@ -797,9 +854,7 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedByteStringLiteral(
-                "abc".into()
-            )),],
+            values: vec![Expr::Value(Value::SingleQuotedByteStringLiteral("abc".into()).with_span(Span::new(Location::new(1, 45), Location::new(1, 51))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bytes(Some(42))
@@ -813,7 +868,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(4, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::DoubleQuotedString("2011-05-05".into())),],
+            values: vec![Expr::Value(Value::SingleQuotedString("2011-05-05".into()).with_span(Span::new(Location::new(1, 20), Location::new(1, 32))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Date
@@ -825,8 +880,8 @@ fn parse_typed_struct_syntax_bigquery() {
         &Expr::Struct {
             values: vec![Expr::TypedString {
                 data_type: DataType::Datetime(None),
-                value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into())
-            },],
+                value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into()).with_span(Span::new(Location::new(1, 57), Location::new(1, 82)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Datetime(None)
@@ -836,7 +891,7 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5.0")),],
+            values: vec![Expr::Value(number("5.0").with_span(Span::new(Location::new(1, 102), Location::new(1, 105))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
@@ -846,7 +901,7 @@ fn parse_typed_struct_syntax_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("1")),],
+            values: vec![Expr::Value(number("1").with_span(Span::new(Location::new(1, 122), Location::new(1, 123))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
@@ -861,12 +916,12 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Interval(Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString("2".into()))),
+                value: Box::new(Expr::Value(Value::SingleQuotedString("2".into()).with_span(Span::new(Location::new(1, 30), Location::new(1, 33))))),
                 leading_field: Some(DateTimeField::Hour),
                 leading_precision: None,
                 last_field: None,
                 fractional_seconds_precision: None
-            }),],
+            })],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Interval
@@ -878,10 +933,9 @@ fn parse_typed_struct_syntax_bigquery() {
         &Expr::Struct {
             values: vec![Expr::TypedString {
                 data_type: DataType::JSON,
-                value: Value::SingleQuotedString(
-                    r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into()
-                )
-            },],
+                value: Value::SingleQuotedString(r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into())
+                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::JSON
@@ -895,7 +949,7 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::DoubleQuotedString("foo".into())),],
+            values: vec![Expr::Value(Value::DoubleQuotedString("foo".into()).with_span(Span::new(Location::new(1, 25), Location::new(1, 30))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::String(Some(42))
@@ -908,7 +962,8 @@ fn parse_typed_struct_syntax_bigquery() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Timestamp(None, TimezoneInfo::None),
                 value: Value::SingleQuotedString("2008-12-25 15:30:00 America/Los_Angeles".into())
-            },],
+                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Timestamp(None, TimezoneInfo::None)
@@ -922,7 +977,8 @@ fn parse_typed_struct_syntax_bigquery() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Time(None, TimezoneInfo::None),
                 value: Value::SingleQuotedString("15:30:00".into())
-            },],
+                    .with_span(Span::new(Location::new(1, 115), Location::new(1, 125)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Time(None, TimezoneInfo::None)
@@ -939,7 +995,8 @@ fn parse_typed_struct_syntax_bigquery() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Numeric(ExactNumberInfo::None),
                 value: Value::SingleQuotedString("1".into())
-            },],
+                    .with_span(Span::new(Location::new(1, 30), Location::new(1, 33)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Numeric(ExactNumberInfo::None)
@@ -952,7 +1009,8 @@ fn parse_typed_struct_syntax_bigquery() {
             values: vec![Expr::TypedString {
                 data_type: DataType::BigNumeric(ExactNumberInfo::None),
                 value: Value::SingleQuotedString("1".into())
-            },],
+                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 58)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::BigNumeric(ExactNumberInfo::None)
@@ -967,7 +1025,10 @@ fn parse_typed_struct_syntax_bigquery() {
     assert_eq!(1, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("1")), Expr::Value(number("2")),],
+            values: vec![
+                Expr::Value(number("1").with_span(Span::new(Location::new(1, 38), Location::new(1, 39)))),
+                Expr::Value(number("2").with_span(Span::new(Location::new(1, 41), Location::new(1, 42)))),
+            ],
             fields: vec![
                 StructField {
                     field_name: Some("key".into()),
@@ -993,7 +1054,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5")),],
+            values: vec![Expr::Value(number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64,
@@ -1004,7 +1065,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![
-                Expr::Value(number("1")),
+                Expr::Value(number("1").with_span(Span::new(Location::new(1, 48), Location::new(1, 49)))),
                 Expr::CompoundIdentifier(vec![
                     Ident {
                         value: "t".into(),
@@ -1039,34 +1100,6 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
         },
         expr_from_projection(&select.projection[1])
     );
-    assert_eq!(
-        &Expr::Struct {
-            values: vec![Expr::Identifier(Ident {
-                value: "nested_col".into(),
-                quote_style: None,
-                span: Span::empty(),
-            }),],
-            fields: vec![
-                StructField {
-                    field_name: Some("arr".into()),
-                    field_type: DataType::Array(ArrayElemTypeDef::AngleBracket(Box::new(
-                        DataType::Float64
-                    )))
-                },
-                StructField {
-                    field_name: Some("str".into()),
-                    field_type: DataType::Struct(
-                        vec![StructField {
-                            field_name: None,
-                            field_type: DataType::Bool
-                        }],
-                        StructBracketKind::AngleBrackets
-                    )
-                },
-            ]
-        },
-        expr_from_projection(&select.projection[2])
-    );
 
     let sql = r#"SELECT STRUCT<x STRUCT, y ARRAY<STRUCT>>(nested_col)"#;
     let select = bigquery_and_generic().verified_only_select(sql);
@@ -1077,7 +1110,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
                 value: "nested_col".into(),
                 quote_style: None,
                 span: Span::empty(),
-            }),],
+            })],
             fields: vec![
                 StructField {
                     field_name: Some("x".into()),
@@ -1102,7 +1135,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::Boolean(true)),],
+            values: vec![Expr::Value(Value::Boolean(true).with_span(Span::new(Location::new(1, 20), Location::new(1, 24))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bool
@@ -1112,9 +1145,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedByteStringLiteral(
-                "abc".into()
-            )),],
+            values: vec![Expr::Value(Value::SingleQuotedByteStringLiteral("abc".into()).with_span(Span::new(Location::new(1, 45), Location::new(1, 51))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Bytes(Some(42))
@@ -1128,7 +1159,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(4, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedString("2011-05-05".into())),],
+            values: vec![Expr::Value(Value::SingleQuotedString("2011-05-05".into()).with_span(Span::new(Location::new(1, 20), Location::new(1, 32))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Date
@@ -1140,8 +1171,8 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
         &Expr::Struct {
             values: vec![Expr::TypedString {
                 data_type: DataType::Datetime(None),
-                value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into())
-            },],
+                value: Value::SingleQuotedString("1999-01-01 01:23:34.45".into()).with_span(Span::new(Location::new(1, 57), Location::new(1, 82)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Datetime(None)
@@ -1151,7 +1182,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5.0")),],
+            values: vec![Expr::Value(number("5.0").with_span(Span::new(Location::new(1, 102), Location::new(1, 105))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Float64
@@ -1161,7 +1192,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("1")),],
+            values: vec![Expr::Value(number("1").with_span(Span::new(Location::new(1, 122), Location::new(1, 123))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Int64
@@ -1176,12 +1207,12 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(
         &Expr::Struct {
             values: vec![Expr::Interval(Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString("1".into()))),
+                value: Box::new(Expr::Value(Value::SingleQuotedString("1".into()).with_span(Span::new(Location::new(1, 30), Location::new(1, 33))))),
                 leading_field: Some(DateTimeField::Month),
                 leading_precision: None,
                 last_field: None,
                 fractional_seconds_precision: None
-            }),],
+            })],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Interval
@@ -1193,10 +1224,9 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
         &Expr::Struct {
             values: vec![Expr::TypedString {
                 data_type: DataType::JSON,
-                value: Value::SingleQuotedString(
-                    r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into()
-                )
-            },],
+                value: Value::SingleQuotedString(r#"{"class" : {"students" : [{"name" : "Jane"}]}}"#.into())
+                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::JSON
@@ -1210,7 +1240,7 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
     assert_eq!(3, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedString("foo".into())),],
+            values: vec![Expr::Value(Value::SingleQuotedString("foo".into()).with_span(Span::new(Location::new(1, 25), Location::new(1, 30))))],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::String(Some(42))
@@ -1223,7 +1253,8 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Timestamp(None, TimezoneInfo::None),
                 value: Value::SingleQuotedString("2008-12-25 15:30:00 America/Los_Angeles".into())
-            },],
+                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 95)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Timestamp(None, TimezoneInfo::None)
@@ -1237,7 +1268,8 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Time(None, TimezoneInfo::None),
                 value: Value::SingleQuotedString("15:30:00".into())
-            },],
+                    .with_span(Span::new(Location::new(1, 115), Location::new(1, 125)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Time(None, TimezoneInfo::None)
@@ -1254,7 +1286,8 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             values: vec![Expr::TypedString {
                 data_type: DataType::Numeric(ExactNumberInfo::None),
                 value: Value::SingleQuotedString("1".into())
-            },],
+                    .with_span(Span::new(Location::new(1, 30), Location::new(1, 33)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::Numeric(ExactNumberInfo::None)
@@ -1267,7 +1300,8 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             values: vec![Expr::TypedString {
                 data_type: DataType::BigNumeric(ExactNumberInfo::None),
                 value: Value::SingleQuotedString("1".into())
-            },],
+                    .with_span(Span::new(Location::new(1, 55), Location::new(1, 58)))
+            }],
             fields: vec![StructField {
                 field_name: None,
                 field_type: DataType::BigNumeric(ExactNumberInfo::None)
@@ -1279,12 +1313,12 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
 
 #[test]
 fn parse_typed_struct_with_field_name_bigquery() {
-    let sql = r#"SELECT STRUCT<x INT64>(5), STRUCT<y STRING>("foo")"#;
+    let sql = r#"SELECT STRUCT<x INT64>(5), STRUCT<y STRING>("foo")"#;  // line 1, column 1
     let select = bigquery().verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5")),],
+            values: vec![Expr::Value(number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22))))],
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
@@ -1294,7 +1328,7 @@ fn parse_typed_struct_with_field_name_bigquery() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::DoubleQuotedString("foo".into())),],
+            values: vec![Expr::Value(Value::DoubleQuotedString("foo".into()).with_span(Span::new(Location::new(1, 42), Location::new(1, 47))))],
             fields: vec![StructField {
                 field_name: Some(Ident::from("y")),
                 field_type: DataType::String(None)
@@ -1303,12 +1337,15 @@ fn parse_typed_struct_with_field_name_bigquery() {
         expr_from_projection(&select.projection[1])
     );
 
-    let sql = r#"SELECT STRUCT<x INT64, y INT64>(5, 5)"#;
+    let sql = r#"SELECT STRUCT<x INT64, y INT64>(5, 5)"#;  // line 1, column 1
     let select = bigquery().verified_only_select(sql);
     assert_eq!(1, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5")), Expr::Value(number("5")),],
+            values: vec![
+                Expr::Value(number("5").with_span(Span::new(Location::new(1, 32), Location::new(1, 33)))),
+                Expr::Value(number("5").with_span(Span::new(Location::new(1, 35), Location::new(1, 36)))),
+            ],
             fields: vec![
                 StructField {
                     field_name: Some(Ident::from("x")),
@@ -1326,12 +1363,12 @@ fn parse_typed_struct_with_field_name_bigquery() {
 
 #[test]
 fn parse_typed_struct_with_field_name_bigquery_and_generic() {
-    let sql = r#"SELECT STRUCT<x INT64>(5), STRUCT<y STRING>('foo')"#;
+    let sql = r#"SELECT STRUCT<x INT64>(5), STRUCT<y STRING>('foo')"#;  // line 1, column 1
     let select = bigquery().verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5")),],
+            values: vec![Expr::Value(number("5").with_span(Span::new(Location::new(1, 21), Location::new(1, 22))))],
             fields: vec![StructField {
                 field_name: Some(Ident::from("x")),
                 field_type: DataType::Int64
@@ -1341,7 +1378,7 @@ fn parse_typed_struct_with_field_name_bigquery_and_generic() {
     );
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(Value::SingleQuotedString("foo".into())),],
+            values: vec![Expr::Value(Value::SingleQuotedString("foo".into()).with_span(Span::new(Location::new(1, 42), Location::new(1, 47))))],
             fields: vec![StructField {
                 field_name: Some(Ident::from("y")),
                 field_type: DataType::String(None)
@@ -1350,12 +1387,15 @@ fn parse_typed_struct_with_field_name_bigquery_and_generic() {
         expr_from_projection(&select.projection[1])
     );
 
-    let sql = r#"SELECT STRUCT<x INT64, y INT64>(5, 5)"#;
+    let sql = r#"SELECT STRUCT<x INT64, y INT64>(5, 5)"#;  // line 1, column 1
     let select = bigquery_and_generic().verified_only_select(sql);
     assert_eq!(1, select.projection.len());
     assert_eq!(
         &Expr::Struct {
-            values: vec![Expr::Value(number("5")), Expr::Value(number("5")),],
+            values: vec![
+                Expr::Value(number("5").with_span(Span::new(Location::new(1, 32), Location::new(1, 33)))),
+                Expr::Value(number("5").with_span(Span::new(Location::new(1, 35), Location::new(1, 36)))),
+            ],
             fields: vec![
                 StructField {
                     field_name: Some(Ident::from("x")),
@@ -1563,7 +1603,7 @@ fn parse_hyphenated_table_identifiers() {
 #[test]
 fn parse_table_time_travel() {
     let version = "2023-08-18 23:08:18".to_string();
-    let sql = format!("SELECT 1 FROM t1 FOR SYSTEM_TIME AS OF '{version}'");
+    let sql = format!("SELECT 1 FROM t1 FOR SYSTEM_TIME AS OF '{version}'");  // line 1, column 1
     let select = bigquery().verified_only_select(&sql);
     assert_eq!(
         select.from,
@@ -1574,7 +1614,7 @@ fn parse_table_time_travel() {
                 args: None,
                 with_hints: vec![],
                 version: Some(TableVersion::ForSystemTimeAsOf(Expr::Value(
-                    Value::SingleQuotedString(version)
+                    Value::SingleQuotedString(version).with_span(Span::new(Location::new(1, 35), Location::new(1, 54)))
                 ))),
                 partitions: vec![],
                 with_ordinality: false,
@@ -1916,7 +1956,7 @@ fn parse_array_agg_func() {
 fn parse_big_query_declare() {
     for (sql, expected_names, expected_data_type, expected_assigned_expr) in [
         (
-            "DECLARE x INT64",
+            "DECLARE x INT64",  // line 1, column 1
             vec![Ident::new("x")],
             Some(DataType::Int64),
             None,

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -1968,19 +1968,25 @@ fn parse_big_query_declare() {
             "DECLARE x INT64 DEFAULT 42",
             vec![Ident::new("x")],
             Some(DataType::Int64),
-            Some(DeclareAssignment::Default(Box::new(Expr::Value(number("42").with_empty_span().with_empty_span())))),
+            Some(DeclareAssignment::Default(Box::new(Expr::Value(
+                number("42").with_empty_span(),
+            )))),
         ),
         (
             "DECLARE x, y, z INT64 DEFAULT 42",
             vec![Ident::new("x"), Ident::new("y"), Ident::new("z")],
             Some(DataType::Int64),
-            Some(DeclareAssignment::Default(Box::new(Expr::Value(number("42").with_empty_span().with_empty_span())))),
+            Some(DeclareAssignment::Default(Box::new(Expr::Value(
+                number("42").with_empty_span(),
+            )))),
         ),
         (
             "DECLARE x DEFAULT 42",
             vec![Ident::new("x")],
             None,
-            Some(DeclareAssignment::Default(Box::new(Expr::Value(number("42").with_empty_span().with_empty_span())))),
+            Some(DeclareAssignment::Default(Box::new(Expr::Value(
+                number("42").with_empty_span(),
+            )))),
         ),
     ] {
         match bigquery().verified_stmt(sql) {

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1393,7 +1393,7 @@ fn parse_freeze_and_unfreeze_partition() {
 
         let expected_partition = Partition::Expr(Expr::Value(Value::SingleQuotedString(
             "2024-08-14".to_string(),
-        )));
+        ).with_empty_span()));
         match clickhouse_and_generic().verified_stmt(&sql) {
             Statement::AlterTable { operations, .. } => {
                 assert_eq!(operations.len(), 1);
@@ -1423,7 +1423,7 @@ fn parse_freeze_and_unfreeze_partition() {
                 assert_eq!(operations.len(), 1);
                 let expected_partition = Partition::Expr(Expr::Value(Value::SingleQuotedString(
                     "2024-08-14".to_string(),
-                )));
+                ).with_empty_span()));
                 let expected_operation = if operation_name == &"FREEZE" {
                     AlterTableOperation::FreezePartition {
                         partition: expected_partition,

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -55,7 +55,10 @@ fn parse_map_access_expr() {
                         "indexOf",
                         [
                             Expr::Identifier(Ident::new("string_names")),
-                            Expr::Value((Value::SingleQuotedString("endpoint".to_string())).with_empty_span())
+                            Expr::Value(
+                                (Value::SingleQuotedString("endpoint".to_string()))
+                                    .with_empty_span()
+                            )
                         ]
                     ),
                 })],
@@ -71,7 +74,9 @@ fn parse_map_access_expr() {
                 left: Box::new(BinaryOp {
                     left: Box::new(Identifier(Ident::new("id"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value((Value::SingleQuotedString("test".to_string())).with_empty_span())),
+                    right: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("test".to_string())).with_empty_span()
+                    )),
                 }),
                 op: BinaryOperator::And,
                 right: Box::new(BinaryOp {
@@ -82,13 +87,18 @@ fn parse_map_access_expr() {
                                 "indexOf",
                                 [
                                     Expr::Identifier(Ident::new("string_name")),
-                                    Expr::Value((Value::SingleQuotedString("app".to_string())).with_empty_span())
+                                    Expr::Value(
+                                        (Value::SingleQuotedString("app".to_string()))
+                                            .with_empty_span()
+                                    )
                                 ]
                             ),
                         })],
                     }),
                     op: BinaryOperator::NotEq,
-                    right: Box::new(Expr::Value((Value::SingleQuotedString("foo".to_string())).with_empty_span())),
+                    right: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("foo".to_string())).with_empty_span()
+                    )),
                 }),
             }),
             group_by: GroupByExpr::Expressions(vec![], vec![]),
@@ -1014,17 +1024,15 @@ fn parse_select_parametric_function() {
                     assert_eq!(parameters.args.len(), 2);
                     assert_eq!(
                         parameters.args[0],
-                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((Value::Number(
-                            "0.5".parse().unwrap(),
-                            false
-                        )).with_empty_span())))
+                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                            (Value::Number("0.5".parse().unwrap(), false)).with_empty_span()
+                        )))
                     );
                     assert_eq!(
                         parameters.args[1],
-                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((Value::Number(
-                            "0.6".parse().unwrap(),
-                            false
-                        )).with_empty_span())))
+                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                            (Value::Number("0.6".parse().unwrap(), false)).with_empty_span()
+                        )))
                     );
                 }
                 _ => unreachable!(),
@@ -1103,7 +1111,10 @@ fn parse_select_order_by_with_fill_interpolate() {
         },
         select.order_by.expect("ORDER BY expected")
     );
-    assert_eq!(Some(Expr::Value((number("2")).with_empty_span())), select.limit);
+    assert_eq!(
+        Some(Expr::Value((number("2")).with_empty_span())),
+        select.limit
+    );
 }
 
 #[test]
@@ -1236,7 +1247,9 @@ fn test_prewhere() {
                 Some(&BinaryOp {
                     left: Box::new(Identifier(Ident::new("x"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
+                    right: Box::new(Expr::Value(
+                        (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                    )),
                 })
             );
             let selection = query.as_ref().body.as_select().unwrap().selection.as_ref();
@@ -1245,7 +1258,9 @@ fn test_prewhere() {
                 Some(&BinaryOp {
                     left: Box::new(Identifier(Ident::new("y"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value((Value::Number("2".parse().unwrap(), false)).with_empty_span())),
+                    right: Box::new(Expr::Value(
+                        (Value::Number("2".parse().unwrap(), false)).with_empty_span()
+                    )),
                 })
             );
         }
@@ -1261,13 +1276,17 @@ fn test_prewhere() {
                     left: Box::new(BinaryOp {
                         left: Box::new(Identifier(Ident::new("x"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
+                        right: Box::new(Expr::Value(
+                            (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                        )),
                     }),
                     op: BinaryOperator::And,
                     right: Box::new(BinaryOp {
                         left: Box::new(Identifier(Ident::new("y"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value((Value::Number("2".parse().unwrap(), false)).with_empty_span())),
+                        right: Box::new(Expr::Value(
+                            (Value::Number("2".parse().unwrap(), false)).with_empty_span()
+                        )),
                     }),
                 })
             );
@@ -1375,10 +1394,9 @@ fn parse_create_table_on_commit_and_as_query() {
             assert_eq!(on_commit, Some(OnCommit::PreserveRows));
             assert_eq!(
                 query.unwrap().body.as_select().unwrap().projection,
-                vec![UnnamedExpr(Expr::Value((Value::Number(
-                    "1".parse().unwrap(),
-                    false
-                )).with_empty_span()))]
+                vec![UnnamedExpr(Expr::Value(
+                    (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                ))]
             );
         }
         _ => unreachable!(),
@@ -1391,9 +1409,9 @@ fn parse_freeze_and_unfreeze_partition() {
     for operation_name in &["FREEZE", "UNFREEZE"] {
         let sql = format!("ALTER TABLE t {operation_name} PARTITION '2024-08-14'");
 
-        let expected_partition = Partition::Expr(Expr::Value(Value::SingleQuotedString(
-            "2024-08-14".to_string(),
-        ).with_empty_span()));
+        let expected_partition = Partition::Expr(Expr::Value(
+            Value::SingleQuotedString("2024-08-14".to_string()).with_empty_span(),
+        ));
         match clickhouse_and_generic().verified_stmt(&sql) {
             Statement::AlterTable { operations, .. } => {
                 assert_eq!(operations.len(), 1);
@@ -1421,9 +1439,9 @@ fn parse_freeze_and_unfreeze_partition() {
         match clickhouse_and_generic().verified_stmt(&sql) {
             Statement::AlterTable { operations, .. } => {
                 assert_eq!(operations.len(), 1);
-                let expected_partition = Partition::Expr(Expr::Value(Value::SingleQuotedString(
-                    "2024-08-14".to_string(),
-                ).with_empty_span()));
+                let expected_partition = Partition::Expr(Expr::Value(
+                    Value::SingleQuotedString("2024-08-14".to_string()).with_empty_span(),
+                ));
                 let expected_operation = if operation_name == &"FREEZE" {
                     AlterTableOperation::FreezePartition {
                         partition: expected_partition,

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -1082,9 +1082,9 @@ fn parse_select_order_by_with_fill_interpolate() {
                     asc: Some(true),
                     nulls_first: Some(true),
                     with_fill: Some(WithFill {
-                        from: Some(Expr::Value((number("10")).with_empty_span())),
-                        to: Some(Expr::Value((number("20")).with_empty_span())),
-                        step: Some(Expr::Value((number("2")).with_empty_span())),
+                        from: Some(Expr::value(number("10"))),
+                        to: Some(Expr::value(number("20"))),
+                        step: Some(Expr::value(number("2"))),
                     }),
                 },
                 OrderByExpr {
@@ -1092,9 +1092,9 @@ fn parse_select_order_by_with_fill_interpolate() {
                     asc: Some(false),
                     nulls_first: Some(false),
                     with_fill: Some(WithFill {
-                        from: Some(Expr::Value((number("30")).with_empty_span())),
-                        to: Some(Expr::Value((number("40")).with_empty_span())),
-                        step: Some(Expr::Value((number("3")).with_empty_span())),
+                        from: Some(Expr::value(number("30"))),
+                        to: Some(Expr::value(number("40"))),
+                        step: Some(Expr::value(number("3"))),
                     }),
                 },
             ],
@@ -1104,17 +1104,14 @@ fn parse_select_order_by_with_fill_interpolate() {
                     expr: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("col1"))),
                         op: BinaryOperator::Plus,
-                        right: Box::new(Expr::Value((number("1")).with_empty_span())),
+                        right: Box::new(Expr::value(number("1"))),
                     }),
                 }])
             })
         },
         select.order_by.expect("ORDER BY expected")
     );
-    assert_eq!(
-        Some(Expr::Value((number("2")).with_empty_span())),
-        select.limit
-    );
+    assert_eq!(Some(Expr::value(number("2"))), select.limit);
 }
 
 #[test]
@@ -1155,9 +1152,9 @@ fn parse_with_fill() {
     let select = clickhouse().verified_query(sql);
     assert_eq!(
         Some(WithFill {
-            from: Some(Expr::Value((number("10")).with_empty_span())),
-            to: Some(Expr::Value((number("20")).with_empty_span())),
-            step: Some(Expr::Value((number("2")).with_empty_span())),
+            from: Some(Expr::value(number("10"))),
+            to: Some(Expr::value(number("20"))),
+            step: Some(Expr::value(number("2"))),
         }),
         select.order_by.expect("ORDER BY expected").exprs[0].with_fill
     );
@@ -1194,7 +1191,7 @@ fn parse_interpolate_body_with_columns() {
                     expr: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("col1"))),
                         op: BinaryOperator::Plus,
-                        right: Box::new(Expr::Value((number("1")).with_empty_span())),
+                        right: Box::new(Expr::value(number("1"))),
                     }),
                 },
                 InterpolateExpr {
@@ -1206,7 +1203,7 @@ fn parse_interpolate_body_with_columns() {
                     expr: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("col4"))),
                         op: BinaryOperator::Plus,
-                        right: Box::new(Expr::Value((number("4")).with_empty_span())),
+                        right: Box::new(Expr::value(number("4"))),
                     }),
                 },
             ])

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -55,7 +55,7 @@ fn parse_map_access_expr() {
                         "indexOf",
                         [
                             Expr::Identifier(Ident::new("string_names")),
-                            Expr::Value(Value::SingleQuotedString("endpoint".to_string()))
+                            Expr::Value((Value::SingleQuotedString("endpoint".to_string())).with_empty_span())
                         ]
                     ),
                 })],
@@ -71,7 +71,7 @@ fn parse_map_access_expr() {
                 left: Box::new(BinaryOp {
                     left: Box::new(Identifier(Ident::new("id"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value(Value::SingleQuotedString("test".to_string()))),
+                    right: Box::new(Expr::Value((Value::SingleQuotedString("test".to_string())).with_empty_span())),
                 }),
                 op: BinaryOperator::And,
                 right: Box::new(BinaryOp {
@@ -82,13 +82,13 @@ fn parse_map_access_expr() {
                                 "indexOf",
                                 [
                                     Expr::Identifier(Ident::new("string_name")),
-                                    Expr::Value(Value::SingleQuotedString("app".to_string()))
+                                    Expr::Value((Value::SingleQuotedString("app".to_string())).with_empty_span())
                                 ]
                             ),
                         })],
                     }),
                     op: BinaryOperator::NotEq,
-                    right: Box::new(Expr::Value(Value::SingleQuotedString("foo".to_string()))),
+                    right: Box::new(Expr::Value((Value::SingleQuotedString("foo".to_string())).with_empty_span())),
                 }),
             }),
             group_by: GroupByExpr::Expressions(vec![], vec![]),
@@ -114,8 +114,8 @@ fn parse_array_expr() {
     assert_eq!(
         &Expr::Array(Array {
             elem: vec![
-                Expr::Value(Value::SingleQuotedString("1".to_string())),
-                Expr::Value(Value::SingleQuotedString("2".to_string())),
+                Expr::Value((Value::SingleQuotedString("1".to_string())).with_empty_span()),
+                Expr::Value((Value::SingleQuotedString("2".to_string())).with_empty_span()),
             ],
             named: false,
         }),
@@ -1014,17 +1014,17 @@ fn parse_select_parametric_function() {
                     assert_eq!(parameters.args.len(), 2);
                     assert_eq!(
                         parameters.args[0],
-                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(Value::Number(
+                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((Value::Number(
                             "0.5".parse().unwrap(),
                             false
-                        ))))
+                        )).with_empty_span())))
                     );
                     assert_eq!(
                         parameters.args[1],
-                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(Value::Number(
+                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((Value::Number(
                             "0.6".parse().unwrap(),
                             false
-                        ))))
+                        )).with_empty_span())))
                     );
                 }
                 _ => unreachable!(),
@@ -1074,9 +1074,9 @@ fn parse_select_order_by_with_fill_interpolate() {
                     asc: Some(true),
                     nulls_first: Some(true),
                     with_fill: Some(WithFill {
-                        from: Some(Expr::Value(number("10"))),
-                        to: Some(Expr::Value(number("20"))),
-                        step: Some(Expr::Value(number("2"))),
+                        from: Some(Expr::Value((number("10")).with_empty_span())),
+                        to: Some(Expr::Value((number("20")).with_empty_span())),
+                        step: Some(Expr::Value((number("2")).with_empty_span())),
                     }),
                 },
                 OrderByExpr {
@@ -1084,9 +1084,9 @@ fn parse_select_order_by_with_fill_interpolate() {
                     asc: Some(false),
                     nulls_first: Some(false),
                     with_fill: Some(WithFill {
-                        from: Some(Expr::Value(number("30"))),
-                        to: Some(Expr::Value(number("40"))),
-                        step: Some(Expr::Value(number("3"))),
+                        from: Some(Expr::Value((number("30")).with_empty_span())),
+                        to: Some(Expr::Value((number("40")).with_empty_span())),
+                        step: Some(Expr::Value((number("3")).with_empty_span())),
                     }),
                 },
             ],
@@ -1096,14 +1096,14 @@ fn parse_select_order_by_with_fill_interpolate() {
                     expr: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("col1"))),
                         op: BinaryOperator::Plus,
-                        right: Box::new(Expr::Value(number("1"))),
+                        right: Box::new(Expr::Value((number("1")).with_empty_span())),
                     }),
                 }])
             })
         },
         select.order_by.expect("ORDER BY expected")
     );
-    assert_eq!(Some(Expr::Value(number("2"))), select.limit);
+    assert_eq!(Some(Expr::Value((number("2")).with_empty_span())), select.limit);
 }
 
 #[test]
@@ -1144,9 +1144,9 @@ fn parse_with_fill() {
     let select = clickhouse().verified_query(sql);
     assert_eq!(
         Some(WithFill {
-            from: Some(Expr::Value(number("10"))),
-            to: Some(Expr::Value(number("20"))),
-            step: Some(Expr::Value(number("2"))),
+            from: Some(Expr::Value((number("10")).with_empty_span())),
+            to: Some(Expr::Value((number("20")).with_empty_span())),
+            step: Some(Expr::Value((number("2")).with_empty_span())),
         }),
         select.order_by.expect("ORDER BY expected").exprs[0].with_fill
     );
@@ -1183,7 +1183,7 @@ fn parse_interpolate_body_with_columns() {
                     expr: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("col1"))),
                         op: BinaryOperator::Plus,
-                        right: Box::new(Expr::Value(number("1"))),
+                        right: Box::new(Expr::Value((number("1")).with_empty_span())),
                     }),
                 },
                 InterpolateExpr {
@@ -1195,7 +1195,7 @@ fn parse_interpolate_body_with_columns() {
                     expr: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("col4"))),
                         op: BinaryOperator::Plus,
-                        right: Box::new(Expr::Value(number("4"))),
+                        right: Box::new(Expr::Value((number("4")).with_empty_span())),
                     }),
                 },
             ])
@@ -1236,7 +1236,7 @@ fn test_prewhere() {
                 Some(&BinaryOp {
                     left: Box::new(Identifier(Ident::new("x"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value(Value::Number("1".parse().unwrap(), false))),
+                    right: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
                 })
             );
             let selection = query.as_ref().body.as_select().unwrap().selection.as_ref();
@@ -1245,7 +1245,7 @@ fn test_prewhere() {
                 Some(&BinaryOp {
                     left: Box::new(Identifier(Ident::new("y"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value(Value::Number("2".parse().unwrap(), false))),
+                    right: Box::new(Expr::Value((Value::Number("2".parse().unwrap(), false)).with_empty_span())),
                 })
             );
         }
@@ -1261,13 +1261,13 @@ fn test_prewhere() {
                     left: Box::new(BinaryOp {
                         left: Box::new(Identifier(Ident::new("x"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value(Value::Number("1".parse().unwrap(), false))),
+                        right: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
                     }),
                     op: BinaryOperator::And,
                     right: Box::new(BinaryOp {
                         left: Box::new(Identifier(Ident::new("y"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value(Value::Number("2".parse().unwrap(), false))),
+                        right: Box::new(Expr::Value((Value::Number("2".parse().unwrap(), false)).with_empty_span())),
                     }),
                 })
             );
@@ -1375,10 +1375,10 @@ fn parse_create_table_on_commit_and_as_query() {
             assert_eq!(on_commit, Some(OnCommit::PreserveRows));
             assert_eq!(
                 query.unwrap().body.as_select().unwrap().projection,
-                vec![UnnamedExpr(Expr::Value(Value::Number(
+                vec![UnnamedExpr(Expr::Value((Value::Number(
                     "1".parse().unwrap(),
                     false
-                )))]
+                )).with_empty_span()))]
             );
         }
         _ => unreachable!(),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6078,7 +6078,7 @@ fn parse_interval_and_or_xor() {
 
 #[test]
 fn parse_at_timezone() {
-    let zero = Expr::Value(number("0"));
+    let zero = Expr::Value(number("0").with_empty_span());
     let sql = "SELECT FROM_UNIXTIME(0) AT TIME ZONE 'UTC-06:00' FROM t";
     let select = verified_only_select(sql);
     assert_eq!(
@@ -7907,7 +7907,7 @@ fn parse_offset() {
         all_dialects_where(|d| !d.is_column_alias(&Keyword::OFFSET, &mut Parser::new(d)));
 
     let expect = Some(Offset {
-        value: Expr::Value(number("2")),
+        value: Expr::Value(number("2").with_empty_span()),
         rows: OffsetRows::Rows,
     });
     let ast = dialects.verified_query("SELECT foo FROM bar OFFSET 2 ROWS");
@@ -7962,7 +7962,7 @@ fn parse_fetch() {
     let fetch_first_two_rows_only = Some(Fetch {
         with_ties: false,
         percent: false,
-        quantity: Some(Expr::Value(number("2"))),
+        quantity: Some(Expr::Value(number("2").with_empty_span())),
     });
     let ast = verified_query("SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
@@ -9478,7 +9478,7 @@ fn verified_expr(query: &str) -> Expr {
 fn parse_offset_and_limit() {
     let sql = "SELECT foo FROM bar LIMIT 1 OFFSET 2";
     let expect = Some(Offset {
-        value: Expr::Value(number("2")),
+        value: Expr::Value(number("2").with_empty_span()),
         rows: OffsetRows::None,
     });
     let ast = verified_query(sql);
@@ -11101,7 +11101,7 @@ fn parse_connect_by() {
                 op: BinaryOperator::Eq,
                 right: Box::new(Expr::Value(Value::SingleQuotedString(
                     "president".to_owned(),
-                ))),
+                ).with_empty_span())),
             },
             relationships: vec![Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("manager_id"))),
@@ -11807,7 +11807,7 @@ fn test_map_syntax() {
     );
 
     fn number_expr(s: &str) -> Expr {
-        Expr::Value(number(s))
+        Expr::Value(number(s).with_empty_span())
     }
 
     check(
@@ -13184,7 +13184,7 @@ fn parse_bang_not() {
         Box::new(Expr::Nested(Box::new(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("b"))),
             op: BinaryOperator::Gt,
-            right: Box::new(Expr::Value(Value::Number("3".parse().unwrap(), false))),
+            right: Box::new(Expr::Value(Value::Number("3".parse().unwrap(), false).with_empty_span())),
         }))),
     ]
     .into_iter()

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -69,7 +69,7 @@ fn parse_numeric_literal_underscore() {
 
     assert_eq!(
         select.projection,
-        vec![UnnamedExpr(Expr::Value(number("10_000")))]
+        vec![UnnamedExpr(Expr::Value((number("10_000")).with_empty_span()))]
     );
 }
 
@@ -93,9 +93,9 @@ fn parse_function_object_name() {
 #[test]
 fn parse_insert_values() {
     let row = vec![
-        Expr::Value(number("1")),
-        Expr::Value(number("2")),
-        Expr::Value(number("3")),
+        Expr::Value((number("1")).with_empty_span()),
+        Expr::Value((number("2")).with_empty_span()),
+        Expr::Value((number("3")).with_empty_span()),
     ];
     let rows1 = vec![row.clone()];
     let rows2 = vec![row.clone(), row];
@@ -384,15 +384,15 @@ fn parse_update() {
                 vec![
                     Assignment {
                         target: AssignmentTarget::ColumnName(ObjectName::from(vec!["a".into()])),
-                        value: Expr::Value(number("1")),
+                        value: Expr::Value((number("1")).with_empty_span()),
                     },
                     Assignment {
                         target: AssignmentTarget::ColumnName(ObjectName::from(vec!["b".into()])),
-                        value: Expr::Value(number("2")),
+                        value: Expr::Value((number("2")).with_empty_span()),
                     },
                     Assignment {
                         target: AssignmentTarget::ColumnName(ObjectName::from(vec!["c".into()])),
-                        value: Expr::Value(number("3")),
+                        value: Expr::Value((number("3")).with_empty_span()),
                     },
                 ]
             );
@@ -556,7 +556,7 @@ fn parse_update_with_table_alias() {
                         Ident::new("u"),
                         Ident::new("username")
                     ])),
-                    value: Expr::Value(Value::SingleQuotedString("new_user".to_string())),
+                    value: Expr::Value((Value::SingleQuotedString("new_user".to_string())).with_empty_span()),
                 }],
                 assignments
             );
@@ -567,9 +567,9 @@ fn parse_update_with_table_alias() {
                         Ident::new("username"),
                     ])),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value(Value::SingleQuotedString(
+                    right: Box::new(Expr::Value((Value::SingleQuotedString(
                         "old_user".to_string()
-                    ))),
+                    )).with_empty_span())),
                 }),
                 selection
             );
@@ -797,7 +797,7 @@ fn parse_where_delete_statement() {
                 Expr::BinaryOp {
                     left: Box::new(Expr::Identifier(Ident::new("name"))),
                     op: Eq,
-                    right: Box::new(Expr::Value(number("5"))),
+                    right: Box::new(Expr::Value((number("5")).with_empty_span())),
                 },
                 selection.unwrap(),
             );
@@ -896,7 +896,7 @@ fn parse_simple_select() {
     assert!(select.distinct.is_none());
     assert_eq!(3, select.projection.len());
     let select = verified_query(sql);
-    assert_eq!(Some(Expr::Value(number("5"))), select.limit);
+    assert_eq!(Some(Expr::Value((number("5")).with_empty_span())), select.limit);
 }
 
 #[test]
@@ -908,10 +908,10 @@ fn parse_limit() {
 fn parse_limit_is_not_an_alias() {
     // In dialects supporting LIMIT it shouldn't be parsed as a table alias
     let ast = verified_query("SELECT id FROM customer LIMIT 1");
-    assert_eq!(Some(Expr::Value(number("1"))), ast.limit);
+    assert_eq!(Some(Expr::Value((number("1")).with_empty_span())), ast.limit);
 
     let ast = verified_query("SELECT 1 LIMIT 5");
-    assert_eq!(Some(Expr::Value(number("5"))), ast.limit);
+    assert_eq!(Some(Expr::Value((number("5")).with_empty_span())), ast.limit);
 }
 
 #[test]
@@ -1129,7 +1129,7 @@ fn parse_column_aliases() {
     } = only(&select.projection)
     {
         assert_eq!(&BinaryOperator::Plus, op);
-        assert_eq!(&Expr::Value(number("1")), right.as_ref());
+        assert_eq!(&Expr::Value((number("1")).with_empty_span()), right.as_ref());
         assert_eq!(&Ident::new("newname"), alias);
     } else {
         panic!("Expected: ExprWithAlias")
@@ -1356,7 +1356,7 @@ fn parse_null_in_select() {
     let sql = "SELECT NULL";
     let select = verified_only_select(sql);
     assert_eq!(
-        &Expr::Value(Value::Null),
+        &Expr::Value((Value::Null).with_empty_span()),
         expr_from_projection(only(&select.projection)),
     );
 }
@@ -1392,18 +1392,18 @@ fn parse_exponent_in_select() -> Result<(), ParserError> {
 
     assert_eq!(
         &vec![
-            SelectItem::UnnamedExpr(Expr::Value(number("10e-20"))),
-            SelectItem::UnnamedExpr(Expr::Value(number("1e3"))),
-            SelectItem::UnnamedExpr(Expr::Value(number("1e+3"))),
+            SelectItem::UnnamedExpr(Expr::Value((number("10e-20")).with_empty_span())),
+            SelectItem::UnnamedExpr(Expr::Value((number("1e3")).with_empty_span())),
+            SelectItem::UnnamedExpr(Expr::Value((number("1e+3")).with_empty_span())),
             SelectItem::ExprWithAlias {
-                expr: Expr::Value(number("1e3")),
+                expr: Expr::Value((number("1e3")).with_empty_span()),
                 alias: Ident::new("a")
             },
             SelectItem::ExprWithAlias {
-                expr: Expr::Value(number("1")),
+                expr: Expr::Value((number("1")).with_empty_span()),
                 alias: Ident::new("e")
             },
-            SelectItem::UnnamedExpr(Expr::Value(number("0.5e2"))),
+            SelectItem::UnnamedExpr(Expr::Value((number("0.5e2")).with_empty_span())),
         ],
         &select.projection
     );
@@ -1437,9 +1437,9 @@ fn parse_escaped_single_quote_string_predicate_with_escape() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("salary"))),
             op: NotEq,
-            right: Box::new(Expr::Value(Value::SingleQuotedString(
+            right: Box::new(Expr::Value((Value::SingleQuotedString(
                 "Jim's salary".to_string()
-            ))),
+            )).with_empty_span())),
         }),
         ast.selection,
     );
@@ -1463,9 +1463,9 @@ fn parse_escaped_single_quote_string_predicate_with_no_escape() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("salary"))),
             op: NotEq,
-            right: Box::new(Expr::Value(Value::SingleQuotedString(
+            right: Box::new(Expr::Value((Value::SingleQuotedString(
                 "Jim''s salary".to_string()
-            ))),
+            )).with_empty_span())),
         }),
         ast.selection,
     );
@@ -1478,11 +1478,11 @@ fn parse_number() {
     #[cfg(feature = "bigdecimal")]
     assert_eq!(
         expr,
-        Expr::Value(Value::Number(bigdecimal::BigDecimal::from(1), false))
+        Expr::Value((Value::Number(bigdecimal::BigDecimal::from(1), false)).with_empty_span())
     );
 
     #[cfg(not(feature = "bigdecimal"))]
-    assert_eq!(expr, Expr::Value(Value::Number("1.0".into(), false)));
+    assert_eq!(expr, Expr::Value((Value::Number("1.0".into(), false)).with_empty_span()));
 }
 
 #[test]
@@ -1634,15 +1634,15 @@ fn parse_json_object() {
         }) => assert_eq!(
             &[
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString("name".into())),
-                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                    name: Expr::Value((Value::SingleQuotedString("name".into())).with_empty_span()),
+                    arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                         "value".into()
-                    ))),
+                    )).with_empty_span())),
                     operator: FunctionArgOperator::Colon
                 },
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString("type".into())),
-                    arg: FunctionArgExpr::Expr(Expr::Value(number("1"))),
+                    name: Expr::Value((Value::SingleQuotedString("type".into())).with_empty_span()),
+                    arg: FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span())),
                     operator: FunctionArgOperator::Colon
                 }
             ],
@@ -1660,15 +1660,15 @@ fn parse_json_object() {
             assert_eq!(
                 &[
                     FunctionArg::ExprNamed {
-                        name: Expr::Value(Value::SingleQuotedString("name".into())),
-                        arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        name: Expr::Value((Value::SingleQuotedString("name".into())).with_empty_span()),
+                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                             "value".into()
-                        ))),
+                        )).with_empty_span())),
                         operator: FunctionArgOperator::Colon
                     },
                     FunctionArg::ExprNamed {
-                        name: Expr::Value(Value::SingleQuotedString("type".into())),
-                        arg: FunctionArgExpr::Expr(Expr::Value(Value::Null)),
+                        name: Expr::Value((Value::SingleQuotedString("type".into())).with_empty_span()),
+                        arg: FunctionArgExpr::Expr(Expr::Value((Value::Null).with_empty_span())),
                         operator: FunctionArgOperator::Colon
                     }
                 ],
@@ -1725,10 +1725,10 @@ fn parse_json_object() {
         }) => {
             assert_eq!(
                 &FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString("name".into())),
-                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                    name: Expr::Value((Value::SingleQuotedString("name".into())).with_empty_span()),
+                    arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                         "value".into()
-                    ))),
+                    )).with_empty_span())),
                     operator: FunctionArgOperator::Colon
                 },
                 &args[0]
@@ -1736,7 +1736,7 @@ fn parse_json_object() {
             assert!(matches!(
                 args[1],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString(_)),
+                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
                     arg: FunctionArgExpr::Expr(Expr::Function(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -1760,10 +1760,10 @@ fn parse_json_object() {
         }) => {
             assert_eq!(
                 &FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString("name".into())),
-                    arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                    name: Expr::Value((Value::SingleQuotedString("name".into())).with_empty_span()),
+                    arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                         "value".into()
-                    ))),
+                    )).with_empty_span())),
                     operator: FunctionArgOperator::Colon
                 },
                 &args[0]
@@ -1771,7 +1771,7 @@ fn parse_json_object() {
             assert!(matches!(
                 args[1],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString(_)),
+                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
                     arg: FunctionArgExpr::Expr(Expr::Function(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -1880,9 +1880,9 @@ fn parse_not_precedence() {
         Expr::UnaryOp {
             op: UnaryOperator::Not,
             expr: Box::new(Expr::Between {
-                expr: Box::new(Expr::Value(number("1"))),
-                low: Box::new(Expr::Value(number("1"))),
-                high: Box::new(Expr::Value(number("2"))),
+                expr: Box::new(Expr::Value((number("1")).with_empty_span())),
+                low: Box::new(Expr::Value((number("1")).with_empty_span())),
+                high: Box::new(Expr::Value((number("2")).with_empty_span())),
                 negated: true,
             }),
         },
@@ -1895,9 +1895,9 @@ fn parse_not_precedence() {
         Expr::UnaryOp {
             op: UnaryOperator::Not,
             expr: Box::new(Expr::Like {
-                expr: Box::new(Expr::Value(Value::SingleQuotedString("a".into()))),
+                expr: Box::new(Expr::Value((Value::SingleQuotedString("a".into())).with_empty_span())),
                 negated: true,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("b".into()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("b".into())).with_empty_span())),
                 escape_char: None,
                 any: false,
             }),
@@ -1912,7 +1912,7 @@ fn parse_not_precedence() {
             op: UnaryOperator::Not,
             expr: Box::new(Expr::InList {
                 expr: Box::new(Expr::Identifier("a".into())),
-                list: vec![Expr::Value(Value::SingleQuotedString("a".into()))],
+                list: vec![Expr::Value((Value::SingleQuotedString("a".into())).with_empty_span())],
                 negated: true,
             }),
         },
@@ -1932,7 +1932,7 @@ fn parse_null_like() {
                 expr: Box::new(Expr::Identifier(Ident::new("column1"))),
                 any: false,
                 negated: false,
-                pattern: Box::new(Expr::Value(Value::Null)),
+                pattern: Box::new(Expr::Value((Value::Null).with_empty_span())),
                 escape_char: None,
             },
             alias: Ident {
@@ -1946,7 +1946,7 @@ fn parse_null_like() {
     assert_eq!(
         SelectItem::ExprWithAlias {
             expr: Expr::Like {
-                expr: Box::new(Expr::Value(Value::Null)),
+                expr: Box::new(Expr::Value((Value::Null).with_empty_span())),
                 any: false,
                 negated: false,
                 pattern: Box::new(Expr::Identifier(Ident::new("column1"))),
@@ -1974,7 +1974,7 @@ fn parse_ilike() {
             Expr::ILike {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
                 escape_char: None,
                 any: false,
             },
@@ -1991,7 +1991,7 @@ fn parse_ilike() {
             Expr::ILike {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
                 escape_char: Some('^'.to_string()),
                 any: false,
             },
@@ -2009,7 +2009,7 @@ fn parse_ilike() {
             Expr::IsNull(Box::new(Expr::ILike {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
                 escape_char: None,
                 any: false,
             })),
@@ -2032,7 +2032,7 @@ fn parse_like() {
             Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
                 escape_char: None,
                 any: false,
             },
@@ -2049,7 +2049,7 @@ fn parse_like() {
             Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
                 escape_char: Some('^'.to_string()),
                 any: false,
             },
@@ -2067,7 +2067,7 @@ fn parse_like() {
             Expr::IsNull(Box::new(Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
                 escape_char: None,
                 any: false,
             })),
@@ -2090,7 +2090,7 @@ fn parse_similar_to() {
             Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
                 escape_char: None,
             },
             select.selection.unwrap()
@@ -2106,7 +2106,7 @@ fn parse_similar_to() {
             Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
                 escape_char: Some('^'.to_string()),
             },
             select.selection.unwrap()
@@ -2122,7 +2122,7 @@ fn parse_similar_to() {
             Expr::IsNull(Box::new(Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value(Value::SingleQuotedString("%a".to_string()))),
+                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
                 escape_char: Some('^'.to_string()),
             })),
             select.selection.unwrap()
@@ -2144,8 +2144,8 @@ fn parse_in_list() {
             Expr::InList {
                 expr: Box::new(Expr::Identifier(Ident::new("segment"))),
                 list: vec![
-                    Expr::Value(Value::SingleQuotedString("HIGH".to_string())),
-                    Expr::Value(Value::SingleQuotedString("MED".to_string())),
+                    Expr::Value((Value::SingleQuotedString("HIGH".to_string())).with_empty_span()),
+                    Expr::Value((Value::SingleQuotedString("MED".to_string())).with_empty_span()),
                 ],
                 negated,
             },
@@ -2287,8 +2287,8 @@ fn parse_between() {
         assert_eq!(
             Expr::Between {
                 expr: Box::new(Expr::Identifier(Ident::new("age"))),
-                low: Box::new(Expr::Value(number("25"))),
-                high: Box::new(Expr::Value(number("32"))),
+                low: Box::new(Expr::Value((number("25")).with_empty_span())),
+                high: Box::new(Expr::Value((number("32")).with_empty_span())),
                 negated,
             },
             select.selection.unwrap()
@@ -2305,16 +2305,16 @@ fn parse_between_with_expr() {
     let select = verified_only_select(sql);
     assert_eq!(
         Expr::IsNull(Box::new(Expr::Between {
-            expr: Box::new(Expr::Value(number("1"))),
+            expr: Box::new(Expr::Value((number("1")).with_empty_span())),
             low: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value(number("1"))),
+                left: Box::new(Expr::Value((number("1")).with_empty_span())),
                 op: Plus,
-                right: Box::new(Expr::Value(number("2"))),
+                right: Box::new(Expr::Value((number("2")).with_empty_span())),
             }),
             high: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value(number("3"))),
+                left: Box::new(Expr::Value((number("3")).with_empty_span())),
                 op: Plus,
-                right: Box::new(Expr::Value(number("4"))),
+                right: Box::new(Expr::Value((number("4")).with_empty_span())),
             }),
             negated: false,
         })),
@@ -2326,19 +2326,19 @@ fn parse_between_with_expr() {
     assert_eq!(
         Expr::BinaryOp {
             left: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value(number("1"))),
+                left: Box::new(Expr::Value((number("1")).with_empty_span())),
                 op: BinaryOperator::Eq,
-                right: Box::new(Expr::Value(number("1"))),
+                right: Box::new(Expr::Value((number("1")).with_empty_span())),
             }),
             op: BinaryOperator::And,
             right: Box::new(Expr::Between {
                 expr: Box::new(Expr::BinaryOp {
-                    left: Box::new(Expr::Value(number("1"))),
+                    left: Box::new(Expr::Value((number("1")).with_empty_span())),
                     op: BinaryOperator::Plus,
                     right: Box::new(Expr::Identifier(Ident::new("x"))),
                 }),
-                low: Box::new(Expr::Value(number("1"))),
-                high: Box::new(Expr::Value(number("2"))),
+                low: Box::new(Expr::Value((number("1")).with_empty_span())),
+                high: Box::new(Expr::Value((number("2")).with_empty_span())),
                 negated: false,
             }),
         },
@@ -2353,13 +2353,13 @@ fn parse_tuples() {
     assert_eq!(
         vec![
             SelectItem::UnnamedExpr(Expr::Tuple(vec![
-                Expr::Value(number("1")),
-                Expr::Value(number("2")),
+                Expr::Value((number("1")).with_empty_span()),
+                Expr::Value((number("2")).with_empty_span()),
             ])),
-            SelectItem::UnnamedExpr(Expr::Nested(Box::new(Expr::Value(number("1"))))),
+            SelectItem::UnnamedExpr(Expr::Nested(Box::new(Expr::Value((number("1")).with_empty_span())))),
             SelectItem::UnnamedExpr(Expr::Tuple(vec![
-                Expr::Value(Value::SingleQuotedString("foo".into())),
-                Expr::Value(number("3")),
+                Expr::Value((Value::SingleQuotedString("foo".into())).with_empty_span()),
+                Expr::Value((number("3")).with_empty_span()),
                 Expr::Identifier(Ident::new("baz")),
             ])),
         ],
@@ -2440,7 +2440,7 @@ fn parse_select_order_by_limit() {
         ],
         select.order_by.expect("ORDER BY expected").exprs
     );
-    assert_eq!(Some(Expr::Value(number("2"))), select.limit);
+    assert_eq!(Some(Expr::Value((number("2")).with_empty_span())), select.limit);
 }
 
 #[test]
@@ -2465,7 +2465,7 @@ fn parse_select_order_by_nulls_order() {
         ],
         select.order_by.expect("ORDER BY expeccted").exprs
     );
-    assert_eq!(Some(Expr::Value(number("2"))), select.limit);
+    assert_eq!(Some(Expr::Value((number("2")).with_empty_span())), select.limit);
 }
 
 #[test]
@@ -2609,7 +2609,7 @@ fn parse_select_having() {
                 within_group: vec![]
             })),
             op: BinaryOperator::Gt,
-            right: Box::new(Expr::Value(number("1"))),
+            right: Box::new(Expr::Value((number("1")).with_empty_span())),
         }),
         select.having
     );
@@ -2650,7 +2650,7 @@ fn parse_select_qualify() {
                 within_group: vec![]
             })),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value(number("1"))),
+            right: Box::new(Expr::Value((number("1")).with_empty_span())),
         }),
         select.qualify
     );
@@ -2661,7 +2661,7 @@ fn parse_select_qualify() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("row_num"))),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value(number("1"))),
+            right: Box::new(Expr::Value((number("1")).with_empty_span())),
         }),
         select.qualify
     );
@@ -3042,15 +3042,15 @@ fn parse_listagg() {
                     FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(Ident::new(
                         "dateid"
                     )))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
                         Value::SingleQuotedString(", ".to_owned())
-                    )))
+                    ).with_empty_span())))
                 ],
                 clauses: vec![FunctionArgumentClause::OnOverflow(
                     ListAggOnOverflow::Truncate {
-                        filler: Some(Box::new(Expr::Value(Value::SingleQuotedString(
+                        filler: Some(Box::new(Expr::Value((Value::SingleQuotedString(
                             "%".to_string(),
-                        )))),
+                        )).with_empty_span()))),
                         with_count: false,
                     }
                 )],
@@ -3302,13 +3302,13 @@ fn gen_number_case(value: &str) -> (Vec<String>, Vec<SelectItem>) {
         format!("{} AS col_alias", value),
     ];
     let expected = vec![
-        SelectItem::UnnamedExpr(Expr::Value(number(value))),
+        SelectItem::UnnamedExpr(Expr::Value((number(value)).with_empty_span())),
         SelectItem::ExprWithAlias {
-            expr: Expr::Value(number(value)),
+            expr: Expr::Value((number(value)).with_empty_span()),
             alias: Ident::new("col_alias"),
         },
         SelectItem::ExprWithAlias {
-            expr: Expr::Value(number(value)),
+            expr: Expr::Value((number(value)).with_empty_span()),
             alias: Ident::new("col_alias"),
         },
     ];
@@ -3329,19 +3329,19 @@ fn gen_sign_number_case(value: &str, op: UnaryOperator) -> (Vec<String>, Vec<Sel
     let expected = vec![
         SelectItem::UnnamedExpr(Expr::UnaryOp {
             op,
-            expr: Box::new(Expr::Value(number(value))),
+            expr: Box::new(Expr::Value((number(value)).with_empty_span())),
         }),
         SelectItem::ExprWithAlias {
             expr: Expr::UnaryOp {
                 op,
-                expr: Box::new(Expr::Value(number(value))),
+                expr: Box::new(Expr::Value((number(value)).with_empty_span())),
             },
             alias: Ident::new("col_alias"),
         },
         SelectItem::ExprWithAlias {
             expr: Expr::UnaryOp {
                 op,
-                expr: Box::new(Expr::Value(number(value))),
+                expr: Box::new(Expr::Value((number(value)).with_empty_span())),
             },
             alias: Ident::new("col_alias"),
         },
@@ -3954,7 +3954,7 @@ fn parse_assert_message() {
             message: Some(message),
         } => {
             match message {
-                Expr::Value(Value::SingleQuotedString(s)) => assert_eq!(s, "No rows in my_table"),
+                Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(s), span: _}) => assert_eq!(s, "No rows in my_table"),
                 _ => unreachable!(),
             };
         }
@@ -4172,11 +4172,11 @@ fn parse_create_table_with_options() {
                 vec![
                     SqlOption::KeyValue {
                         key: "foo".into(),
-                        value: Expr::Value(Value::SingleQuotedString("bar".into())),
+                        value: Expr::Value((Value::SingleQuotedString("bar".into())).with_empty_span()),
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
-                        value: Expr::Value(number("123")),
+                        value: Expr::Value((number("123")).with_empty_span()),
                     },
                 ],
                 with_options
@@ -4402,7 +4402,7 @@ fn parse_alter_table() {
                         quote_style: Some('\''),
                         span: Span::empty(),
                     },
-                    value: Expr::Value(Value::SingleQuotedString("parquet".to_string())),
+                    value: Expr::Value((Value::SingleQuotedString("parquet".to_string())).with_empty_span()),
                 }],
             );
         }
@@ -4546,11 +4546,11 @@ fn parse_alter_view_with_options() {
                 vec![
                     SqlOption::KeyValue {
                         key: "foo".into(),
-                        value: Expr::Value(Value::SingleQuotedString("bar".into())),
+                        value: Expr::Value((Value::SingleQuotedString("bar".into())).with_empty_span()),
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
-                        value: Expr::Value(number("123")),
+                        value: Expr::Value((number("123")).with_empty_span()),
                     },
                 ],
                 with_options
@@ -4716,7 +4716,7 @@ fn parse_alter_table_alter_column() {
             assert_eq!(
                 op,
                 AlterColumnOperation::SetDefault {
-                    value: Expr::Value(test_utils::number("0"))
+                    value: Expr::Value((test_utils::number("0")).with_empty_span())
                 }
             );
         }
@@ -5050,16 +5050,16 @@ fn parse_named_argument_function() {
                 args: vec![
                     FunctionArg::Named {
                         name: Ident::new("a"),
-                        arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                             "1".to_owned()
-                        ))),
+                        )).with_empty_span())),
                         operator: FunctionArgOperator::RightArrow
                     },
                     FunctionArg::Named {
                         name: Ident::new("b"),
-                        arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                             "2".to_owned()
-                        ))),
+                        )).with_empty_span())),
                         operator: FunctionArgOperator::RightArrow
                     },
                 ],
@@ -5090,16 +5090,16 @@ fn parse_named_argument_function_with_eq_operator() {
                 args: vec![
                     FunctionArg::Named {
                         name: Ident::new("a"),
-                        arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                             "1".to_owned()
-                        ))),
+                        )).with_empty_span())),
                         operator: FunctionArgOperator::Equals
                     },
                     FunctionArg::Named {
                         name: Ident::new("b"),
-                        arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                             "2".to_owned()
-                        ))),
+                        )).with_empty_span())),
                         operator: FunctionArgOperator::Equals
                     },
                 ],
@@ -5123,7 +5123,7 @@ fn parse_named_argument_function_with_eq_operator() {
             [Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("bar"))),
                 op: BinaryOperator::Eq,
-                right: Box::new(Expr::Value(number("42"))),
+                right: Box::new(Expr::Value((number("42")).with_empty_span())),
             }]
         ),
     );
@@ -5469,14 +5469,14 @@ fn parse_literal_integer() {
     let select = verified_only_select(sql);
     assert_eq!(3, select.projection.len());
     assert_eq!(
-        &Expr::Value(number("1")),
+        &Expr::Value((number("1")).with_empty_span()),
         expr_from_projection(&select.projection[0]),
     );
     // negative literal is parsed as a - and expr
     assert_eq!(
         &UnaryOp {
             op: UnaryOperator::Minus,
-            expr: Box::new(Expr::Value(number("10")))
+            expr: Box::new(Expr::Value((number("10")).with_empty_span()))
         },
         expr_from_projection(&select.projection[1]),
     );
@@ -5484,7 +5484,7 @@ fn parse_literal_integer() {
     assert_eq!(
         &UnaryOp {
             op: UnaryOperator::Plus,
-            expr: Box::new(Expr::Value(number("20")))
+            expr: Box::new(Expr::Value((number("20")).with_empty_span()))
         },
         expr_from_projection(&select.projection[2]),
     )
@@ -5498,11 +5498,11 @@ fn parse_literal_decimal() {
     let select = verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
-        &Expr::Value(number("0.300000000000000004")),
+        &Expr::Value((number("0.300000000000000004")).with_empty_span()),
         expr_from_projection(&select.projection[0]),
     );
     assert_eq!(
-        &Expr::Value(number("9007199254740993.0")),
+        &Expr::Value((number("9007199254740993.0")).with_empty_span()),
         expr_from_projection(&select.projection[1]),
     )
 }
@@ -5513,15 +5513,15 @@ fn parse_literal_string() {
     let select = verified_only_select(sql);
     assert_eq!(3, select.projection.len());
     assert_eq!(
-        &Expr::Value(Value::SingleQuotedString("one".to_string())),
+        &Expr::Value((Value::SingleQuotedString("one".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
-        &Expr::Value(Value::NationalStringLiteral("national string".to_string())),
+        &Expr::Value((Value::NationalStringLiteral("national string".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[1])
     );
     assert_eq!(
-        &Expr::Value(Value::HexStringLiteral("deadBEEF".to_string())),
+        &Expr::Value((Value::HexStringLiteral("deadBEEF".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[2])
     );
 
@@ -5606,7 +5606,7 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1-1")))),
+            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from("1-1"))).with_empty_span())),
             leading_field: Some(DateTimeField::Year),
             leading_precision: None,
             last_field: Some(DateTimeField::Month),
@@ -5619,9 +5619,9 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
+            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
                 "01:01.01"
-            )))),
+            ))).with_empty_span())),
             leading_field: Some(DateTimeField::Minute),
             leading_precision: Some(5),
             last_field: Some(DateTimeField::Second),
@@ -5634,7 +5634,7 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("1")))),
+            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from("1"))).with_empty_span())),
             leading_field: Some(DateTimeField::Second),
             leading_precision: Some(5),
             last_field: None,
@@ -5647,7 +5647,7 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
+            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from("10"))).with_empty_span())),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: None,
             last_field: None,
@@ -5660,7 +5660,7 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value(number("5"))),
+            value: Box::new(Expr::Value((number("5")).with_empty_span())),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
             last_field: None,
@@ -5673,7 +5673,7 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value(number("5"))),
+            value: Box::new(Expr::Value((number("5")).with_empty_span())),
             leading_field: Some(DateTimeField::Days),
             leading_precision: None,
             last_field: None,
@@ -5686,7 +5686,7 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from("10")))),
+            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from("10"))).with_empty_span())),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: Some(1),
             last_field: None,
@@ -5755,9 +5755,9 @@ fn parse_interval_dont_require_unit() {
     let select = dialects.verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
+            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
                 "1 DAY"
-            )))),
+            ))).with_empty_span())),
             leading_field: None,
             leading_precision: None,
             last_field: None,
@@ -5794,9 +5794,9 @@ fn parse_interval_require_qualifier() {
         expr_from_projection(only(&select.projection)),
         &Expr::Interval(Interval {
             value: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value(number("1"))),
+                left: Box::new(Expr::Value((number("1")).with_empty_span())),
                 op: BinaryOperator::Plus,
-                right: Box::new(Expr::Value(number("1"))),
+                right: Box::new(Expr::Value((number("1")).with_empty_span())),
             }),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
@@ -5811,9 +5811,9 @@ fn parse_interval_require_qualifier() {
         expr_from_projection(only(&select.projection)),
         &Expr::Interval(Interval {
             value: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value(Value::SingleQuotedString("1".to_string()))),
+                left: Box::new(Expr::Value((Value::SingleQuotedString("1".to_string())).with_empty_span())),
                 op: BinaryOperator::Plus,
-                right: Box::new(Expr::Value(Value::SingleQuotedString("1".to_string()))),
+                right: Box::new(Expr::Value((Value::SingleQuotedString("1".to_string())).with_empty_span())),
             }),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
@@ -5829,12 +5829,12 @@ fn parse_interval_require_qualifier() {
         &Expr::Interval(Interval {
             value: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::BinaryOp {
-                    left: Box::new(Expr::Value(Value::SingleQuotedString("1".to_string()))),
+                    left: Box::new(Expr::Value((Value::SingleQuotedString("1".to_string())).with_empty_span())),
                     op: BinaryOperator::Plus,
-                    right: Box::new(Expr::Value(Value::SingleQuotedString("2".to_string()))),
+                    right: Box::new(Expr::Value((Value::SingleQuotedString("2".to_string())).with_empty_span())),
                 }),
                 op: BinaryOperator::Minus,
-                right: Box::new(Expr::Value(Value::SingleQuotedString("3".to_string()))),
+                right: Box::new(Expr::Value((Value::SingleQuotedString("3".to_string())).with_empty_span())),
             }),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
@@ -5853,9 +5853,9 @@ fn parse_interval_disallow_interval_expr() {
     assert_eq!(
         expr_from_projection(only(&select.projection)),
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
+            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
                 "1 DAY"
-            )))),
+            ))).with_empty_span())),
             leading_field: None,
             leading_precision: None,
             last_field: None,
@@ -5876,9 +5876,9 @@ fn parse_interval_disallow_interval_expr() {
         expr_from_projection(only(&select.projection)),
         &Expr::BinaryOp {
             left: Box::new(Expr::Interval(Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
+                value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
                     "1 DAY"
-                )))),
+                ))).with_empty_span())),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
@@ -5886,9 +5886,9 @@ fn parse_interval_disallow_interval_expr() {
             })),
             op: BinaryOperator::Gt,
             right: Box::new(Expr::Interval(Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString(String::from(
+                value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
                     "1 SECOND"
-                )))),
+                ))).with_empty_span())),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
@@ -5906,9 +5906,9 @@ fn interval_disallow_interval_expr_gt() {
         expr,
         Expr::BinaryOp {
             left: Box::new(Expr::Interval(Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString(
+                value: Box::new(Expr::Value((Value::SingleQuotedString(
                     "1 second".to_string()
-                ))),
+                )).with_empty_span())),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
@@ -5933,9 +5933,9 @@ fn interval_disallow_interval_expr_double_colon() {
         Expr::Cast {
             kind: CastKind::DoubleColon,
             expr: Box::new(Expr::Interval(Interval {
-                value: Box::new(Expr::Value(Value::SingleQuotedString(
+                value: Box::new(Expr::Value((Value::SingleQuotedString(
                     "1 second".to_string()
-                ))),
+                )).with_empty_span())),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
@@ -5995,9 +5995,9 @@ fn parse_interval_and_or_xor() {
                         })),
                         op: BinaryOperator::Plus,
                         right: Box::new(Expr::Interval(Interval {
-                            value: Box::new(Expr::Value(Value::SingleQuotedString(
+                            value: Box::new(Expr::Value((Value::SingleQuotedString(
                                 "5 days".to_string(),
-                            ))),
+                            )).with_empty_span())),
                             leading_field: None,
                             leading_precision: None,
                             last_field: None,
@@ -6021,9 +6021,9 @@ fn parse_interval_and_or_xor() {
                         })),
                         op: BinaryOperator::Plus,
                         right: Box::new(Expr::Interval(Interval {
-                            value: Box::new(Expr::Value(Value::SingleQuotedString(
+                            value: Box::new(Expr::Value((Value::SingleQuotedString(
                                 "3 days".to_string(),
-                            ))),
+                            )).with_empty_span())),
                             leading_field: None,
                             leading_precision: None,
                             last_field: None,
@@ -6084,9 +6084,9 @@ fn parse_at_timezone() {
     assert_eq!(
         &Expr::AtTimeZone {
             timestamp: Box::new(call("FROM_UNIXTIME", [zero.clone()])),
-            time_zone: Box::new(Expr::Value(Value::SingleQuotedString(
+            time_zone: Box::new(Expr::Value((Value::SingleQuotedString(
                 "UTC-06:00".to_string()
-            ))),
+            )).with_empty_span())),
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -6100,11 +6100,11 @@ fn parse_at_timezone() {
                 [
                     Expr::AtTimeZone {
                         timestamp: Box::new(call("FROM_UNIXTIME", [zero])),
-                        time_zone: Box::new(Expr::Value(Value::SingleQuotedString(
+                        time_zone: Box::new(Expr::Value((Value::SingleQuotedString(
                             "UTC-06:00".to_string()
-                        ))),
+                        )).with_empty_span())),
                     },
-                    Expr::Value(Value::SingleQuotedString("%Y-%m-%dT%H".to_string()),)
+                    Expr::Value((Value::SingleQuotedString("%Y-%m-%dT%H".to_string())).with_empty_span())
                 ]
             ),
             alias: Ident {
@@ -6278,7 +6278,7 @@ fn parse_table_function() {
             assert_eq!(
                 call(
                     "FUN",
-                    [Expr::Value(Value::SingleQuotedString("1".to_owned()))],
+                    [Expr::Value((Value::SingleQuotedString("1".to_owned())).with_empty_span())],
                 ),
                 expr
             );
@@ -6461,9 +6461,9 @@ fn parse_unnest_in_from_clause() {
                 array_exprs: vec![call(
                     "make_array",
                     [
-                        Expr::Value(number("1")),
-                        Expr::Value(number("2")),
-                        Expr::Value(number("3")),
+                        Expr::Value((number("1")).with_empty_span()),
+                        Expr::Value((number("2")).with_empty_span()),
+                        Expr::Value((number("3")).with_empty_span()),
                     ],
                 )],
                 with_offset: false,
@@ -6487,14 +6487,14 @@ fn parse_unnest_in_from_clause() {
                     call(
                         "make_array",
                         [
-                            Expr::Value(number("1")),
-                            Expr::Value(number("2")),
-                            Expr::Value(number("3")),
+                            Expr::Value((number("1")).with_empty_span()),
+                            Expr::Value((number("2")).with_empty_span()),
+                            Expr::Value((number("3")).with_empty_span()),
                         ],
                     ),
                     call(
                         "make_array",
-                        [Expr::Value(number("5")), Expr::Value(number("6"))],
+                        [Expr::Value((number("5")).with_empty_span()), Expr::Value((number("6")).with_empty_span())],
                     ),
                 ],
                 with_offset: false,
@@ -6543,22 +6543,22 @@ fn parse_searched_case_expr() {
                 BinaryOp {
                     left: Box::new(Identifier(Ident::new("bar"))),
                     op: Eq,
-                    right: Box::new(Expr::Value(number("0"))),
+                    right: Box::new(Expr::Value((number("0")).with_empty_span())),
                 },
                 BinaryOp {
                     left: Box::new(Identifier(Ident::new("bar"))),
                     op: GtEq,
-                    right: Box::new(Expr::Value(number("0"))),
+                    right: Box::new(Expr::Value((number("0")).with_empty_span())),
                 },
             ],
             results: vec![
-                Expr::Value(Value::SingleQuotedString("null".to_string())),
-                Expr::Value(Value::SingleQuotedString("=0".to_string())),
-                Expr::Value(Value::SingleQuotedString(">=0".to_string())),
+                Expr::Value((Value::SingleQuotedString("null".to_string())).with_empty_span()),
+                Expr::Value((Value::SingleQuotedString("=0".to_string())).with_empty_span()),
+                Expr::Value((Value::SingleQuotedString(">=0".to_string())).with_empty_span()),
             ],
-            else_result: Some(Box::new(Expr::Value(Value::SingleQuotedString(
+            else_result: Some(Box::new(Expr::Value((Value::SingleQuotedString(
                 "<0".to_string()
-            )))),
+            )).with_empty_span()))),
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -6573,11 +6573,11 @@ fn parse_simple_case_expr() {
     assert_eq!(
         &Case {
             operand: Some(Box::new(Identifier(Ident::new("foo")))),
-            conditions: vec![Expr::Value(number("1"))],
-            results: vec![Expr::Value(Value::SingleQuotedString("Y".to_string()))],
-            else_result: Some(Box::new(Expr::Value(Value::SingleQuotedString(
+            conditions: vec![Expr::Value((number("1")).with_empty_span())],
+            results: vec![Expr::Value((Value::SingleQuotedString("Y".to_string())).with_empty_span())],
+            else_result: Some(Box::new(Expr::Value((Value::SingleQuotedString(
                 "N".to_string()
-            )))),
+            )).with_empty_span()))),
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -7326,13 +7326,13 @@ fn parse_overlay() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Overlay {
-            expr: Box::new(Expr::Value(Value::SingleQuotedString("abcdef".to_string()))),
+            expr: Box::new(Expr::Value((Value::SingleQuotedString("abcdef".to_string())).with_empty_span())),
             overlay_what: Box::new(Expr::Identifier(Ident::new("name"))),
-            overlay_from: Box::new(Expr::Value(number("3"))),
+            overlay_from: Box::new(Expr::Value((number("3")).with_empty_span())),
             overlay_for: Some(Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("id"))),
                 op: BinaryOperator::Plus,
-                right: Box::new(Expr::Value(number("1"))),
+                right: Box::new(Expr::Value((number("1")).with_empty_span())),
             })),
         },
         expr_from_projection(only(&select.projection))
@@ -7560,11 +7560,11 @@ fn parse_create_view_with_options() {
                 CreateTableOptions::With(vec![
                     SqlOption::KeyValue {
                         key: "foo".into(),
-                        value: Expr::Value(Value::SingleQuotedString("bar".into())),
+                        value: Expr::Value((Value::SingleQuotedString("bar".into())).with_empty_span()),
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
-                        value: Expr::Value(number("123")),
+                        value: Expr::Value((number("123")).with_empty_span()),
                     },
                 ]),
                 options
@@ -7935,7 +7935,7 @@ fn parse_offset() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value(number("0")),
+            value: Expr::Value((number("0")).with_empty_span()),
             rows: OffsetRows::Rows,
         })
     );
@@ -7943,7 +7943,7 @@ fn parse_offset() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value(number("1")),
+            value: Expr::Value((number("1")).with_empty_span()),
             rows: OffsetRows::Row,
         })
     );
@@ -7951,7 +7951,7 @@ fn parse_offset() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value(number("1")),
+            value: Expr::Value((number("1")).with_empty_span()),
             rows: OffsetRows::None,
         })
     );
@@ -7989,7 +7989,7 @@ fn parse_fetch() {
         Some(Fetch {
             with_ties: true,
             percent: false,
-            quantity: Some(Expr::Value(number("2"))),
+            quantity: Some(Expr::Value((number("2")).with_empty_span())),
         })
     );
     let ast = verified_query("SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY");
@@ -7998,7 +7998,7 @@ fn parse_fetch() {
         Some(Fetch {
             with_ties: false,
             percent: true,
-            quantity: Some(Expr::Value(number("50"))),
+            quantity: Some(Expr::Value((number("50")).with_empty_span())),
         })
     );
     let ast = verified_query(
@@ -8007,7 +8007,7 @@ fn parse_fetch() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value(number("2")),
+            value: Expr::Value((number("2")).with_empty_span()),
             rows: OffsetRows::Rows,
         })
     );
@@ -8029,7 +8029,7 @@ fn parse_fetch() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value(number("2")),
+            value: Expr::Value((number("2")).with_empty_span()),
             rows: OffsetRows::Rows,
         })
     );
@@ -8040,7 +8040,7 @@ fn parse_fetch() {
                 assert_eq!(
                     subquery.offset,
                     Some(Offset {
-                        value: Expr::Value(number("2")),
+                        value: Expr::Value((number("2")).with_empty_span()),
                         rows: OffsetRows::Rows,
                     })
                 );
@@ -8090,7 +8090,7 @@ fn lateral_derived() {
         let join = &from.joins[0];
         assert_eq!(
             join.join_operator,
-            JoinOperator::Left(JoinConstraint::On(Expr::Value(test_utils::number("1"))))
+            JoinOperator::Left(JoinConstraint::On(Expr::Value((test_utils::number("1")).with_empty_span())))
         );
         if let TableFactor::Derived {
             lateral,
@@ -8150,7 +8150,7 @@ fn lateral_function() {
                     lateral: true,
                     name: ObjectName::from(vec!["generate_series".into()]),
                     args: vec![
-                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(number("1")))),
+                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span()))),
                         FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::CompoundIdentifier(
                             vec![Ident::new("customer"), Ident::new("id")],
                         ))),
@@ -8314,7 +8314,7 @@ fn parse_set_variable() {
             );
             assert_eq!(
                 value,
-                vec![Expr::Value(Value::SingleQuotedString("1".into()))]
+                vec![Expr::Value((Value::SingleQuotedString("1".into())).with_empty_span())]
             );
         }
         _ => unreachable!(),
@@ -8342,9 +8342,9 @@ fn parse_set_variable() {
             assert_eq!(
                 value,
                 vec![
-                    Expr::Value(number("1")),
-                    Expr::Value(number("2")),
-                    Expr::Value(number("3")),
+                    Expr::Value((number("1")).with_empty_span()),
+                    Expr::Value((number("2")).with_empty_span()),
+                    Expr::Value((number("3")).with_empty_span()),
                 ]
             );
         }
@@ -8414,7 +8414,7 @@ fn parse_set_role_as_variable() {
             );
             assert_eq!(
                 value,
-                vec![Expr::Value(Value::SingleQuotedString("foobar".into()))]
+                vec![Expr::Value((Value::SingleQuotedString("foobar".into())).with_empty_span())]
             );
         }
         _ => unreachable!(),
@@ -8430,15 +8430,15 @@ fn parse_double_colon_cast_at_timezone() {
         &Expr::AtTimeZone {
             timestamp: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value(Value::SingleQuotedString(
+                expr: Box::new(Expr::Value((Value::SingleQuotedString(
                     "2001-01-01T00:00:00.000Z".to_string()
-                ),)),
+                )).with_empty_span())),
                 data_type: DataType::Timestamp(None, TimezoneInfo::None),
                 format: None
             }),
-            time_zone: Box::new(Expr::Value(Value::SingleQuotedString(
+            time_zone: Box::new(Expr::Value((Value::SingleQuotedString(
                 "Europe/Brussels".to_string()
-            ))),
+            )).with_empty_span())),
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -8461,7 +8461,7 @@ fn parse_set_time_zone() {
             );
             assert_eq!(
                 value,
-                vec![Expr::Value(Value::SingleQuotedString("UTC".into()))]
+                vec![Expr::Value((Value::SingleQuotedString("UTC".into())).with_empty_span())]
             );
         }
         _ => unreachable!(),
@@ -8475,7 +8475,7 @@ fn parse_set_time_zone_alias() {
     match verified_stmt("SET TIME ZONE 'UTC'") {
         Statement::SetTimeZone { local, value } => {
             assert!(!local);
-            assert_eq!(value, Expr::Value(Value::SingleQuotedString("UTC".into())));
+            assert_eq!(value, Expr::Value((Value::SingleQuotedString("UTC".into())).with_empty_span()));
         }
         _ => unreachable!(),
     }
@@ -8672,7 +8672,7 @@ fn test_create_index_with_with_clause() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("fillfactor"))),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value(number("70"))),
+            right: Box::new(Expr::Value((number("70")).with_empty_span())),
         },
         Expr::Identifier(Ident::new("single_param")),
     ];
@@ -9161,9 +9161,9 @@ fn parse_merge() {
                                 Ident::new("A"),
                             ])),
                             op: BinaryOperator::Eq,
-                            right: Box::new(Expr::Value(Value::SingleQuotedString(
+                            right: Box::new(Expr::Value((Value::SingleQuotedString(
                                 "a".to_string()
-                            ))),
+                            )).with_empty_span())),
                         }),
                         action: MergeAction::Update {
                             assignments: vec![
@@ -9389,7 +9389,7 @@ fn test_placeholder() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("id"))),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value(Value::Placeholder("$Id1".into()))),
+            right: Box::new(Expr::Value((Value::Placeholder("$Id1".into())).with_empty_span())),
         })
     );
 
@@ -9397,12 +9397,12 @@ fn test_placeholder() {
     let ast = dialects.verified_query(sql);
     assert_eq!(
         ast.limit,
-        Some(Expr::Value(Value::Placeholder("$1".into())))
+        Some(Expr::Value((Value::Placeholder("$1".into())).with_empty_span()))
     );
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value(Value::Placeholder("$2".into())),
+            value: Expr::Value((Value::Placeholder("$2".into())).with_empty_span()),
             rows: OffsetRows::None,
         }),
     );
@@ -9426,7 +9426,7 @@ fn test_placeholder() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("id"))),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value(Value::Placeholder("?".into()))),
+            right: Box::new(Expr::Value((Value::Placeholder("?".into())).with_empty_span())),
         })
     );
 
@@ -9435,9 +9435,9 @@ fn test_placeholder() {
     assert_eq!(
         ast.projection,
         vec![
-            UnnamedExpr(Expr::Value(Value::Placeholder("$fromage_français".into()))),
-            UnnamedExpr(Expr::Value(Value::Placeholder(":x".into()))),
-            UnnamedExpr(Expr::Value(Value::Placeholder("?123".into()))),
+            UnnamedExpr(Expr::Value((Value::Placeholder("$fromage_français".into())).with_empty_span())),
+            UnnamedExpr(Expr::Value((Value::Placeholder(":x".into())).with_empty_span())),
+            UnnamedExpr(Expr::Value((Value::Placeholder("?123".into())).with_empty_span())),
         ]
     );
 }
@@ -9483,7 +9483,7 @@ fn parse_offset_and_limit() {
     });
     let ast = verified_query(sql);
     assert_eq!(ast.offset, expect);
-    assert_eq!(ast.limit, Some(Expr::Value(number("1"))));
+    assert_eq!(ast.limit, Some(Expr::Value((number("1")).with_empty_span())));
 
     // different order is OK
     one_statement_parses_to("SELECT foo FROM bar OFFSET 2 LIMIT 1", sql);
@@ -9503,18 +9503,18 @@ fn parse_offset_and_limit() {
     assert_eq!(
         ast.limit,
         Some(Expr::BinaryOp {
-            left: Box::new(Expr::Value(number("1"))),
+            left: Box::new(Expr::Value((number("1")).with_empty_span())),
             op: BinaryOperator::Plus,
-            right: Box::new(Expr::Value(number("2"))),
+            right: Box::new(Expr::Value((number("2")).with_empty_span())),
         }),
     );
     assert_eq!(
         ast.offset,
         Some(Offset {
             value: Expr::BinaryOp {
-                left: Box::new(Expr::Value(number("3"))),
+                left: Box::new(Expr::Value((number("3")).with_empty_span())),
                 op: BinaryOperator::Multiply,
-                right: Box::new(Expr::Value(number("4"))),
+                right: Box::new(Expr::Value((number("4")).with_empty_span())),
             },
             rows: OffsetRows::None,
         }),
@@ -9585,7 +9585,7 @@ fn parse_time_functions() {
 fn parse_position() {
     assert_eq!(
         Expr::Position {
-            expr: Box::new(Expr::Value(Value::SingleQuotedString("@".to_string()))),
+            expr: Box::new(Expr::Value((Value::SingleQuotedString("@".to_string())).with_empty_span())),
             r#in: Box::new(Expr::Identifier(Ident::new("field"))),
         },
         verified_expr("POSITION('@' IN field)"),
@@ -9596,9 +9596,9 @@ fn parse_position() {
         call(
             "position",
             [
-                Expr::Value(Value::SingleQuotedString("an".to_owned())),
-                Expr::Value(Value::SingleQuotedString("banana".to_owned())),
-                Expr::Value(number("1")),
+                Expr::Value((Value::SingleQuotedString("an".to_owned())).with_empty_span()),
+                Expr::Value((Value::SingleQuotedString("banana".to_owned())).with_empty_span()),
+                Expr::Value((number("1")).with_empty_span()),
             ]
         ),
         verified_expr("position('an', 'banana', 1)")
@@ -9851,11 +9851,11 @@ fn parse_cache_table() {
             options: vec![
                 SqlOption::KeyValue {
                     key: Ident::with_quote('\'', "K1"),
-                    value: Expr::Value(Value::SingleQuotedString("V1".into())),
+                    value: Expr::Value((Value::SingleQuotedString("V1".into())).with_empty_span()),
                 },
                 SqlOption::KeyValue {
                     key: Ident::with_quote('\'', "K2"),
-                    value: Expr::Value(number("0.88")),
+                    value: Expr::Value((number("0.88")).with_empty_span()),
                 },
             ],
             query: None,
@@ -9876,11 +9876,11 @@ fn parse_cache_table() {
             options: vec![
                 SqlOption::KeyValue {
                     key: Ident::with_quote('\'', "K1"),
-                    value: Expr::Value(Value::SingleQuotedString("V1".into())),
+                    value: Expr::Value((Value::SingleQuotedString("V1".into())).with_empty_span()),
                 },
                 SqlOption::KeyValue {
                     key: Ident::with_quote('\'', "K2"),
-                    value: Expr::Value(number("0.88")),
+                    value: Expr::Value((number("0.88")).with_empty_span()),
                 },
             ],
             query: Some(query.clone().into()),
@@ -9901,11 +9901,11 @@ fn parse_cache_table() {
             options: vec![
                 SqlOption::KeyValue {
                     key: Ident::with_quote('\'', "K1"),
-                    value: Expr::Value(Value::SingleQuotedString("V1".into())),
+                    value: Expr::Value((Value::SingleQuotedString("V1".into())).with_empty_span()),
                 },
                 SqlOption::KeyValue {
                     key: Ident::with_quote('\'', "K2"),
-                    value: Expr::Value(number("0.88")),
+                    value: Expr::Value((number("0.88")).with_empty_span()),
                 },
             ],
             query: Some(query.clone().into()),
@@ -10116,7 +10116,7 @@ fn parse_escaped_string_with_unescape() {
                     let expr = expr_from_projection(only(&value.projection));
                     assert_eq!(
                         *expr,
-                        Expr::Value(Value::SingleQuotedString(quoted.to_string()))
+                        Expr::Value((Value::SingleQuotedString(quoted.to_string())).with_empty_span())
                     );
                 }
                 _ => unreachable!(),
@@ -10156,7 +10156,7 @@ fn parse_escaped_string_without_unescape() {
                     let expr = expr_from_projection(only(&value.projection));
                     assert_eq!(
                         *expr,
-                        Expr::Value(Value::SingleQuotedString(quoted.to_string()))
+                        Expr::Value((Value::SingleQuotedString(quoted.to_string())).with_empty_span())
                     );
                 }
                 _ => unreachable!(),
@@ -10227,11 +10227,11 @@ fn parse_pivot_table() {
             value_column: vec![Ident::new("a"), Ident::new("MONTH")],
             value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
-                    expr: Expr::Value(number("1")),
+                    expr: Expr::Value((number("1")).with_empty_span()),
                     alias: Some(Ident::new("x"))
                 },
                 ExprWithAlias {
-                    expr: Expr::Value(Value::SingleQuotedString("two".to_string())),
+                    expr: Expr::Value((Value::SingleQuotedString("two".to_string())).with_empty_span()),
                     alias: None
                 },
                 ExprWithAlias {
@@ -10462,11 +10462,11 @@ fn parse_pivot_unpivot_table() {
             value_column: vec![Ident::new("year")],
             value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
-                    expr: Expr::Value(Value::SingleQuotedString("population_2000".to_string())),
+                    expr: Expr::Value((Value::SingleQuotedString("population_2000".to_string())).with_empty_span()),
                     alias: None
                 },
                 ExprWithAlias {
-                    expr: Expr::Value(Value::SingleQuotedString("population_2010".to_string())),
+                    expr: Expr::Value((Value::SingleQuotedString("population_2010".to_string())).with_empty_span()),
                     alias: None
                 },
             ]),
@@ -10712,9 +10712,9 @@ fn parse_call() {
             parameters: FunctionArguments::None,
             args: FunctionArguments::List(FunctionArgumentList {
                 duplicate_treatment: None,
-                args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
                     Value::SingleQuotedString("a".to_string())
-                )))],
+                ).with_empty_span())))],
                 clauses: vec![],
             }),
             name: ObjectName::from(vec![Ident::new("my_procedure")]),
@@ -10742,8 +10742,8 @@ fn parse_execute_stored_procedure() {
             },
         ])),
         parameters: vec![
-            Expr::Value(Value::NationalStringLiteral("param1".to_string())),
-            Expr::Value(Value::NationalStringLiteral("param2".to_string())),
+            Expr::Value((Value::NationalStringLiteral("param1".to_string())).with_empty_span()),
+            Expr::Value((Value::NationalStringLiteral("param2".to_string())).with_empty_span()),
         ],
         has_parentheses: false,
         immediate: false,
@@ -10770,12 +10770,12 @@ fn parse_execute_immediate() {
     let dialects = all_dialects_where(|d| d.supports_execute_immediate());
 
     let expected = Statement::Execute {
-        parameters: vec![Expr::Value(Value::SingleQuotedString(
+        parameters: vec![Expr::Value((Value::SingleQuotedString(
             "SELECT 1".to_string(),
-        ))],
+        )).with_empty_span())],
         immediate: true,
         using: vec![ExprWithAlias {
-            expr: Expr::Value(number("1")),
+            expr: Expr::Value((number("1")).with_empty_span()),
             alias: Some(Ident::new("b")),
         }],
         into: vec![Ident::new("a")],
@@ -10925,7 +10925,7 @@ fn parse_unload() {
                     quote_style: None,
                     span: Span::empty(),
                 },
-                value: Expr::Value(Value::SingleQuotedString("AVRO".to_string()))
+                value: Expr::Value((Value::SingleQuotedString("AVRO".to_string())).with_empty_span())
             }]
         }
     );
@@ -11033,7 +11033,7 @@ fn parse_map_access_expr() {
             AccessExpr::Subscript(Subscript::Index {
                 index: Expr::UnaryOp {
                     op: UnaryOperator::Minus,
-                    expr: Expr::Value(number("1")).into(),
+                    expr: Expr::Value((number("1")).with_empty_span()).into(),
                 },
             }),
             AccessExpr::Subscript(Subscript::Index {
@@ -11045,9 +11045,9 @@ fn parse_map_access_expr() {
                     parameters: FunctionArguments::None,
                     args: FunctionArguments::List(FunctionArgumentList {
                         duplicate_treatment: None,
-                        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
-                            number("2"),
-                        )))],
+                        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
+                            number("2")
+                        ).with_empty_span())))],
                         clauses: vec![],
                     }),
                     filter: None,
@@ -11169,7 +11169,7 @@ fn parse_connect_by() {
             selection: Some(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("employee_id"))),
                 op: BinaryOperator::NotEq,
-                right: Box::new(Expr::Value(number("42"))),
+                right: Box::new(Expr::Value((number("42")).with_empty_span())),
             }),
             group_by: GroupByExpr::Expressions(vec![], vec![]),
             cluster_by: vec![],
@@ -11184,9 +11184,9 @@ fn parse_connect_by() {
                 condition: Expr::BinaryOp {
                     left: Box::new(Expr::Identifier(Ident::new("title"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value(Value::SingleQuotedString(
+                    right: Box::new(Expr::Value((Value::SingleQuotedString(
                         "president".to_owned(),
-                    ))),
+                    )).with_empty_span())),
                 },
                 relationships: vec![Expr::BinaryOp {
                     left: Box::new(Expr::Identifier(Ident::new("manager_id"))),
@@ -11269,7 +11269,7 @@ fn test_selective_aggregation() {
                     filter: Some(Box::new(Expr::Like {
                         negated: false,
                         expr: Box::new(Expr::Identifier(Ident::new("name"))),
-                        pattern: Box::new(Expr::Value(Value::SingleQuotedString("a%".to_owned()))),
+                        pattern: Box::new(Expr::Value((Value::SingleQuotedString("a%".to_owned())).with_empty_span())),
                         escape_char: None,
                         any: false,
                     })),
@@ -11625,7 +11625,7 @@ fn test_select_wildcard_with_replace() {
     let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
         opt_replace: Some(ReplaceSelectItem {
             items: vec![Box::new(ReplaceSelectElement {
-                expr: Expr::Value(Value::SingleQuotedString("widget".to_owned())),
+                expr: Expr::Value((Value::SingleQuotedString("widget".to_owned())).with_empty_span()),
                 column_name: Ident::new("item_name"),
                 as_keyword: true,
             })],
@@ -11644,13 +11644,13 @@ fn test_select_wildcard_with_replace() {
                     expr: Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("quantity"))),
                         op: BinaryOperator::Divide,
-                        right: Box::new(Expr::Value(number("2"))),
+                        right: Box::new(Expr::Value((number("2")).with_empty_span())),
                     },
                     column_name: Ident::new("quantity"),
                     as_keyword: true,
                 }),
                 Box::new(ReplaceSelectElement {
-                    expr: Expr::Value(number("3")),
+                    expr: Expr::Value((number("3")).with_empty_span()),
                     column_name: Ident::new("order_id"),
                     as_keyword: true,
                 }),
@@ -11733,15 +11733,15 @@ fn test_dictionary_syntax() {
         Expr::Dictionary(vec![
             DictionaryField {
                 key: Ident::with_quote('\'', "Alberta"),
-                value: Box::new(Expr::Value(Value::SingleQuotedString(
+                value: Box::new(Expr::Value((Value::SingleQuotedString(
                     "Edmonton".to_owned(),
-                ))),
+                )).with_empty_span())),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "Manitoba"),
-                value: Box::new(Expr::Value(Value::SingleQuotedString(
+                value: Box::new(Expr::Value((Value::SingleQuotedString(
                     "Winnipeg".to_owned(),
-                ))),
+                )).with_empty_span())),
             },
         ]),
     );
@@ -11753,9 +11753,9 @@ fn test_dictionary_syntax() {
                 key: Ident::with_quote('\'', "start"),
                 value: Box::new(Expr::Cast {
                     kind: CastKind::Cast,
-                    expr: Box::new(Expr::Value(Value::SingleQuotedString(
+                    expr: Box::new(Expr::Value((Value::SingleQuotedString(
                         "2023-04-01".to_owned(),
-                    ))),
+                    )).with_empty_span())),
                     data_type: DataType::Timestamp(None, TimezoneInfo::None),
                     format: None,
                 }),
@@ -11764,9 +11764,9 @@ fn test_dictionary_syntax() {
                 key: Ident::with_quote('\'', "end"),
                 value: Box::new(Expr::Cast {
                     kind: CastKind::Cast,
-                    expr: Box::new(Expr::Value(Value::SingleQuotedString(
+                    expr: Box::new(Expr::Value((Value::SingleQuotedString(
                         "2023-04-05".to_owned(),
-                    ))),
+                    )).with_empty_span())),
                     data_type: DataType::Timestamp(None, TimezoneInfo::None),
                     format: None,
                 }),
@@ -11789,18 +11789,18 @@ fn test_map_syntax() {
         Expr::Map(Map {
             entries: vec![
                 MapEntry {
-                    key: Box::new(Expr::Value(Value::SingleQuotedString("Alberta".to_owned()))),
-                    value: Box::new(Expr::Value(Value::SingleQuotedString(
+                    key: Box::new(Expr::Value((Value::SingleQuotedString("Alberta".to_owned())).with_empty_span())),
+                    value: Box::new(Expr::Value((Value::SingleQuotedString(
                         "Edmonton".to_owned(),
-                    ))),
+                    )).with_empty_span())),
                 },
                 MapEntry {
-                    key: Box::new(Expr::Value(Value::SingleQuotedString(
+                    key: Box::new(Expr::Value((Value::SingleQuotedString(
                         "Manitoba".to_owned(),
-                    ))),
-                    value: Box::new(Expr::Value(Value::SingleQuotedString(
+                    )).with_empty_span())),
+                    value: Box::new(Expr::Value((Value::SingleQuotedString(
                         "Winnipeg".to_owned(),
-                    ))),
+                    )).with_empty_span())),
                 },
             ],
         }),
@@ -11835,14 +11835,14 @@ fn test_map_syntax() {
                         elem: vec![number_expr("1"), number_expr("2"), number_expr("3")],
                         named: false,
                     })),
-                    value: Box::new(Expr::Value(number("10.0"))),
+                    value: Box::new(Expr::Value((number("10.0")).with_empty_span())),
                 },
                 MapEntry {
                     key: Box::new(Expr::Array(Array {
                         elem: vec![number_expr("4"), number_expr("5"), number_expr("6")],
                         named: false,
                     })),
-                    value: Box::new(Expr::Value(number("20.0"))),
+                    value: Box::new(Expr::Value((number("20.0")).with_empty_span())),
                 },
             ],
         }),
@@ -11854,17 +11854,17 @@ fn test_map_syntax() {
             root: Box::new(Expr::Map(Map {
                 entries: vec![
                     MapEntry {
-                        key: Box::new(Expr::Value(Value::SingleQuotedString("a".to_owned()))),
+                        key: Box::new(Expr::Value((Value::SingleQuotedString("a".to_owned())).with_empty_span())),
                         value: Box::new(number_expr("10")),
                     },
                     MapEntry {
-                        key: Box::new(Expr::Value(Value::SingleQuotedString("b".to_owned()))),
+                        key: Box::new(Expr::Value((Value::SingleQuotedString("b".to_owned())).with_empty_span())),
                         value: Box::new(number_expr("20")),
                     },
                 ],
             })),
             access_chain: vec![AccessExpr::Subscript(Subscript::Index {
-                index: Expr::Value(Value::SingleQuotedString("a".to_owned())),
+                index: Expr::Value((Value::SingleQuotedString("a".to_owned())).with_empty_span()),
             })],
         },
     );
@@ -12013,9 +12013,9 @@ fn test_extract_seconds_ok() {
             syntax: ExtractSyntax::From,
             expr: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value(Value::SingleQuotedString(
+                expr: Box::new(Expr::Value((Value::SingleQuotedString(
                     "2 seconds".to_string()
-                ))),
+                )).with_empty_span())),
                 data_type: DataType::Interval,
                 format: None,
             }),
@@ -12038,9 +12038,9 @@ fn test_extract_seconds_ok() {
                 syntax: ExtractSyntax::From,
                 expr: Box::new(Expr::Cast {
                     kind: CastKind::DoubleColon,
-                    expr: Box::new(Expr::Value(Value::SingleQuotedString(
+                    expr: Box::new(Expr::Value((Value::SingleQuotedString(
                         "2 seconds".to_string(),
-                    ))),
+                    )).with_empty_span())),
                     data_type: DataType::Interval,
                     format: None,
                 }),
@@ -12092,9 +12092,9 @@ fn test_extract_seconds_single_quote_ok() {
             syntax: ExtractSyntax::From,
             expr: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value(Value::SingleQuotedString(
+                expr: Box::new(Expr::Value((Value::SingleQuotedString(
                     "2 seconds".to_string()
-                ))),
+                )).with_empty_span())),
                 data_type: DataType::Interval,
                 format: None,
             }),
@@ -12145,11 +12145,11 @@ fn parse_explain_with_option_list() {
         Some(vec![
             UtilityOption {
                 name: Ident::new("ANALYZE"),
-                arg: Some(Expr::Value(Value::Boolean(false))),
+                arg: Some(Expr::Value((Value::Boolean(false)).with_empty_span())),
             },
             UtilityOption {
                 name: Ident::new("VERBOSE"),
-                arg: Some(Expr::Value(Value::Boolean(true))),
+                arg: Some(Expr::Value((Value::Boolean(true)).with_empty_span())),
             },
         ]),
     );
@@ -12185,7 +12185,7 @@ fn parse_explain_with_option_list() {
             },
             UtilityOption {
                 name: Ident::new("FORMAT2"),
-                arg: Some(Expr::Value(Value::SingleQuotedString("JSON".to_string()))),
+                arg: Some(Expr::Value((Value::SingleQuotedString("JSON".to_string())).with_empty_span())),
             },
             UtilityOption {
                 name: Ident::new("FORMAT3"),
@@ -12207,20 +12207,20 @@ fn parse_explain_with_option_list() {
         Some(vec![
             UtilityOption {
                 name: Ident::new("NUM1"),
-                arg: Some(Expr::Value(Value::Number("10".parse().unwrap(), false))),
+                arg: Some(Expr::Value((Value::Number("10".parse().unwrap(), false)).with_empty_span())),
             },
             UtilityOption {
                 name: Ident::new("NUM2"),
                 arg: Some(Expr::UnaryOp {
                     op: UnaryOperator::Plus,
-                    expr: Box::new(Expr::Value(Value::Number("10.1".parse().unwrap(), false))),
+                    expr: Box::new(Expr::Value((Value::Number("10.1".parse().unwrap(), false)).with_empty_span())),
                 }),
             },
             UtilityOption {
                 name: Ident::new("NUM3"),
                 arg: Some(Expr::UnaryOp {
                     op: UnaryOperator::Minus,
-                    expr: Box::new(Expr::Value(Value::Number("10.2".parse().unwrap(), false))),
+                    expr: Box::new(Expr::Value((Value::Number("10.2".parse().unwrap(), false)).with_empty_span())),
                 }),
             },
         ]),
@@ -12233,7 +12233,7 @@ fn parse_explain_with_option_list() {
         },
         UtilityOption {
             name: Ident::new("VERBOSE"),
-            arg: Some(Expr::Value(Value::Boolean(true))),
+            arg: Some(Expr::Value((Value::Boolean(true)).with_empty_span())),
         },
         UtilityOption {
             name: Ident::new("WAL"),
@@ -12247,7 +12247,7 @@ fn parse_explain_with_option_list() {
             name: Ident::new("USER_DEF_NUM"),
             arg: Some(Expr::UnaryOp {
                 op: UnaryOperator::Minus,
-                expr: Box::new(Expr::Value(Value::Number("100.1".parse().unwrap(), false))),
+                expr: Box::new(Expr::Value((Value::Number("100.1".parse().unwrap(), false)).with_empty_span())),
             }),
         },
     ];
@@ -12292,15 +12292,15 @@ fn test_create_policy() {
                 Some(Expr::BinaryOp {
                     left: Box::new(Expr::Identifier(Ident::new("c0"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value(Value::Number("1".parse().unwrap(), false))),
+                    right: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
                 })
             );
             assert_eq!(
                 with_check,
                 Some(Expr::BinaryOp {
-                    left: Box::new(Expr::Value(Value::Number("1".parse().unwrap(), false))),
+                    left: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value(Value::Number("1".parse().unwrap(), false))),
+                    right: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
                 })
             );
         }
@@ -12513,11 +12513,11 @@ fn test_create_connector() {
                 Some(vec![
                     SqlOption::KeyValue {
                         key: Ident::with_quote('\'', "user"),
-                        value: Expr::Value(Value::SingleQuotedString("root".to_string()))
+                        value: Expr::Value((Value::SingleQuotedString("root".to_string())).with_empty_span())
                     },
                     SqlOption::KeyValue {
                         key: Ident::with_quote('\'', "password"),
-                        value: Expr::Value(Value::SingleQuotedString("password".to_string()))
+                        value: Expr::Value((Value::SingleQuotedString("password".to_string())).with_empty_span())
                     }
                 ])
             );
@@ -12580,11 +12580,11 @@ fn test_alter_connector() {
                 Some(vec![
                     SqlOption::KeyValue {
                         key: Ident::with_quote('\'', "user"),
-                        value: Expr::Value(Value::SingleQuotedString("root".to_string()))
+                        value: Expr::Value((Value::SingleQuotedString("root".to_string())).with_empty_span())
                     },
                     SqlOption::KeyValue {
                         key: Ident::with_quote('\'', "password"),
-                        value: Expr::Value(Value::SingleQuotedString("password".to_string()))
+                        value: Expr::Value((Value::SingleQuotedString("password".to_string())).with_empty_span())
                     }
                 ])
             );
@@ -13051,12 +13051,12 @@ fn parse_load_data() {
                     Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("year"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value(Value::Number("2024".parse().unwrap(), false))),
+                        right: Box::new(Expr::Value((Value::Number("2024".parse().unwrap(), false)).with_empty_span())),
                     },
                     Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("month"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value(Value::Number("11".parse().unwrap(), false))),
+                        right: Box::new(Expr::Value((Value::Number("11".parse().unwrap(), false)).with_empty_span())),
                     }
                 ]),
                 partitioned
@@ -13089,24 +13089,24 @@ fn parse_load_data() {
                     Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("year"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value(Value::Number("2024".parse().unwrap(), false))),
+                        right: Box::new(Expr::Value((Value::Number("2024".parse().unwrap(), false)).with_empty_span())),
                     },
                     Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("month"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value(Value::Number("11".parse().unwrap(), false))),
+                        right: Box::new(Expr::Value((Value::Number("11".parse().unwrap(), false)).with_empty_span())),
                     }
                 ]),
                 partitioned
             );
             assert_eq!(
                 Some(HiveLoadDataFormat {
-                    serde: Expr::Value(Value::SingleQuotedString(
+                    serde: Expr::Value((Value::SingleQuotedString(
                         "org.apache.hadoop.hive.serde2.OpenCSVSerde".to_string()
-                    )),
-                    input_format: Expr::Value(Value::SingleQuotedString(
+                    )).with_empty_span()),
+                    input_format: Expr::Value((Value::SingleQuotedString(
                         "org.apache.hadoop.mapred.TextInputFormat".to_string()
-                    ))
+                    )).with_empty_span())
                 }),
                 table_format
             );
@@ -13526,11 +13526,11 @@ fn parse_composite_access_expr() {
                         values: vec![
                             Expr::Named {
                                 name: Ident::new("a"),
-                                expr: Box::new(Expr::Value(Number("1".parse().unwrap(), false))),
+                                expr: Box::new(Expr::Value((Number("1".parse().unwrap(), false)).with_empty_span())),
                             },
                             Expr::Named {
                                 name: Ident::new("b"),
-                                expr: Box::new(Expr::Value(Value::Null)),
+                                expr: Box::new(Expr::Value((Value::Null).with_empty_span())),
                             },
                         ],
                         fields: vec![],
@@ -13538,7 +13538,7 @@ fn parse_composite_access_expr() {
                 },
                 Expr::Named {
                     name: Ident::new("d"),
-                    expr: Box::new(Expr::Value(Value::Null)),
+                    expr: Box::new(Expr::Value((Value::Null).with_empty_span())),
                 },
             ],
             fields: vec![],
@@ -13565,11 +13565,11 @@ fn parse_create_table_with_enum_types() {
                             vec![
                                 EnumMember::NamedValue(
                                     "a".to_string(),
-                                    Expr::Value(Number("1".parse().unwrap(), false))
+                                    Expr::Value((Number("1".parse().unwrap(), false)).with_empty_span())
                                 ),
                                 EnumMember::NamedValue(
                                     "b".to_string(),
-                                    Expr::Value(Number("2".parse().unwrap(), false))
+                                    Expr::Value((Number("2".parse().unwrap(), false)).with_empty_span())
                                 )
                             ],
                             Some(8)
@@ -13582,11 +13582,11 @@ fn parse_create_table_with_enum_types() {
                             vec![
                                 EnumMember::NamedValue(
                                     "a".to_string(),
-                                    Expr::Value(Number("1".parse().unwrap(), false))
+                                    Expr::Value((Number("1".parse().unwrap(), false)).with_empty_span())
                                 ),
                                 EnumMember::NamedValue(
                                     "b".to_string(),
-                                    Expr::Value(Number("2".parse().unwrap(), false))
+                                    Expr::Value((Number("2".parse().unwrap(), false)).with_empty_span())
                                 )
                             ],
                             Some(16)
@@ -13752,8 +13752,8 @@ fn test_lambdas() {
                 call(
                     "array",
                     [
-                        Expr::Value(Value::SingleQuotedString("Hello".to_owned())),
-                        Expr::Value(Value::SingleQuotedString("World".to_owned()))
+                        Expr::Value((Value::SingleQuotedString("Hello".to_owned())).with_empty_span()),
+                        Expr::Value((Value::SingleQuotedString("World".to_owned())).with_empty_span())
                     ]
                 ),
                 Expr::Lambda(LambdaFunction {
@@ -13779,13 +13779,13 @@ fn test_lambdas() {
                             }
                         ],
                         results: vec![
-                            Expr::Value(number("0")),
+                            Expr::Value((number("0")).with_empty_span()),
                             Expr::UnaryOp {
                                 op: UnaryOperator::Minus,
-                                expr: Box::new(Expr::Value(number("1")))
+                                expr: Box::new(Expr::Value((number("1")).with_empty_span()))
                             }
                         ],
-                        else_result: Some(Box::new(Expr::Value(number("1"))))
+                        else_result: Some(Box::new(Expr::Value((number("1")).with_empty_span())))
                     })
                 })
             ]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -69,7 +69,9 @@ fn parse_numeric_literal_underscore() {
 
     assert_eq!(
         select.projection,
-        vec![UnnamedExpr(Expr::Value((number("10_000")).with_empty_span()))]
+        vec![UnnamedExpr(Expr::Value(
+            (number("10_000")).with_empty_span()
+        ))]
     );
 }
 
@@ -556,7 +558,9 @@ fn parse_update_with_table_alias() {
                         Ident::new("u"),
                         Ident::new("username")
                     ])),
-                    value: Expr::Value((Value::SingleQuotedString("new_user".to_string())).with_empty_span()),
+                    value: Expr::Value(
+                        (Value::SingleQuotedString("new_user".to_string())).with_empty_span()
+                    ),
                 }],
                 assignments
             );
@@ -567,9 +571,9 @@ fn parse_update_with_table_alias() {
                         Ident::new("username"),
                     ])),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value((Value::SingleQuotedString(
-                        "old_user".to_string()
-                    )).with_empty_span())),
+                    right: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("old_user".to_string())).with_empty_span()
+                    )),
                 }),
                 selection
             );
@@ -896,7 +900,10 @@ fn parse_simple_select() {
     assert!(select.distinct.is_none());
     assert_eq!(3, select.projection.len());
     let select = verified_query(sql);
-    assert_eq!(Some(Expr::Value((number("5")).with_empty_span())), select.limit);
+    assert_eq!(
+        Some(Expr::Value((number("5")).with_empty_span())),
+        select.limit
+    );
 }
 
 #[test]
@@ -908,10 +915,16 @@ fn parse_limit() {
 fn parse_limit_is_not_an_alias() {
     // In dialects supporting LIMIT it shouldn't be parsed as a table alias
     let ast = verified_query("SELECT id FROM customer LIMIT 1");
-    assert_eq!(Some(Expr::Value((number("1")).with_empty_span())), ast.limit);
+    assert_eq!(
+        Some(Expr::Value((number("1")).with_empty_span())),
+        ast.limit
+    );
 
     let ast = verified_query("SELECT 1 LIMIT 5");
-    assert_eq!(Some(Expr::Value((number("5")).with_empty_span())), ast.limit);
+    assert_eq!(
+        Some(Expr::Value((number("5")).with_empty_span())),
+        ast.limit
+    );
 }
 
 #[test]
@@ -1129,7 +1142,10 @@ fn parse_column_aliases() {
     } = only(&select.projection)
     {
         assert_eq!(&BinaryOperator::Plus, op);
-        assert_eq!(&Expr::Value((number("1")).with_empty_span()), right.as_ref());
+        assert_eq!(
+            &Expr::Value((number("1")).with_empty_span()),
+            right.as_ref()
+        );
         assert_eq!(&Ident::new("newname"), alias);
     } else {
         panic!("Expected: ExprWithAlias")
@@ -1437,9 +1453,9 @@ fn parse_escaped_single_quote_string_predicate_with_escape() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("salary"))),
             op: NotEq,
-            right: Box::new(Expr::Value((Value::SingleQuotedString(
-                "Jim's salary".to_string()
-            )).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("Jim's salary".to_string())).with_empty_span()
+            )),
         }),
         ast.selection,
     );
@@ -1463,9 +1479,9 @@ fn parse_escaped_single_quote_string_predicate_with_no_escape() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("salary"))),
             op: NotEq,
-            right: Box::new(Expr::Value((Value::SingleQuotedString(
-                "Jim''s salary".to_string()
-            )).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("Jim''s salary".to_string())).with_empty_span()
+            )),
         }),
         ast.selection,
     );
@@ -1482,7 +1498,10 @@ fn parse_number() {
     );
 
     #[cfg(not(feature = "bigdecimal"))]
-    assert_eq!(expr, Expr::Value((Value::Number("1.0".into(), false)).with_empty_span()));
+    assert_eq!(
+        expr,
+        Expr::Value((Value::Number("1.0".into(), false)).with_empty_span())
+    );
 }
 
 #[test]
@@ -1635,9 +1654,9 @@ fn parse_json_object() {
             &[
                 FunctionArg::ExprNamed {
                     name: Expr::Value((Value::SingleQuotedString("name".into())).with_empty_span()),
-                    arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                        "value".into()
-                    )).with_empty_span())),
+                    arg: FunctionArgExpr::Expr(Expr::Value(
+                        (Value::SingleQuotedString("value".into())).with_empty_span()
+                    )),
                     operator: FunctionArgOperator::Colon
                 },
                 FunctionArg::ExprNamed {
@@ -1660,14 +1679,18 @@ fn parse_json_object() {
             assert_eq!(
                 &[
                     FunctionArg::ExprNamed {
-                        name: Expr::Value((Value::SingleQuotedString("name".into())).with_empty_span()),
-                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                            "value".into()
-                        )).with_empty_span())),
+                        name: Expr::Value(
+                            (Value::SingleQuotedString("name".into())).with_empty_span()
+                        ),
+                        arg: FunctionArgExpr::Expr(Expr::Value(
+                            (Value::SingleQuotedString("value".into())).with_empty_span()
+                        )),
                         operator: FunctionArgOperator::Colon
                     },
                     FunctionArg::ExprNamed {
-                        name: Expr::Value((Value::SingleQuotedString("type".into())).with_empty_span()),
+                        name: Expr::Value(
+                            (Value::SingleQuotedString("type".into())).with_empty_span()
+                        ),
                         arg: FunctionArgExpr::Expr(Expr::Value((Value::Null).with_empty_span())),
                         operator: FunctionArgOperator::Colon
                     }
@@ -1726,9 +1749,9 @@ fn parse_json_object() {
             assert_eq!(
                 &FunctionArg::ExprNamed {
                     name: Expr::Value((Value::SingleQuotedString("name".into())).with_empty_span()),
-                    arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                        "value".into()
-                    )).with_empty_span())),
+                    arg: FunctionArgExpr::Expr(Expr::Value(
+                        (Value::SingleQuotedString("value".into())).with_empty_span()
+                    )),
                     operator: FunctionArgOperator::Colon
                 },
                 &args[0]
@@ -1736,7 +1759,10 @@ fn parse_json_object() {
             assert!(matches!(
                 args[1],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
+                    name: Expr::Value(ValueWithSpan {
+                        value: Value::SingleQuotedString(_),
+                        span: _
+                    }),
                     arg: FunctionArgExpr::Expr(Expr::Function(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -1761,9 +1787,9 @@ fn parse_json_object() {
             assert_eq!(
                 &FunctionArg::ExprNamed {
                     name: Expr::Value((Value::SingleQuotedString("name".into())).with_empty_span()),
-                    arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                        "value".into()
-                    )).with_empty_span())),
+                    arg: FunctionArgExpr::Expr(Expr::Value(
+                        (Value::SingleQuotedString("value".into())).with_empty_span()
+                    )),
                     operator: FunctionArgOperator::Colon
                 },
                 &args[0]
@@ -1771,7 +1797,10 @@ fn parse_json_object() {
             assert!(matches!(
                 args[1],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
+                    name: Expr::Value(ValueWithSpan {
+                        value: Value::SingleQuotedString(_),
+                        span: _
+                    }),
                     arg: FunctionArgExpr::Expr(Expr::Function(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -1895,9 +1924,13 @@ fn parse_not_precedence() {
         Expr::UnaryOp {
             op: UnaryOperator::Not,
             expr: Box::new(Expr::Like {
-                expr: Box::new(Expr::Value((Value::SingleQuotedString("a".into())).with_empty_span())),
+                expr: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("a".into())).with_empty_span()
+                )),
                 negated: true,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("b".into())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("b".into())).with_empty_span()
+                )),
                 escape_char: None,
                 any: false,
             }),
@@ -1912,7 +1945,9 @@ fn parse_not_precedence() {
             op: UnaryOperator::Not,
             expr: Box::new(Expr::InList {
                 expr: Box::new(Expr::Identifier("a".into())),
-                list: vec![Expr::Value((Value::SingleQuotedString("a".into())).with_empty_span())],
+                list: vec![Expr::Value(
+                    (Value::SingleQuotedString("a".into())).with_empty_span()
+                )],
                 negated: true,
             }),
         },
@@ -1974,7 +2009,9 @@ fn parse_ilike() {
             Expr::ILike {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("%a".to_string())).with_empty_span()
+                )),
                 escape_char: None,
                 any: false,
             },
@@ -1991,7 +2028,9 @@ fn parse_ilike() {
             Expr::ILike {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("%a".to_string())).with_empty_span()
+                )),
                 escape_char: Some('^'.to_string()),
                 any: false,
             },
@@ -2009,7 +2048,9 @@ fn parse_ilike() {
             Expr::IsNull(Box::new(Expr::ILike {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("%a".to_string())).with_empty_span()
+                )),
                 escape_char: None,
                 any: false,
             })),
@@ -2032,7 +2073,9 @@ fn parse_like() {
             Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("%a".to_string())).with_empty_span()
+                )),
                 escape_char: None,
                 any: false,
             },
@@ -2049,7 +2092,9 @@ fn parse_like() {
             Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("%a".to_string())).with_empty_span()
+                )),
                 escape_char: Some('^'.to_string()),
                 any: false,
             },
@@ -2067,7 +2112,9 @@ fn parse_like() {
             Expr::IsNull(Box::new(Expr::Like {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("%a".to_string())).with_empty_span()
+                )),
                 escape_char: None,
                 any: false,
             })),
@@ -2090,7 +2137,9 @@ fn parse_similar_to() {
             Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("%a".to_string())).with_empty_span()
+                )),
                 escape_char: None,
             },
             select.selection.unwrap()
@@ -2106,7 +2155,9 @@ fn parse_similar_to() {
             Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("%a".to_string())).with_empty_span()
+                )),
                 escape_char: Some('^'.to_string()),
             },
             select.selection.unwrap()
@@ -2122,7 +2173,9 @@ fn parse_similar_to() {
             Expr::IsNull(Box::new(Expr::SimilarTo {
                 expr: Box::new(Expr::Identifier(Ident::new("name"))),
                 negated,
-                pattern: Box::new(Expr::Value((Value::SingleQuotedString("%a".to_string())).with_empty_span())),
+                pattern: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("%a".to_string())).with_empty_span()
+                )),
                 escape_char: Some('^'.to_string()),
             })),
             select.selection.unwrap()
@@ -2356,7 +2409,9 @@ fn parse_tuples() {
                 Expr::Value((number("1")).with_empty_span()),
                 Expr::Value((number("2")).with_empty_span()),
             ])),
-            SelectItem::UnnamedExpr(Expr::Nested(Box::new(Expr::Value((number("1")).with_empty_span())))),
+            SelectItem::UnnamedExpr(Expr::Nested(Box::new(Expr::Value(
+                (number("1")).with_empty_span()
+            )))),
             SelectItem::UnnamedExpr(Expr::Tuple(vec![
                 Expr::Value((Value::SingleQuotedString("foo".into())).with_empty_span()),
                 Expr::Value((number("3")).with_empty_span()),
@@ -2440,7 +2495,10 @@ fn parse_select_order_by_limit() {
         ],
         select.order_by.expect("ORDER BY expected").exprs
     );
-    assert_eq!(Some(Expr::Value((number("2")).with_empty_span())), select.limit);
+    assert_eq!(
+        Some(Expr::Value((number("2")).with_empty_span())),
+        select.limit
+    );
 }
 
 #[test]
@@ -2465,7 +2523,10 @@ fn parse_select_order_by_nulls_order() {
         ],
         select.order_by.expect("ORDER BY expeccted").exprs
     );
-    assert_eq!(Some(Expr::Value((number("2")).with_empty_span())), select.limit);
+    assert_eq!(
+        Some(Expr::Value((number("2")).with_empty_span())),
+        select.limit
+    );
 }
 
 #[test]
@@ -3042,15 +3103,15 @@ fn parse_listagg() {
                     FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(Ident::new(
                         "dateid"
                     )))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
-                        Value::SingleQuotedString(", ".to_owned())
-                    ).with_empty_span())))
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        (Value::SingleQuotedString(", ".to_owned())).with_empty_span()
+                    )))
                 ],
                 clauses: vec![FunctionArgumentClause::OnOverflow(
                     ListAggOnOverflow::Truncate {
-                        filler: Some(Box::new(Expr::Value((Value::SingleQuotedString(
-                            "%".to_string(),
-                        )).with_empty_span()))),
+                        filler: Some(Box::new(Expr::Value(
+                            (Value::SingleQuotedString("%".to_string(),)).with_empty_span()
+                        ))),
                         with_count: false,
                     }
                 )],
@@ -3954,7 +4015,10 @@ fn parse_assert_message() {
             message: Some(message),
         } => {
             match message {
-                Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(s), span: _}) => assert_eq!(s, "No rows in my_table"),
+                Expr::Value(ValueWithSpan {
+                    value: Value::SingleQuotedString(s),
+                    span: _,
+                }) => assert_eq!(s, "No rows in my_table"),
                 _ => unreachable!(),
             };
         }
@@ -4172,7 +4236,9 @@ fn parse_create_table_with_options() {
                 vec![
                     SqlOption::KeyValue {
                         key: "foo".into(),
-                        value: Expr::Value((Value::SingleQuotedString("bar".into())).with_empty_span()),
+                        value: Expr::Value(
+                            (Value::SingleQuotedString("bar".into())).with_empty_span()
+                        ),
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
@@ -4402,7 +4468,9 @@ fn parse_alter_table() {
                         quote_style: Some('\''),
                         span: Span::empty(),
                     },
-                    value: Expr::Value((Value::SingleQuotedString("parquet".to_string())).with_empty_span()),
+                    value: Expr::Value(
+                        (Value::SingleQuotedString("parquet".to_string())).with_empty_span()
+                    ),
                 }],
             );
         }
@@ -4546,7 +4614,9 @@ fn parse_alter_view_with_options() {
                 vec![
                     SqlOption::KeyValue {
                         key: "foo".into(),
-                        value: Expr::Value((Value::SingleQuotedString("bar".into())).with_empty_span()),
+                        value: Expr::Value(
+                            (Value::SingleQuotedString("bar".into())).with_empty_span()
+                        ),
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
@@ -5050,16 +5120,16 @@ fn parse_named_argument_function() {
                 args: vec![
                     FunctionArg::Named {
                         name: Ident::new("a"),
-                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                            "1".to_owned()
-                        )).with_empty_span())),
+                        arg: FunctionArgExpr::Expr(Expr::Value(
+                            (Value::SingleQuotedString("1".to_owned())).with_empty_span()
+                        )),
                         operator: FunctionArgOperator::RightArrow
                     },
                     FunctionArg::Named {
                         name: Ident::new("b"),
-                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                            "2".to_owned()
-                        )).with_empty_span())),
+                        arg: FunctionArgExpr::Expr(Expr::Value(
+                            (Value::SingleQuotedString("2".to_owned())).with_empty_span()
+                        )),
                         operator: FunctionArgOperator::RightArrow
                     },
                 ],
@@ -5090,16 +5160,16 @@ fn parse_named_argument_function_with_eq_operator() {
                 args: vec![
                     FunctionArg::Named {
                         name: Ident::new("a"),
-                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                            "1".to_owned()
-                        )).with_empty_span())),
+                        arg: FunctionArgExpr::Expr(Expr::Value(
+                            (Value::SingleQuotedString("1".to_owned())).with_empty_span()
+                        )),
                         operator: FunctionArgOperator::Equals
                     },
                     FunctionArg::Named {
                         name: Ident::new("b"),
-                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                            "2".to_owned()
-                        )).with_empty_span())),
+                        arg: FunctionArgExpr::Expr(Expr::Value(
+                            (Value::SingleQuotedString("2".to_owned())).with_empty_span()
+                        )),
                         operator: FunctionArgOperator::Equals
                     },
                 ],
@@ -5517,7 +5587,9 @@ fn parse_literal_string() {
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
-        &Expr::Value((Value::NationalStringLiteral("national string".to_string())).with_empty_span()),
+        &Expr::Value(
+            (Value::NationalStringLiteral("national string".to_string())).with_empty_span()
+        ),
         expr_from_projection(&select.projection[1])
     );
     assert_eq!(
@@ -5606,7 +5678,9 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from("1-1"))).with_empty_span())),
+            value: Box::new(Expr::Value(
+                (Value::SingleQuotedString(String::from("1-1"))).with_empty_span()
+            )),
             leading_field: Some(DateTimeField::Year),
             leading_precision: None,
             last_field: Some(DateTimeField::Month),
@@ -5619,9 +5693,9 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
-                "01:01.01"
-            ))).with_empty_span())),
+            value: Box::new(Expr::Value(
+                (Value::SingleQuotedString(String::from("01:01.01"))).with_empty_span()
+            )),
             leading_field: Some(DateTimeField::Minute),
             leading_precision: Some(5),
             last_field: Some(DateTimeField::Second),
@@ -5634,7 +5708,9 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from("1"))).with_empty_span())),
+            value: Box::new(Expr::Value(
+                (Value::SingleQuotedString(String::from("1"))).with_empty_span()
+            )),
             leading_field: Some(DateTimeField::Second),
             leading_precision: Some(5),
             last_field: None,
@@ -5647,7 +5723,9 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from("10"))).with_empty_span())),
+            value: Box::new(Expr::Value(
+                (Value::SingleQuotedString(String::from("10"))).with_empty_span()
+            )),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: None,
             last_field: None,
@@ -5686,7 +5764,9 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from("10"))).with_empty_span())),
+            value: Box::new(Expr::Value(
+                (Value::SingleQuotedString(String::from("10"))).with_empty_span()
+            )),
             leading_field: Some(DateTimeField::Hour),
             leading_precision: Some(1),
             last_field: None,
@@ -5755,9 +5835,9 @@ fn parse_interval_dont_require_unit() {
     let select = dialects.verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
-                "1 DAY"
-            ))).with_empty_span())),
+            value: Box::new(Expr::Value(
+                (Value::SingleQuotedString(String::from("1 DAY"))).with_empty_span()
+            )),
             leading_field: None,
             leading_precision: None,
             last_field: None,
@@ -5811,9 +5891,13 @@ fn parse_interval_require_qualifier() {
         expr_from_projection(only(&select.projection)),
         &Expr::Interval(Interval {
             value: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value((Value::SingleQuotedString("1".to_string())).with_empty_span())),
+                left: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("1".to_string())).with_empty_span()
+                )),
                 op: BinaryOperator::Plus,
-                right: Box::new(Expr::Value((Value::SingleQuotedString("1".to_string())).with_empty_span())),
+                right: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("1".to_string())).with_empty_span()
+                )),
             }),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
@@ -5829,12 +5913,18 @@ fn parse_interval_require_qualifier() {
         &Expr::Interval(Interval {
             value: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::BinaryOp {
-                    left: Box::new(Expr::Value((Value::SingleQuotedString("1".to_string())).with_empty_span())),
+                    left: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("1".to_string())).with_empty_span()
+                    )),
                     op: BinaryOperator::Plus,
-                    right: Box::new(Expr::Value((Value::SingleQuotedString("2".to_string())).with_empty_span())),
+                    right: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("2".to_string())).with_empty_span()
+                    )),
                 }),
                 op: BinaryOperator::Minus,
-                right: Box::new(Expr::Value((Value::SingleQuotedString("3".to_string())).with_empty_span())),
+                right: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("3".to_string())).with_empty_span()
+                )),
             }),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
@@ -5853,9 +5943,9 @@ fn parse_interval_disallow_interval_expr() {
     assert_eq!(
         expr_from_projection(only(&select.projection)),
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
-                "1 DAY"
-            ))).with_empty_span())),
+            value: Box::new(Expr::Value(
+                (Value::SingleQuotedString(String::from("1 DAY"))).with_empty_span()
+            )),
             leading_field: None,
             leading_precision: None,
             last_field: None,
@@ -5876,9 +5966,9 @@ fn parse_interval_disallow_interval_expr() {
         expr_from_projection(only(&select.projection)),
         &Expr::BinaryOp {
             left: Box::new(Expr::Interval(Interval {
-                value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
-                    "1 DAY"
-                ))).with_empty_span())),
+                value: Box::new(Expr::Value(
+                    (Value::SingleQuotedString(String::from("1 DAY"))).with_empty_span()
+                )),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
@@ -5886,9 +5976,9 @@ fn parse_interval_disallow_interval_expr() {
             })),
             op: BinaryOperator::Gt,
             right: Box::new(Expr::Interval(Interval {
-                value: Box::new(Expr::Value((Value::SingleQuotedString(String::from(
-                    "1 SECOND"
-                ))).with_empty_span())),
+                value: Box::new(Expr::Value(
+                    (Value::SingleQuotedString(String::from("1 SECOND"))).with_empty_span()
+                )),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
@@ -5906,9 +5996,9 @@ fn interval_disallow_interval_expr_gt() {
         expr,
         Expr::BinaryOp {
             left: Box::new(Expr::Interval(Interval {
-                value: Box::new(Expr::Value((Value::SingleQuotedString(
-                    "1 second".to_string()
-                )).with_empty_span())),
+                value: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("1 second".to_string())).with_empty_span()
+                )),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
@@ -5933,9 +6023,9 @@ fn interval_disallow_interval_expr_double_colon() {
         Expr::Cast {
             kind: CastKind::DoubleColon,
             expr: Box::new(Expr::Interval(Interval {
-                value: Box::new(Expr::Value((Value::SingleQuotedString(
-                    "1 second".to_string()
-                )).with_empty_span())),
+                value: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("1 second".to_string())).with_empty_span()
+                )),
                 leading_field: None,
                 leading_precision: None,
                 last_field: None,
@@ -5995,9 +6085,9 @@ fn parse_interval_and_or_xor() {
                         })),
                         op: BinaryOperator::Plus,
                         right: Box::new(Expr::Interval(Interval {
-                            value: Box::new(Expr::Value((Value::SingleQuotedString(
-                                "5 days".to_string(),
-                            )).with_empty_span())),
+                            value: Box::new(Expr::Value(
+                                (Value::SingleQuotedString("5 days".to_string())).with_empty_span(),
+                            )),
                             leading_field: None,
                             leading_precision: None,
                             last_field: None,
@@ -6021,9 +6111,9 @@ fn parse_interval_and_or_xor() {
                         })),
                         op: BinaryOperator::Plus,
                         right: Box::new(Expr::Interval(Interval {
-                            value: Box::new(Expr::Value((Value::SingleQuotedString(
-                                "3 days".to_string(),
-                            )).with_empty_span())),
+                            value: Box::new(Expr::Value(
+                                (Value::SingleQuotedString("3 days".to_string())).with_empty_span(),
+                            )),
                             leading_field: None,
                             leading_precision: None,
                             last_field: None,
@@ -6084,9 +6174,9 @@ fn parse_at_timezone() {
     assert_eq!(
         &Expr::AtTimeZone {
             timestamp: Box::new(call("FROM_UNIXTIME", [zero.clone()])),
-            time_zone: Box::new(Expr::Value((Value::SingleQuotedString(
-                "UTC-06:00".to_string()
-            )).with_empty_span())),
+            time_zone: Box::new(Expr::Value(
+                (Value::SingleQuotedString("UTC-06:00".to_string())).with_empty_span()
+            )),
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -6100,11 +6190,13 @@ fn parse_at_timezone() {
                 [
                     Expr::AtTimeZone {
                         timestamp: Box::new(call("FROM_UNIXTIME", [zero])),
-                        time_zone: Box::new(Expr::Value((Value::SingleQuotedString(
-                            "UTC-06:00".to_string()
-                        )).with_empty_span())),
+                        time_zone: Box::new(Expr::Value(
+                            (Value::SingleQuotedString("UTC-06:00".to_string())).with_empty_span()
+                        )),
                     },
-                    Expr::Value((Value::SingleQuotedString("%Y-%m-%dT%H".to_string())).with_empty_span())
+                    Expr::Value(
+                        (Value::SingleQuotedString("%Y-%m-%dT%H".to_string())).with_empty_span()
+                    )
                 ]
             ),
             alias: Ident {
@@ -6278,7 +6370,9 @@ fn parse_table_function() {
             assert_eq!(
                 call(
                     "FUN",
-                    [Expr::Value((Value::SingleQuotedString("1".to_owned())).with_empty_span())],
+                    [Expr::Value(
+                        (Value::SingleQuotedString("1".to_owned())).with_empty_span()
+                    )],
                 ),
                 expr
             );
@@ -6494,7 +6588,10 @@ fn parse_unnest_in_from_clause() {
                     ),
                     call(
                         "make_array",
-                        [Expr::Value((number("5")).with_empty_span()), Expr::Value((number("6")).with_empty_span())],
+                        [
+                            Expr::Value((number("5")).with_empty_span()),
+                            Expr::Value((number("6")).with_empty_span()),
+                        ],
                     ),
                 ],
                 with_offset: false,
@@ -6556,9 +6653,9 @@ fn parse_searched_case_expr() {
                 Expr::Value((Value::SingleQuotedString("=0".to_string())).with_empty_span()),
                 Expr::Value((Value::SingleQuotedString(">=0".to_string())).with_empty_span()),
             ],
-            else_result: Some(Box::new(Expr::Value((Value::SingleQuotedString(
-                "<0".to_string()
-            )).with_empty_span()))),
+            else_result: Some(Box::new(Expr::Value(
+                (Value::SingleQuotedString("<0".to_string())).with_empty_span()
+            ))),
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -6574,10 +6671,12 @@ fn parse_simple_case_expr() {
         &Case {
             operand: Some(Box::new(Identifier(Ident::new("foo")))),
             conditions: vec![Expr::Value((number("1")).with_empty_span())],
-            results: vec![Expr::Value((Value::SingleQuotedString("Y".to_string())).with_empty_span())],
-            else_result: Some(Box::new(Expr::Value((Value::SingleQuotedString(
-                "N".to_string()
-            )).with_empty_span()))),
+            results: vec![Expr::Value(
+                (Value::SingleQuotedString("Y".to_string())).with_empty_span()
+            )],
+            else_result: Some(Box::new(Expr::Value(
+                (Value::SingleQuotedString("N".to_string())).with_empty_span()
+            ))),
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -7326,7 +7425,9 @@ fn parse_overlay() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Overlay {
-            expr: Box::new(Expr::Value((Value::SingleQuotedString("abcdef".to_string())).with_empty_span())),
+            expr: Box::new(Expr::Value(
+                (Value::SingleQuotedString("abcdef".to_string())).with_empty_span()
+            )),
             overlay_what: Box::new(Expr::Identifier(Ident::new("name"))),
             overlay_from: Box::new(Expr::Value((number("3")).with_empty_span())),
             overlay_for: Some(Box::new(Expr::BinaryOp {
@@ -7560,7 +7661,9 @@ fn parse_create_view_with_options() {
                 CreateTableOptions::With(vec![
                     SqlOption::KeyValue {
                         key: "foo".into(),
-                        value: Expr::Value((Value::SingleQuotedString("bar".into())).with_empty_span()),
+                        value: Expr::Value(
+                            (Value::SingleQuotedString("bar".into())).with_empty_span()
+                        ),
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
@@ -8090,7 +8193,9 @@ fn lateral_derived() {
         let join = &from.joins[0];
         assert_eq!(
             join.join_operator,
-            JoinOperator::Left(JoinConstraint::On(Expr::Value((test_utils::number("1")).with_empty_span())))
+            JoinOperator::Left(JoinConstraint::On(Expr::Value(
+                (test_utils::number("1")).with_empty_span()
+            )))
         );
         if let TableFactor::Derived {
             lateral,
@@ -8150,7 +8255,9 @@ fn lateral_function() {
                     lateral: true,
                     name: ObjectName::from(vec!["generate_series".into()]),
                     args: vec![
-                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span()))),
+                        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                            (number("1")).with_empty_span(),
+                        ))),
                         FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::CompoundIdentifier(
                             vec![Ident::new("customer"), Ident::new("id")],
                         ))),
@@ -8314,7 +8421,9 @@ fn parse_set_variable() {
             );
             assert_eq!(
                 value,
-                vec![Expr::Value((Value::SingleQuotedString("1".into())).with_empty_span())]
+                vec![Expr::Value(
+                    (Value::SingleQuotedString("1".into())).with_empty_span()
+                )]
             );
         }
         _ => unreachable!(),
@@ -8414,7 +8523,9 @@ fn parse_set_role_as_variable() {
             );
             assert_eq!(
                 value,
-                vec![Expr::Value((Value::SingleQuotedString("foobar".into())).with_empty_span())]
+                vec![Expr::Value(
+                    (Value::SingleQuotedString("foobar".into())).with_empty_span()
+                )]
             );
         }
         _ => unreachable!(),
@@ -8430,15 +8541,16 @@ fn parse_double_colon_cast_at_timezone() {
         &Expr::AtTimeZone {
             timestamp: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value((Value::SingleQuotedString(
-                    "2001-01-01T00:00:00.000Z".to_string()
-                )).with_empty_span())),
+                expr: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("2001-01-01T00:00:00.000Z".to_string()))
+                        .with_empty_span()
+                )),
                 data_type: DataType::Timestamp(None, TimezoneInfo::None),
                 format: None
             }),
-            time_zone: Box::new(Expr::Value((Value::SingleQuotedString(
-                "Europe/Brussels".to_string()
-            )).with_empty_span())),
+            time_zone: Box::new(Expr::Value(
+                (Value::SingleQuotedString("Europe/Brussels".to_string())).with_empty_span()
+            )),
         },
         expr_from_projection(only(&select.projection)),
     );
@@ -8461,7 +8573,9 @@ fn parse_set_time_zone() {
             );
             assert_eq!(
                 value,
-                vec![Expr::Value((Value::SingleQuotedString("UTC".into())).with_empty_span())]
+                vec![Expr::Value(
+                    (Value::SingleQuotedString("UTC".into())).with_empty_span()
+                )]
             );
         }
         _ => unreachable!(),
@@ -8475,7 +8589,10 @@ fn parse_set_time_zone_alias() {
     match verified_stmt("SET TIME ZONE 'UTC'") {
         Statement::SetTimeZone { local, value } => {
             assert!(!local);
-            assert_eq!(value, Expr::Value((Value::SingleQuotedString("UTC".into())).with_empty_span()));
+            assert_eq!(
+                value,
+                Expr::Value((Value::SingleQuotedString("UTC".into())).with_empty_span())
+            );
         }
         _ => unreachable!(),
     }
@@ -9161,9 +9278,9 @@ fn parse_merge() {
                                 Ident::new("A"),
                             ])),
                             op: BinaryOperator::Eq,
-                            right: Box::new(Expr::Value((Value::SingleQuotedString(
-                                "a".to_string()
-                            )).with_empty_span())),
+                            right: Box::new(Expr::Value(
+                                (Value::SingleQuotedString("a".to_string())).with_empty_span()
+                            )),
                         }),
                         action: MergeAction::Update {
                             assignments: vec![
@@ -9389,7 +9506,9 @@ fn test_placeholder() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("id"))),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value((Value::Placeholder("$Id1".into())).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::Placeholder("$Id1".into())).with_empty_span()
+            )),
         })
     );
 
@@ -9397,7 +9516,9 @@ fn test_placeholder() {
     let ast = dialects.verified_query(sql);
     assert_eq!(
         ast.limit,
-        Some(Expr::Value((Value::Placeholder("$1".into())).with_empty_span()))
+        Some(Expr::Value(
+            (Value::Placeholder("$1".into())).with_empty_span()
+        ))
     );
     assert_eq!(
         ast.offset,
@@ -9426,7 +9547,9 @@ fn test_placeholder() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("id"))),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value((Value::Placeholder("?".into())).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::Placeholder("?".into())).with_empty_span()
+            )),
         })
     );
 
@@ -9435,9 +9558,15 @@ fn test_placeholder() {
     assert_eq!(
         ast.projection,
         vec![
-            UnnamedExpr(Expr::Value((Value::Placeholder("$fromage_français".into())).with_empty_span())),
-            UnnamedExpr(Expr::Value((Value::Placeholder(":x".into())).with_empty_span())),
-            UnnamedExpr(Expr::Value((Value::Placeholder("?123".into())).with_empty_span())),
+            UnnamedExpr(Expr::Value(
+                (Value::Placeholder("$fromage_français".into())).with_empty_span()
+            )),
+            UnnamedExpr(Expr::Value(
+                (Value::Placeholder(":x".into())).with_empty_span()
+            )),
+            UnnamedExpr(Expr::Value(
+                (Value::Placeholder("?123".into())).with_empty_span()
+            )),
         ]
     );
 }
@@ -9483,7 +9612,10 @@ fn parse_offset_and_limit() {
     });
     let ast = verified_query(sql);
     assert_eq!(ast.offset, expect);
-    assert_eq!(ast.limit, Some(Expr::Value((number("1")).with_empty_span())));
+    assert_eq!(
+        ast.limit,
+        Some(Expr::Value((number("1")).with_empty_span()))
+    );
 
     // different order is OK
     one_statement_parses_to("SELECT foo FROM bar OFFSET 2 LIMIT 1", sql);
@@ -9585,7 +9717,9 @@ fn parse_time_functions() {
 fn parse_position() {
     assert_eq!(
         Expr::Position {
-            expr: Box::new(Expr::Value((Value::SingleQuotedString("@".to_string())).with_empty_span())),
+            expr: Box::new(Expr::Value(
+                (Value::SingleQuotedString("@".to_string())).with_empty_span()
+            )),
             r#in: Box::new(Expr::Identifier(Ident::new("field"))),
         },
         verified_expr("POSITION('@' IN field)"),
@@ -10116,7 +10250,9 @@ fn parse_escaped_string_with_unescape() {
                     let expr = expr_from_projection(only(&value.projection));
                     assert_eq!(
                         *expr,
-                        Expr::Value((Value::SingleQuotedString(quoted.to_string())).with_empty_span())
+                        Expr::Value(
+                            (Value::SingleQuotedString(quoted.to_string())).with_empty_span()
+                        )
                     );
                 }
                 _ => unreachable!(),
@@ -10156,7 +10292,9 @@ fn parse_escaped_string_without_unescape() {
                     let expr = expr_from_projection(only(&value.projection));
                     assert_eq!(
                         *expr,
-                        Expr::Value((Value::SingleQuotedString(quoted.to_string())).with_empty_span())
+                        Expr::Value(
+                            (Value::SingleQuotedString(quoted.to_string())).with_empty_span()
+                        )
                     );
                 }
                 _ => unreachable!(),
@@ -10231,7 +10369,9 @@ fn parse_pivot_table() {
                     alias: Some(Ident::new("x"))
                 },
                 ExprWithAlias {
-                    expr: Expr::Value((Value::SingleQuotedString("two".to_string())).with_empty_span()),
+                    expr: Expr::Value(
+                        (Value::SingleQuotedString("two".to_string())).with_empty_span()
+                    ),
                     alias: None
                 },
                 ExprWithAlias {
@@ -10462,11 +10602,17 @@ fn parse_pivot_unpivot_table() {
             value_column: vec![Ident::new("year")],
             value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
-                    expr: Expr::Value((Value::SingleQuotedString("population_2000".to_string())).with_empty_span()),
+                    expr: Expr::Value(
+                        (Value::SingleQuotedString("population_2000".to_string()))
+                            .with_empty_span()
+                    ),
                     alias: None
                 },
                 ExprWithAlias {
-                    expr: Expr::Value((Value::SingleQuotedString("population_2010".to_string())).with_empty_span()),
+                    expr: Expr::Value(
+                        (Value::SingleQuotedString("population_2010".to_string()))
+                            .with_empty_span()
+                    ),
                     alias: None
                 },
             ]),
@@ -10712,9 +10858,9 @@ fn parse_call() {
             parameters: FunctionArguments::None,
             args: FunctionArguments::List(FunctionArgumentList {
                 duplicate_treatment: None,
-                args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
-                    Value::SingleQuotedString("a".to_string())
-                ).with_empty_span())))],
+                args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                    (Value::SingleQuotedString("a".to_string())).with_empty_span()
+                )))],
                 clauses: vec![],
             }),
             name: ObjectName::from(vec![Ident::new("my_procedure")]),
@@ -10770,9 +10916,9 @@ fn parse_execute_immediate() {
     let dialects = all_dialects_where(|d| d.supports_execute_immediate());
 
     let expected = Statement::Execute {
-        parameters: vec![Expr::Value((Value::SingleQuotedString(
-            "SELECT 1".to_string(),
-        )).with_empty_span())],
+        parameters: vec![Expr::Value(
+            (Value::SingleQuotedString("SELECT 1".to_string())).with_empty_span(),
+        )],
         immediate: true,
         using: vec![ExprWithAlias {
             expr: Expr::Value((number("1")).with_empty_span()),
@@ -10925,7 +11071,9 @@ fn parse_unload() {
                     quote_style: None,
                     span: Span::empty(),
                 },
-                value: Expr::Value((Value::SingleQuotedString("AVRO".to_string())).with_empty_span())
+                value: Expr::Value(
+                    (Value::SingleQuotedString("AVRO".to_string())).with_empty_span()
+                )
             }]
         }
     );
@@ -11045,9 +11193,9 @@ fn parse_map_access_expr() {
                     parameters: FunctionArguments::None,
                     args: FunctionArguments::List(FunctionArgumentList {
                         duplicate_treatment: None,
-                        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
-                            number("2")
-                        ).with_empty_span())))],
+                        args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                            (number("2")).with_empty_span(),
+                        )))],
                         clauses: vec![],
                     }),
                     filter: None,
@@ -11099,9 +11247,9 @@ fn parse_connect_by() {
             condition: Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("title"))),
                 op: BinaryOperator::Eq,
-                right: Box::new(Expr::Value(Value::SingleQuotedString(
-                    "president".to_owned(),
-                ).with_empty_span())),
+                right: Box::new(Expr::Value(
+                    Value::SingleQuotedString("president".to_owned()).with_empty_span(),
+                )),
             },
             relationships: vec![Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("manager_id"))),
@@ -11184,9 +11332,9 @@ fn parse_connect_by() {
                 condition: Expr::BinaryOp {
                     left: Box::new(Expr::Identifier(Ident::new("title"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value((Value::SingleQuotedString(
-                        "president".to_owned(),
-                    )).with_empty_span())),
+                    right: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("president".to_owned(),)).with_empty_span()
+                    )),
                 },
                 relationships: vec![Expr::BinaryOp {
                     left: Box::new(Expr::Identifier(Ident::new("manager_id"))),
@@ -11269,7 +11417,9 @@ fn test_selective_aggregation() {
                     filter: Some(Box::new(Expr::Like {
                         negated: false,
                         expr: Box::new(Expr::Identifier(Ident::new("name"))),
-                        pattern: Box::new(Expr::Value((Value::SingleQuotedString("a%".to_owned())).with_empty_span())),
+                        pattern: Box::new(Expr::Value(
+                            (Value::SingleQuotedString("a%".to_owned())).with_empty_span()
+                        )),
                         escape_char: None,
                         any: false,
                     })),
@@ -11625,7 +11775,9 @@ fn test_select_wildcard_with_replace() {
     let expected = SelectItem::Wildcard(WildcardAdditionalOptions {
         opt_replace: Some(ReplaceSelectItem {
             items: vec![Box::new(ReplaceSelectElement {
-                expr: Expr::Value((Value::SingleQuotedString("widget".to_owned())).with_empty_span()),
+                expr: Expr::Value(
+                    (Value::SingleQuotedString("widget".to_owned())).with_empty_span(),
+                ),
                 column_name: Ident::new("item_name"),
                 as_keyword: true,
             })],
@@ -11733,15 +11885,15 @@ fn test_dictionary_syntax() {
         Expr::Dictionary(vec![
             DictionaryField {
                 key: Ident::with_quote('\'', "Alberta"),
-                value: Box::new(Expr::Value((Value::SingleQuotedString(
-                    "Edmonton".to_owned(),
-                )).with_empty_span())),
+                value: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("Edmonton".to_owned())).with_empty_span(),
+                )),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "Manitoba"),
-                value: Box::new(Expr::Value((Value::SingleQuotedString(
-                    "Winnipeg".to_owned(),
-                )).with_empty_span())),
+                value: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("Winnipeg".to_owned())).with_empty_span(),
+                )),
             },
         ]),
     );
@@ -11753,9 +11905,9 @@ fn test_dictionary_syntax() {
                 key: Ident::with_quote('\'', "start"),
                 value: Box::new(Expr::Cast {
                     kind: CastKind::Cast,
-                    expr: Box::new(Expr::Value((Value::SingleQuotedString(
-                        "2023-04-01".to_owned(),
-                    )).with_empty_span())),
+                    expr: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("2023-04-01".to_owned())).with_empty_span(),
+                    )),
                     data_type: DataType::Timestamp(None, TimezoneInfo::None),
                     format: None,
                 }),
@@ -11764,9 +11916,9 @@ fn test_dictionary_syntax() {
                 key: Ident::with_quote('\'', "end"),
                 value: Box::new(Expr::Cast {
                     kind: CastKind::Cast,
-                    expr: Box::new(Expr::Value((Value::SingleQuotedString(
-                        "2023-04-05".to_owned(),
-                    )).with_empty_span())),
+                    expr: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("2023-04-05".to_owned())).with_empty_span(),
+                    )),
                     data_type: DataType::Timestamp(None, TimezoneInfo::None),
                     format: None,
                 }),
@@ -11789,18 +11941,20 @@ fn test_map_syntax() {
         Expr::Map(Map {
             entries: vec![
                 MapEntry {
-                    key: Box::new(Expr::Value((Value::SingleQuotedString("Alberta".to_owned())).with_empty_span())),
-                    value: Box::new(Expr::Value((Value::SingleQuotedString(
-                        "Edmonton".to_owned(),
-                    )).with_empty_span())),
+                    key: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("Alberta".to_owned())).with_empty_span(),
+                    )),
+                    value: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("Edmonton".to_owned())).with_empty_span(),
+                    )),
                 },
                 MapEntry {
-                    key: Box::new(Expr::Value((Value::SingleQuotedString(
-                        "Manitoba".to_owned(),
-                    )).with_empty_span())),
-                    value: Box::new(Expr::Value((Value::SingleQuotedString(
-                        "Winnipeg".to_owned(),
-                    )).with_empty_span())),
+                    key: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("Manitoba".to_owned())).with_empty_span(),
+                    )),
+                    value: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("Winnipeg".to_owned())).with_empty_span(),
+                    )),
                 },
             ],
         }),
@@ -11854,11 +12008,15 @@ fn test_map_syntax() {
             root: Box::new(Expr::Map(Map {
                 entries: vec![
                     MapEntry {
-                        key: Box::new(Expr::Value((Value::SingleQuotedString("a".to_owned())).with_empty_span())),
+                        key: Box::new(Expr::Value(
+                            (Value::SingleQuotedString("a".to_owned())).with_empty_span(),
+                        )),
                         value: Box::new(number_expr("10")),
                     },
                     MapEntry {
-                        key: Box::new(Expr::Value((Value::SingleQuotedString("b".to_owned())).with_empty_span())),
+                        key: Box::new(Expr::Value(
+                            (Value::SingleQuotedString("b".to_owned())).with_empty_span(),
+                        )),
                         value: Box::new(number_expr("20")),
                     },
                 ],
@@ -12013,9 +12171,9 @@ fn test_extract_seconds_ok() {
             syntax: ExtractSyntax::From,
             expr: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value((Value::SingleQuotedString(
-                    "2 seconds".to_string()
-                )).with_empty_span())),
+                expr: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("2 seconds".to_string())).with_empty_span()
+                )),
                 data_type: DataType::Interval,
                 format: None,
             }),
@@ -12038,9 +12196,9 @@ fn test_extract_seconds_ok() {
                 syntax: ExtractSyntax::From,
                 expr: Box::new(Expr::Cast {
                     kind: CastKind::DoubleColon,
-                    expr: Box::new(Expr::Value((Value::SingleQuotedString(
-                        "2 seconds".to_string(),
-                    )).with_empty_span())),
+                    expr: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("2 seconds".to_string())).with_empty_span(),
+                    )),
                     data_type: DataType::Interval,
                     format: None,
                 }),
@@ -12092,9 +12250,9 @@ fn test_extract_seconds_single_quote_ok() {
             syntax: ExtractSyntax::From,
             expr: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value((Value::SingleQuotedString(
-                    "2 seconds".to_string()
-                )).with_empty_span())),
+                expr: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("2 seconds".to_string())).with_empty_span()
+                )),
                 data_type: DataType::Interval,
                 format: None,
             }),
@@ -12185,7 +12343,9 @@ fn parse_explain_with_option_list() {
             },
             UtilityOption {
                 name: Ident::new("FORMAT2"),
-                arg: Some(Expr::Value((Value::SingleQuotedString("JSON".to_string())).with_empty_span())),
+                arg: Some(Expr::Value(
+                    (Value::SingleQuotedString("JSON".to_string())).with_empty_span(),
+                )),
             },
             UtilityOption {
                 name: Ident::new("FORMAT3"),
@@ -12207,20 +12367,26 @@ fn parse_explain_with_option_list() {
         Some(vec![
             UtilityOption {
                 name: Ident::new("NUM1"),
-                arg: Some(Expr::Value((Value::Number("10".parse().unwrap(), false)).with_empty_span())),
+                arg: Some(Expr::Value(
+                    (Value::Number("10".parse().unwrap(), false)).with_empty_span(),
+                )),
             },
             UtilityOption {
                 name: Ident::new("NUM2"),
                 arg: Some(Expr::UnaryOp {
                     op: UnaryOperator::Plus,
-                    expr: Box::new(Expr::Value((Value::Number("10.1".parse().unwrap(), false)).with_empty_span())),
+                    expr: Box::new(Expr::Value(
+                        (Value::Number("10.1".parse().unwrap(), false)).with_empty_span(),
+                    )),
                 }),
             },
             UtilityOption {
                 name: Ident::new("NUM3"),
                 arg: Some(Expr::UnaryOp {
                     op: UnaryOperator::Minus,
-                    expr: Box::new(Expr::Value((Value::Number("10.2".parse().unwrap(), false)).with_empty_span())),
+                    expr: Box::new(Expr::Value(
+                        (Value::Number("10.2".parse().unwrap(), false)).with_empty_span(),
+                    )),
                 }),
             },
         ]),
@@ -12247,7 +12413,9 @@ fn parse_explain_with_option_list() {
             name: Ident::new("USER_DEF_NUM"),
             arg: Some(Expr::UnaryOp {
                 op: UnaryOperator::Minus,
-                expr: Box::new(Expr::Value((Value::Number("100.1".parse().unwrap(), false)).with_empty_span())),
+                expr: Box::new(Expr::Value(
+                    (Value::Number("100.1".parse().unwrap(), false)).with_empty_span(),
+                )),
             }),
         },
     ];
@@ -12292,15 +12460,21 @@ fn test_create_policy() {
                 Some(Expr::BinaryOp {
                     left: Box::new(Expr::Identifier(Ident::new("c0"))),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
+                    right: Box::new(Expr::Value(
+                        (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                    )),
                 })
             );
             assert_eq!(
                 with_check,
                 Some(Expr::BinaryOp {
-                    left: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
+                    left: Box::new(Expr::Value(
+                        (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                    )),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
+                    right: Box::new(Expr::Value(
+                        (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                    )),
                 })
             );
         }
@@ -12513,11 +12687,15 @@ fn test_create_connector() {
                 Some(vec![
                     SqlOption::KeyValue {
                         key: Ident::with_quote('\'', "user"),
-                        value: Expr::Value((Value::SingleQuotedString("root".to_string())).with_empty_span())
+                        value: Expr::Value(
+                            (Value::SingleQuotedString("root".to_string())).with_empty_span()
+                        )
                     },
                     SqlOption::KeyValue {
                         key: Ident::with_quote('\'', "password"),
-                        value: Expr::Value((Value::SingleQuotedString("password".to_string())).with_empty_span())
+                        value: Expr::Value(
+                            (Value::SingleQuotedString("password".to_string())).with_empty_span()
+                        )
                     }
                 ])
             );
@@ -12580,11 +12758,15 @@ fn test_alter_connector() {
                 Some(vec![
                     SqlOption::KeyValue {
                         key: Ident::with_quote('\'', "user"),
-                        value: Expr::Value((Value::SingleQuotedString("root".to_string())).with_empty_span())
+                        value: Expr::Value(
+                            (Value::SingleQuotedString("root".to_string())).with_empty_span()
+                        )
                     },
                     SqlOption::KeyValue {
                         key: Ident::with_quote('\'', "password"),
-                        value: Expr::Value((Value::SingleQuotedString("password".to_string())).with_empty_span())
+                        value: Expr::Value(
+                            (Value::SingleQuotedString("password".to_string())).with_empty_span()
+                        )
                     }
                 ])
             );
@@ -13051,12 +13233,16 @@ fn parse_load_data() {
                     Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("year"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value((Value::Number("2024".parse().unwrap(), false)).with_empty_span())),
+                        right: Box::new(Expr::Value(
+                            (Value::Number("2024".parse().unwrap(), false)).with_empty_span()
+                        )),
                     },
                     Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("month"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value((Value::Number("11".parse().unwrap(), false)).with_empty_span())),
+                        right: Box::new(Expr::Value(
+                            (Value::Number("11".parse().unwrap(), false)).with_empty_span()
+                        )),
                     }
                 ]),
                 partitioned
@@ -13089,24 +13275,34 @@ fn parse_load_data() {
                     Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("year"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value((Value::Number("2024".parse().unwrap(), false)).with_empty_span())),
+                        right: Box::new(Expr::Value(
+                            (Value::Number("2024".parse().unwrap(), false)).with_empty_span()
+                        )),
                     },
                     Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("month"))),
                         op: BinaryOperator::Eq,
-                        right: Box::new(Expr::Value((Value::Number("11".parse().unwrap(), false)).with_empty_span())),
+                        right: Box::new(Expr::Value(
+                            (Value::Number("11".parse().unwrap(), false)).with_empty_span()
+                        )),
                     }
                 ]),
                 partitioned
             );
             assert_eq!(
                 Some(HiveLoadDataFormat {
-                    serde: Expr::Value((Value::SingleQuotedString(
-                        "org.apache.hadoop.hive.serde2.OpenCSVSerde".to_string()
-                    )).with_empty_span()),
-                    input_format: Expr::Value((Value::SingleQuotedString(
-                        "org.apache.hadoop.mapred.TextInputFormat".to_string()
-                    )).with_empty_span())
+                    serde: Expr::Value(
+                        (Value::SingleQuotedString(
+                            "org.apache.hadoop.hive.serde2.OpenCSVSerde".to_string()
+                        ))
+                        .with_empty_span()
+                    ),
+                    input_format: Expr::Value(
+                        (Value::SingleQuotedString(
+                            "org.apache.hadoop.mapred.TextInputFormat".to_string()
+                        ))
+                        .with_empty_span()
+                    )
                 }),
                 table_format
             );
@@ -13184,7 +13380,9 @@ fn parse_bang_not() {
         Box::new(Expr::Nested(Box::new(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("b"))),
             op: BinaryOperator::Gt,
-            right: Box::new(Expr::Value(Value::Number("3".parse().unwrap(), false).with_empty_span())),
+            right: Box::new(Expr::Value(
+                Value::Number("3".parse().unwrap(), false).with_empty_span(),
+            )),
         }))),
     ]
     .into_iter()
@@ -13526,7 +13724,9 @@ fn parse_composite_access_expr() {
                         values: vec![
                             Expr::Named {
                                 name: Ident::new("a"),
-                                expr: Box::new(Expr::Value((Number("1".parse().unwrap(), false)).with_empty_span())),
+                                expr: Box::new(Expr::Value(
+                                    (Number("1".parse().unwrap(), false)).with_empty_span(),
+                                )),
                             },
                             Expr::Named {
                                 name: Ident::new("b"),
@@ -13565,11 +13765,15 @@ fn parse_create_table_with_enum_types() {
                             vec![
                                 EnumMember::NamedValue(
                                     "a".to_string(),
-                                    Expr::Value((Number("1".parse().unwrap(), false)).with_empty_span())
+                                    Expr::Value(
+                                        (Number("1".parse().unwrap(), false)).with_empty_span()
+                                    )
                                 ),
                                 EnumMember::NamedValue(
                                     "b".to_string(),
-                                    Expr::Value((Number("2".parse().unwrap(), false)).with_empty_span())
+                                    Expr::Value(
+                                        (Number("2".parse().unwrap(), false)).with_empty_span()
+                                    )
                                 )
                             ],
                             Some(8)
@@ -13582,11 +13786,15 @@ fn parse_create_table_with_enum_types() {
                             vec![
                                 EnumMember::NamedValue(
                                     "a".to_string(),
-                                    Expr::Value((Number("1".parse().unwrap(), false)).with_empty_span())
+                                    Expr::Value(
+                                        (Number("1".parse().unwrap(), false)).with_empty_span()
+                                    )
                                 ),
                                 EnumMember::NamedValue(
                                     "b".to_string(),
-                                    Expr::Value((Number("2".parse().unwrap(), false)).with_empty_span())
+                                    Expr::Value(
+                                        (Number("2".parse().unwrap(), false)).with_empty_span()
+                                    )
                                 )
                             ],
                             Some(16)
@@ -13752,8 +13960,12 @@ fn test_lambdas() {
                 call(
                     "array",
                     [
-                        Expr::Value((Value::SingleQuotedString("Hello".to_owned())).with_empty_span()),
-                        Expr::Value((Value::SingleQuotedString("World".to_owned())).with_empty_span())
+                        Expr::Value(
+                            (Value::SingleQuotedString("Hello".to_owned())).with_empty_span()
+                        ),
+                        Expr::Value(
+                            (Value::SingleQuotedString("World".to_owned())).with_empty_span()
+                        )
                     ]
                 ),
                 Expr::Lambda(LambdaFunction {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -95,9 +95,9 @@ fn parse_function_object_name() {
 #[test]
 fn parse_insert_values() {
     let row = vec![
-        Expr::Value((number("1")).with_empty_span()),
-        Expr::Value((number("2")).with_empty_span()),
-        Expr::Value((number("3")).with_empty_span()),
+        Expr::value(number("1")),
+        Expr::value(number("2")),
+        Expr::value(number("3")),
     ];
     let rows1 = vec![row.clone()];
     let rows2 = vec![row.clone(), row];
@@ -386,15 +386,15 @@ fn parse_update() {
                 vec![
                     Assignment {
                         target: AssignmentTarget::ColumnName(ObjectName::from(vec!["a".into()])),
-                        value: Expr::Value((number("1")).with_empty_span()),
+                        value: Expr::value(number("1")),
                     },
                     Assignment {
                         target: AssignmentTarget::ColumnName(ObjectName::from(vec!["b".into()])),
-                        value: Expr::Value((number("2")).with_empty_span()),
+                        value: Expr::value(number("2")),
                     },
                     Assignment {
                         target: AssignmentTarget::ColumnName(ObjectName::from(vec!["c".into()])),
-                        value: Expr::Value((number("3")).with_empty_span()),
+                        value: Expr::value(number("3")),
                     },
                 ]
             );
@@ -801,7 +801,7 @@ fn parse_where_delete_statement() {
                 Expr::BinaryOp {
                     left: Box::new(Expr::Identifier(Ident::new("name"))),
                     op: Eq,
-                    right: Box::new(Expr::Value((number("5")).with_empty_span())),
+                    right: Box::new(Expr::value(number("5"))),
                 },
                 selection.unwrap(),
             );
@@ -901,7 +901,7 @@ fn parse_simple_select() {
     assert_eq!(3, select.projection.len());
     let select = verified_query(sql);
     assert_eq!(
-        Some(Expr::Value((number("5")).with_empty_span())),
+        Some(Expr::value(number("5"))),
         select.limit
     );
 }
@@ -916,13 +916,13 @@ fn parse_limit_is_not_an_alias() {
     // In dialects supporting LIMIT it shouldn't be parsed as a table alias
     let ast = verified_query("SELECT id FROM customer LIMIT 1");
     assert_eq!(
-        Some(Expr::Value((number("1")).with_empty_span())),
+        Some(Expr::value(number("1"))),
         ast.limit
     );
 
     let ast = verified_query("SELECT 1 LIMIT 5");
     assert_eq!(
-        Some(Expr::Value((number("5")).with_empty_span())),
+        Some(Expr::value(number("5"))),
         ast.limit
     );
 }
@@ -1143,7 +1143,7 @@ fn parse_column_aliases() {
     {
         assert_eq!(&BinaryOperator::Plus, op);
         assert_eq!(
-            &Expr::Value((number("1")).with_empty_span()),
+            &Expr::value(number("1")),
             right.as_ref()
         );
         assert_eq!(&Ident::new("newname"), alias);
@@ -1409,17 +1409,17 @@ fn parse_exponent_in_select() -> Result<(), ParserError> {
     assert_eq!(
         &vec![
             SelectItem::UnnamedExpr(Expr::Value((number("10e-20")).with_empty_span())),
-            SelectItem::UnnamedExpr(Expr::Value((number("1e3")).with_empty_span())),
+            SelectItem::UnnamedExpr(Expr::value(number("1e3"))),
             SelectItem::UnnamedExpr(Expr::Value((number("1e+3")).with_empty_span())),
             SelectItem::ExprWithAlias {
-                expr: Expr::Value((number("1e3")).with_empty_span()),
+                expr: Expr::value(number("1e3")),
                 alias: Ident::new("a")
             },
             SelectItem::ExprWithAlias {
-                expr: Expr::Value((number("1")).with_empty_span()),
+                expr: Expr::value(number("1")),
                 alias: Ident::new("e")
             },
-            SelectItem::UnnamedExpr(Expr::Value((number("0.5e2")).with_empty_span())),
+            SelectItem::UnnamedExpr(Expr::value(number("0.5e2"))),
         ],
         &select.projection
     );
@@ -1661,7 +1661,7 @@ fn parse_json_object() {
                 },
                 FunctionArg::ExprNamed {
                     name: Expr::Value((Value::SingleQuotedString("type".into())).with_empty_span()),
-                    arg: FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span())),
+                    arg: FunctionArgExpr::Expr(Expr::value(number("1"))),
                     operator: FunctionArgOperator::Colon
                 }
             ],
@@ -1909,9 +1909,9 @@ fn parse_not_precedence() {
         Expr::UnaryOp {
             op: UnaryOperator::Not,
             expr: Box::new(Expr::Between {
-                expr: Box::new(Expr::Value((number("1")).with_empty_span())),
-                low: Box::new(Expr::Value((number("1")).with_empty_span())),
-                high: Box::new(Expr::Value((number("2")).with_empty_span())),
+                expr: Box::new(Expr::value(number("1"))),
+                low: Box::new(Expr::value(number("1"))),
+                high: Box::new(Expr::value(number("2"))),
                 negated: true,
             }),
         },
@@ -2340,8 +2340,8 @@ fn parse_between() {
         assert_eq!(
             Expr::Between {
                 expr: Box::new(Expr::Identifier(Ident::new("age"))),
-                low: Box::new(Expr::Value((number("25")).with_empty_span())),
-                high: Box::new(Expr::Value((number("32")).with_empty_span())),
+                low: Box::new(Expr::value(number("25"))),
+                high: Box::new(Expr::value(number("32"))),
                 negated,
             },
             select.selection.unwrap()
@@ -2358,16 +2358,16 @@ fn parse_between_with_expr() {
     let select = verified_only_select(sql);
     assert_eq!(
         Expr::IsNull(Box::new(Expr::Between {
-            expr: Box::new(Expr::Value((number("1")).with_empty_span())),
+            expr: Box::new(Expr::value(number("1"))),
             low: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value((number("1")).with_empty_span())),
+                left: Box::new(Expr::value(number("1"))),
                 op: Plus,
-                right: Box::new(Expr::Value((number("2")).with_empty_span())),
+                right: Box::new(Expr::value(number("2"))),
             }),
             high: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value((number("3")).with_empty_span())),
+                left: Box::new(Expr::value(number("3"))),
                 op: Plus,
-                right: Box::new(Expr::Value((number("4")).with_empty_span())),
+                right: Box::new(Expr::value(number("4"))),
             }),
             negated: false,
         })),
@@ -2379,19 +2379,19 @@ fn parse_between_with_expr() {
     assert_eq!(
         Expr::BinaryOp {
             left: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value((number("1")).with_empty_span())),
+                left: Box::new(Expr::value(number("1"))),
                 op: BinaryOperator::Eq,
-                right: Box::new(Expr::Value((number("1")).with_empty_span())),
+                right: Box::new(Expr::value(number("1"))),
             }),
             op: BinaryOperator::And,
             right: Box::new(Expr::Between {
                 expr: Box::new(Expr::BinaryOp {
-                    left: Box::new(Expr::Value((number("1")).with_empty_span())),
+                    left: Box::new(Expr::value(number("1"))),
                     op: BinaryOperator::Plus,
                     right: Box::new(Expr::Identifier(Ident::new("x"))),
                 }),
-                low: Box::new(Expr::Value((number("1")).with_empty_span())),
-                high: Box::new(Expr::Value((number("2")).with_empty_span())),
+                low: Box::new(Expr::value(number("1"))),
+                high: Box::new(Expr::value(number("2"))),
                 negated: false,
             }),
         },
@@ -2406,15 +2406,15 @@ fn parse_tuples() {
     assert_eq!(
         vec![
             SelectItem::UnnamedExpr(Expr::Tuple(vec![
-                Expr::Value((number("1")).with_empty_span()),
-                Expr::Value((number("2")).with_empty_span()),
+                Expr::value(number("1")),
+                Expr::value(number("2")),
             ])),
             SelectItem::UnnamedExpr(Expr::Nested(Box::new(Expr::Value(
                 (number("1")).with_empty_span()
             )))),
             SelectItem::UnnamedExpr(Expr::Tuple(vec![
                 Expr::Value((Value::SingleQuotedString("foo".into())).with_empty_span()),
-                Expr::Value((number("3")).with_empty_span()),
+                Expr::value(number("3")),
                 Expr::Identifier(Ident::new("baz")),
             ])),
         ],
@@ -2496,7 +2496,7 @@ fn parse_select_order_by_limit() {
         select.order_by.expect("ORDER BY expected").exprs
     );
     assert_eq!(
-        Some(Expr::Value((number("2")).with_empty_span())),
+        Some(Expr::value(number("2"))),
         select.limit
     );
 }
@@ -2524,7 +2524,7 @@ fn parse_select_order_by_nulls_order() {
         select.order_by.expect("ORDER BY expeccted").exprs
     );
     assert_eq!(
-        Some(Expr::Value((number("2")).with_empty_span())),
+        Some(Expr::value(number("2"))),
         select.limit
     );
 }
@@ -2670,7 +2670,7 @@ fn parse_select_having() {
                 within_group: vec![]
             })),
             op: BinaryOperator::Gt,
-            right: Box::new(Expr::Value((number("1")).with_empty_span())),
+            right: Box::new(Expr::value(number("1"))),
         }),
         select.having
     );
@@ -2711,7 +2711,7 @@ fn parse_select_qualify() {
                 within_group: vec![]
             })),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value((number("1")).with_empty_span())),
+            right: Box::new(Expr::value(number("1"))),
         }),
         select.qualify
     );
@@ -2722,7 +2722,7 @@ fn parse_select_qualify() {
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("row_num"))),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value((number("1")).with_empty_span())),
+            right: Box::new(Expr::value(number("1"))),
         }),
         select.qualify
     );
@@ -3363,13 +3363,13 @@ fn gen_number_case(value: &str) -> (Vec<String>, Vec<SelectItem>) {
         format!("{} AS col_alias", value),
     ];
     let expected = vec![
-        SelectItem::UnnamedExpr(Expr::Value((number(value)).with_empty_span())),
+        SelectItem::UnnamedExpr(Expr::value(number(value))),
         SelectItem::ExprWithAlias {
-            expr: Expr::Value((number(value)).with_empty_span()),
+            expr: Expr::value(number(value)),
             alias: Ident::new("col_alias"),
         },
         SelectItem::ExprWithAlias {
-            expr: Expr::Value((number(value)).with_empty_span()),
+            expr: Expr::value(number(value)),
             alias: Ident::new("col_alias"),
         },
     ];
@@ -3390,19 +3390,19 @@ fn gen_sign_number_case(value: &str, op: UnaryOperator) -> (Vec<String>, Vec<Sel
     let expected = vec![
         SelectItem::UnnamedExpr(Expr::UnaryOp {
             op,
-            expr: Box::new(Expr::Value((number(value)).with_empty_span())),
+            expr: Box::new(Expr::value(number(value))),
         }),
         SelectItem::ExprWithAlias {
             expr: Expr::UnaryOp {
                 op,
-                expr: Box::new(Expr::Value((number(value)).with_empty_span())),
+                expr: Box::new(Expr::value(number(value))),
             },
             alias: Ident::new("col_alias"),
         },
         SelectItem::ExprWithAlias {
             expr: Expr::UnaryOp {
                 op,
-                expr: Box::new(Expr::Value((number(value)).with_empty_span())),
+                expr: Box::new(Expr::value(number(value))),
             },
             alias: Ident::new("col_alias"),
         },
@@ -4242,7 +4242,7 @@ fn parse_create_table_with_options() {
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
-                        value: Expr::Value((number("123")).with_empty_span()),
+                        value: Expr::value(number("123")),
                     },
                 ],
                 with_options
@@ -4620,7 +4620,7 @@ fn parse_alter_view_with_options() {
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
-                        value: Expr::Value((number("123")).with_empty_span()),
+                        value: Expr::value(number("123")),
                     },
                 ],
                 with_options
@@ -5193,7 +5193,7 @@ fn parse_named_argument_function_with_eq_operator() {
             [Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("bar"))),
                 op: BinaryOperator::Eq,
-                right: Box::new(Expr::Value((number("42")).with_empty_span())),
+                right: Box::new(Expr::value(number("42"))),
             }]
         ),
     );
@@ -5539,14 +5539,14 @@ fn parse_literal_integer() {
     let select = verified_only_select(sql);
     assert_eq!(3, select.projection.len());
     assert_eq!(
-        &Expr::Value((number("1")).with_empty_span()),
+        &Expr::value(number("1")),
         expr_from_projection(&select.projection[0]),
     );
     // negative literal is parsed as a - and expr
     assert_eq!(
         &UnaryOp {
             op: UnaryOperator::Minus,
-            expr: Box::new(Expr::Value((number("10")).with_empty_span()))
+            expr: Box::new(Expr::value(number("10")))
         },
         expr_from_projection(&select.projection[1]),
     );
@@ -5554,7 +5554,7 @@ fn parse_literal_integer() {
     assert_eq!(
         &UnaryOp {
             op: UnaryOperator::Plus,
-            expr: Box::new(Expr::Value((number("20")).with_empty_span()))
+            expr: Box::new(Expr::value(number("20")))
         },
         expr_from_projection(&select.projection[2]),
     )
@@ -5568,11 +5568,11 @@ fn parse_literal_decimal() {
     let select = verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
-        &Expr::Value((number("0.300000000000000004")).with_empty_span()),
+        &Expr::value(number("0.300000000000000004")),
         expr_from_projection(&select.projection[0]),
     );
     assert_eq!(
-        &Expr::Value((number("9007199254740993.0")).with_empty_span()),
+        &Expr::value(number("9007199254740993.0")),
         expr_from_projection(&select.projection[1]),
     )
 }
@@ -5738,7 +5738,7 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value((number("5")).with_empty_span())),
+            value: Box::new(Expr::value(number("5"))),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
             last_field: None,
@@ -5751,7 +5751,7 @@ fn parse_interval_all() {
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Interval(Interval {
-            value: Box::new(Expr::Value((number("5")).with_empty_span())),
+            value: Box::new(Expr::value(number("5"))),
             leading_field: Some(DateTimeField::Days),
             leading_precision: None,
             last_field: None,
@@ -5874,9 +5874,9 @@ fn parse_interval_require_qualifier() {
         expr_from_projection(only(&select.projection)),
         &Expr::Interval(Interval {
             value: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value((number("1")).with_empty_span())),
+                left: Box::new(Expr::value(number("1"))),
                 op: BinaryOperator::Plus,
-                right: Box::new(Expr::Value((number("1")).with_empty_span())),
+                right: Box::new(Expr::value(number("1"))),
             }),
             leading_field: Some(DateTimeField::Day),
             leading_precision: None,
@@ -6168,7 +6168,7 @@ fn parse_interval_and_or_xor() {
 
 #[test]
 fn parse_at_timezone() {
-    let zero = Expr::Value(number("0").with_empty_span());
+    let zero = Expr::value(number("0"));
     let sql = "SELECT FROM_UNIXTIME(0) AT TIME ZONE 'UTC-06:00' FROM t";
     let select = verified_only_select(sql);
     assert_eq!(
@@ -6555,9 +6555,9 @@ fn parse_unnest_in_from_clause() {
                 array_exprs: vec![call(
                     "make_array",
                     [
-                        Expr::Value((number("1")).with_empty_span()),
-                        Expr::Value((number("2")).with_empty_span()),
-                        Expr::Value((number("3")).with_empty_span()),
+                        Expr::value(number("1")),
+                        Expr::value(number("2")),
+                        Expr::value(number("3")),
                     ],
                 )],
                 with_offset: false,
@@ -6581,16 +6581,16 @@ fn parse_unnest_in_from_clause() {
                     call(
                         "make_array",
                         [
-                            Expr::Value((number("1")).with_empty_span()),
-                            Expr::Value((number("2")).with_empty_span()),
-                            Expr::Value((number("3")).with_empty_span()),
+                            Expr::value(number("1")),
+                            Expr::value(number("2")),
+                            Expr::value(number("3")),
                         ],
                     ),
                     call(
                         "make_array",
                         [
-                            Expr::Value((number("5")).with_empty_span()),
-                            Expr::Value((number("6")).with_empty_span()),
+                            Expr::value(number("5")),
+                            Expr::value(number("6")),
                         ],
                     ),
                 ],
@@ -6640,12 +6640,12 @@ fn parse_searched_case_expr() {
                 BinaryOp {
                     left: Box::new(Identifier(Ident::new("bar"))),
                     op: Eq,
-                    right: Box::new(Expr::Value((number("0")).with_empty_span())),
+                    right: Box::new(Expr::value(number("0"))),
                 },
                 BinaryOp {
                     left: Box::new(Identifier(Ident::new("bar"))),
                     op: GtEq,
-                    right: Box::new(Expr::Value((number("0")).with_empty_span())),
+                    right: Box::new(Expr::value(number("0"))),
                 },
             ],
             results: vec![
@@ -6670,7 +6670,7 @@ fn parse_simple_case_expr() {
     assert_eq!(
         &Case {
             operand: Some(Box::new(Identifier(Ident::new("foo")))),
-            conditions: vec![Expr::Value((number("1")).with_empty_span())],
+            conditions: vec![Expr::value(number("1"))],
             results: vec![Expr::Value(
                 (Value::SingleQuotedString("Y".to_string())).with_empty_span()
             )],
@@ -7429,11 +7429,11 @@ fn parse_overlay() {
                 (Value::SingleQuotedString("abcdef".to_string())).with_empty_span()
             )),
             overlay_what: Box::new(Expr::Identifier(Ident::new("name"))),
-            overlay_from: Box::new(Expr::Value((number("3")).with_empty_span())),
+            overlay_from: Box::new(Expr::value(number("3"))),
             overlay_for: Some(Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("id"))),
                 op: BinaryOperator::Plus,
-                right: Box::new(Expr::Value((number("1")).with_empty_span())),
+                right: Box::new(Expr::value(number("1"))),
             })),
         },
         expr_from_projection(only(&select.projection))
@@ -7667,7 +7667,7 @@ fn parse_create_view_with_options() {
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
-                        value: Expr::Value((number("123")).with_empty_span()),
+                        value: Expr::value(number("123")),
                     },
                 ]),
                 options
@@ -8010,7 +8010,7 @@ fn parse_offset() {
         all_dialects_where(|d| !d.is_column_alias(&Keyword::OFFSET, &mut Parser::new(d)));
 
     let expect = Some(Offset {
-        value: Expr::Value(number("2").with_empty_span()),
+        value: Expr::value(number("2")),
         rows: OffsetRows::Rows,
     });
     let ast = dialects.verified_query("SELECT foo FROM bar OFFSET 2 ROWS");
@@ -8038,7 +8038,7 @@ fn parse_offset() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value((number("0")).with_empty_span()),
+            value: Expr::value(number("0")),
             rows: OffsetRows::Rows,
         })
     );
@@ -8046,7 +8046,7 @@ fn parse_offset() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value((number("1")).with_empty_span()),
+            value: Expr::value(number("1")),
             rows: OffsetRows::Row,
         })
     );
@@ -8054,7 +8054,7 @@ fn parse_offset() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value((number("1")).with_empty_span()),
+            value: Expr::value(number("1")),
             rows: OffsetRows::None,
         })
     );
@@ -8065,7 +8065,7 @@ fn parse_fetch() {
     let fetch_first_two_rows_only = Some(Fetch {
         with_ties: false,
         percent: false,
-        quantity: Some(Expr::Value(number("2").with_empty_span())),
+        quantity: Some(Expr::value(number("2"))),
     });
     let ast = verified_query("SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
@@ -8092,7 +8092,7 @@ fn parse_fetch() {
         Some(Fetch {
             with_ties: true,
             percent: false,
-            quantity: Some(Expr::Value((number("2")).with_empty_span())),
+            quantity: Some(Expr::value(number("2"))),
         })
     );
     let ast = verified_query("SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY");
@@ -8101,7 +8101,7 @@ fn parse_fetch() {
         Some(Fetch {
             with_ties: false,
             percent: true,
-            quantity: Some(Expr::Value((number("50")).with_empty_span())),
+            quantity: Some(Expr::value(number("50"))),
         })
     );
     let ast = verified_query(
@@ -8110,7 +8110,7 @@ fn parse_fetch() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value((number("2")).with_empty_span()),
+            value: Expr::value(number("2")),
             rows: OffsetRows::Rows,
         })
     );
@@ -8132,7 +8132,7 @@ fn parse_fetch() {
     assert_eq!(
         ast.offset,
         Some(Offset {
-            value: Expr::Value((number("2")).with_empty_span()),
+            value: Expr::value(number("2")),
             rows: OffsetRows::Rows,
         })
     );
@@ -8143,7 +8143,7 @@ fn parse_fetch() {
                 assert_eq!(
                     subquery.offset,
                     Some(Offset {
-                        value: Expr::Value((number("2")).with_empty_span()),
+                        value: Expr::value(number("2")),
                         rows: OffsetRows::Rows,
                     })
                 );
@@ -8451,9 +8451,9 @@ fn parse_set_variable() {
             assert_eq!(
                 value,
                 vec![
-                    Expr::Value((number("1")).with_empty_span()),
-                    Expr::Value((number("2")).with_empty_span()),
-                    Expr::Value((number("3")).with_empty_span()),
+                    Expr::value(number("1")),
+                    Expr::value(number("2")),
+                    Expr::value(number("3")),
                 ]
             );
         }
@@ -8789,7 +8789,7 @@ fn test_create_index_with_with_clause() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("fillfactor"))),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value((number("70")).with_empty_span())),
+            right: Box::new(Expr::value(number("70"))),
         },
         Expr::Identifier(Ident::new("single_param")),
     ];
@@ -9607,14 +9607,14 @@ fn verified_expr(query: &str) -> Expr {
 fn parse_offset_and_limit() {
     let sql = "SELECT foo FROM bar LIMIT 1 OFFSET 2";
     let expect = Some(Offset {
-        value: Expr::Value(number("2").with_empty_span()),
+        value: Expr::value(number("2")),
         rows: OffsetRows::None,
     });
     let ast = verified_query(sql);
     assert_eq!(ast.offset, expect);
     assert_eq!(
         ast.limit,
-        Some(Expr::Value((number("1")).with_empty_span()))
+        Some(Expr::value(number("1")))
     );
 
     // different order is OK
@@ -9635,18 +9635,18 @@ fn parse_offset_and_limit() {
     assert_eq!(
         ast.limit,
         Some(Expr::BinaryOp {
-            left: Box::new(Expr::Value((number("1")).with_empty_span())),
+            left: Box::new(Expr::value(number("1"))),
             op: BinaryOperator::Plus,
-            right: Box::new(Expr::Value((number("2")).with_empty_span())),
+            right: Box::new(Expr::value(number("2"))),
         }),
     );
     assert_eq!(
         ast.offset,
         Some(Offset {
             value: Expr::BinaryOp {
-                left: Box::new(Expr::Value((number("3")).with_empty_span())),
+                left: Box::new(Expr::value(number("3"))),
                 op: BinaryOperator::Multiply,
-                right: Box::new(Expr::Value((number("4")).with_empty_span())),
+                right: Box::new(Expr::value(number("4"))),
             },
             rows: OffsetRows::None,
         }),
@@ -9732,7 +9732,7 @@ fn parse_position() {
             [
                 Expr::Value((Value::SingleQuotedString("an".to_owned())).with_empty_span()),
                 Expr::Value((Value::SingleQuotedString("banana".to_owned())).with_empty_span()),
-                Expr::Value((number("1")).with_empty_span()),
+                Expr::value(number("1")),
             ]
         ),
         verified_expr("position('an', 'banana', 1)")
@@ -9989,7 +9989,7 @@ fn parse_cache_table() {
                 },
                 SqlOption::KeyValue {
                     key: Ident::with_quote('\'', "K2"),
-                    value: Expr::Value((number("0.88")).with_empty_span()),
+                    value: Expr::value(number("0.88")),
                 },
             ],
             query: None,
@@ -10014,7 +10014,7 @@ fn parse_cache_table() {
                 },
                 SqlOption::KeyValue {
                     key: Ident::with_quote('\'', "K2"),
-                    value: Expr::Value((number("0.88")).with_empty_span()),
+                    value: Expr::value(number("0.88")),
                 },
             ],
             query: Some(query.clone().into()),
@@ -10039,7 +10039,7 @@ fn parse_cache_table() {
                 },
                 SqlOption::KeyValue {
                     key: Ident::with_quote('\'', "K2"),
-                    value: Expr::Value((number("0.88")).with_empty_span()),
+                    value: Expr::value(number("0.88")),
                 },
             ],
             query: Some(query.clone().into()),
@@ -10365,7 +10365,7 @@ fn parse_pivot_table() {
             value_column: vec![Ident::new("a"), Ident::new("MONTH")],
             value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
-                    expr: Expr::Value((number("1")).with_empty_span()),
+                    expr: Expr::value(number("1")),
                     alias: Some(Ident::new("x"))
                 },
                 ExprWithAlias {
@@ -10921,7 +10921,7 @@ fn parse_execute_immediate() {
         )],
         immediate: true,
         using: vec![ExprWithAlias {
-            expr: Expr::Value((number("1")).with_empty_span()),
+            expr: Expr::value(number("1")),
             alias: Some(Ident::new("b")),
         }],
         into: vec![Ident::new("a")],
@@ -11181,7 +11181,7 @@ fn parse_map_access_expr() {
             AccessExpr::Subscript(Subscript::Index {
                 index: Expr::UnaryOp {
                     op: UnaryOperator::Minus,
-                    expr: Expr::Value((number("1")).with_empty_span()).into(),
+                    expr: Expr::value(number("1")).into(),
                 },
             }),
             AccessExpr::Subscript(Subscript::Index {
@@ -11317,7 +11317,7 @@ fn parse_connect_by() {
             selection: Some(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("employee_id"))),
                 op: BinaryOperator::NotEq,
-                right: Box::new(Expr::Value((number("42")).with_empty_span())),
+                right: Box::new(Expr::value(number("42"))),
             }),
             group_by: GroupByExpr::Expressions(vec![], vec![]),
             cluster_by: vec![],
@@ -11796,13 +11796,13 @@ fn test_select_wildcard_with_replace() {
                     expr: Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("quantity"))),
                         op: BinaryOperator::Divide,
-                        right: Box::new(Expr::Value((number("2")).with_empty_span())),
+                        right: Box::new(Expr::value(number("2"))),
                     },
                     column_name: Ident::new("quantity"),
                     as_keyword: true,
                 }),
                 Box::new(ReplaceSelectElement {
-                    expr: Expr::Value((number("3")).with_empty_span()),
+                    expr: Expr::value(number("3")),
                     column_name: Ident::new("order_id"),
                     as_keyword: true,
                 }),
@@ -11961,7 +11961,7 @@ fn test_map_syntax() {
     );
 
     fn number_expr(s: &str) -> Expr {
-        Expr::Value(number(s).with_empty_span())
+        Expr::value(number(s))
     }
 
     check(
@@ -11989,14 +11989,14 @@ fn test_map_syntax() {
                         elem: vec![number_expr("1"), number_expr("2"), number_expr("3")],
                         named: false,
                     })),
-                    value: Box::new(Expr::Value((number("10.0")).with_empty_span())),
+                    value: Box::new(Expr::value(number("10.0"))),
                 },
                 MapEntry {
                     key: Box::new(Expr::Array(Array {
                         elem: vec![number_expr("4"), number_expr("5"), number_expr("6")],
                         named: false,
                     })),
-                    value: Box::new(Expr::Value((number("20.0")).with_empty_span())),
+                    value: Box::new(Expr::value(number("20.0"))),
                 },
             ],
         }),
@@ -13991,13 +13991,13 @@ fn test_lambdas() {
                             }
                         ],
                         results: vec![
-                            Expr::Value((number("0")).with_empty_span()),
+                            Expr::value(number("0")),
                             Expr::UnaryOp {
                                 op: UnaryOperator::Minus,
-                                expr: Box::new(Expr::Value((number("1")).with_empty_span()))
+                                expr: Box::new(Expr::value(number("1")))
                             }
                         ],
-                        else_result: Some(Box::new(Expr::Value((number("1")).with_empty_span())))
+                        else_result: Some(Box::new(Expr::value(number("1"))))
                     })
                 })
             ]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -900,10 +900,7 @@ fn parse_simple_select() {
     assert!(select.distinct.is_none());
     assert_eq!(3, select.projection.len());
     let select = verified_query(sql);
-    assert_eq!(
-        Some(Expr::value(number("5"))),
-        select.limit
-    );
+    assert_eq!(Some(Expr::value(number("5"))), select.limit);
 }
 
 #[test]
@@ -915,16 +912,10 @@ fn parse_limit() {
 fn parse_limit_is_not_an_alias() {
     // In dialects supporting LIMIT it shouldn't be parsed as a table alias
     let ast = verified_query("SELECT id FROM customer LIMIT 1");
-    assert_eq!(
-        Some(Expr::value(number("1"))),
-        ast.limit
-    );
+    assert_eq!(Some(Expr::value(number("1"))), ast.limit);
 
     let ast = verified_query("SELECT 1 LIMIT 5");
-    assert_eq!(
-        Some(Expr::value(number("5"))),
-        ast.limit
-    );
+    assert_eq!(Some(Expr::value(number("5"))), ast.limit);
 }
 
 #[test]
@@ -1142,10 +1133,7 @@ fn parse_column_aliases() {
     } = only(&select.projection)
     {
         assert_eq!(&BinaryOperator::Plus, op);
-        assert_eq!(
-            &Expr::value(number("1")),
-            right.as_ref()
-        );
+        assert_eq!(&Expr::value(number("1")), right.as_ref());
         assert_eq!(&Ident::new("newname"), alias);
     } else {
         panic!("Expected: ExprWithAlias")
@@ -2495,10 +2483,7 @@ fn parse_select_order_by_limit() {
         ],
         select.order_by.expect("ORDER BY expected").exprs
     );
-    assert_eq!(
-        Some(Expr::value(number("2"))),
-        select.limit
-    );
+    assert_eq!(Some(Expr::value(number("2"))), select.limit);
 }
 
 #[test]
@@ -2523,10 +2508,7 @@ fn parse_select_order_by_nulls_order() {
         ],
         select.order_by.expect("ORDER BY expeccted").exprs
     );
-    assert_eq!(
-        Some(Expr::value(number("2"))),
-        select.limit
-    );
+    assert_eq!(Some(Expr::value(number("2"))), select.limit);
 }
 
 #[test]
@@ -6588,10 +6570,7 @@ fn parse_unnest_in_from_clause() {
                     ),
                     call(
                         "make_array",
-                        [
-                            Expr::value(number("5")),
-                            Expr::value(number("6")),
-                        ],
+                        [Expr::value(number("5")), Expr::value(number("6"))],
                     ),
                 ],
                 with_offset: false,
@@ -9612,10 +9591,7 @@ fn parse_offset_and_limit() {
     });
     let ast = verified_query(sql);
     assert_eq!(ast.offset, expect);
-    assert_eq!(
-        ast.limit,
-        Some(Expr::value(number("1")))
-    );
+    assert_eq!(ast.limit, Some(Expr::value(number("1"))));
 
     // different order is OK
     one_statement_parses_to("SELECT foo FROM bar OFFSET 2 LIMIT 1", sql);

--- a/tests/sqlparser_custom_dialect.rs
+++ b/tests/sqlparser_custom_dialect.rs
@@ -41,7 +41,7 @@ fn custom_prefix_parser() -> Result<(), ParserError> {
 
         fn parse_prefix(&self, parser: &mut Parser) -> Option<Result<Expr, ParserError>> {
             if parser.consume_token(&Token::Number("1".to_string(), false)) {
-                Some(Ok(Expr::Value(Value::Null)))
+                Some(Ok(Expr::Value(Value::Null.with_empty_span())))
             } else {
                 None
             }

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -47,7 +47,7 @@ fn test_databricks_identifiers() {
         databricks()
             .verified_only_select(r#"SELECT "Ä""#)
             .projection[0],
-        SelectItem::UnnamedExpr(Expr::Value(Value::DoubleQuotedString("Ä".to_owned())))
+        SelectItem::UnnamedExpr(Expr::Value((Value::DoubleQuotedString("Ä".to_owned())).with_empty_span()))
     );
 }
 
@@ -62,9 +62,9 @@ fn test_databricks_exists() {
                 call(
                     "array",
                     [
-                        Expr::Value(number("1")),
-                        Expr::Value(number("2")),
-                        Expr::Value(number("3"))
+                        Expr::Value((number("1")).with_empty_span()),
+                        Expr::Value((number("2")).with_empty_span()),
+                        Expr::Value((number("3")).with_empty_span())
                     ]
                 ),
                 Expr::Lambda(LambdaFunction {
@@ -89,12 +89,12 @@ fn test_values_clause() {
         explicit_row: false,
         rows: vec![
             vec![
-                Expr::Value(Value::DoubleQuotedString("one".to_owned())),
-                Expr::Value(number("1")),
+                Expr::Value((Value::DoubleQuotedString("one".to_owned())).with_empty_span()),
+                Expr::Value((number("1")).with_empty_span()),
             ],
             vec![
-                Expr::Value(Value::SingleQuotedString("two".to_owned())),
-                Expr::Value(number("2")),
+                Expr::Value((Value::SingleQuotedString("two".to_owned())).with_empty_span()),
+                Expr::Value((number("2")).with_empty_span()),
             ],
         ],
     };
@@ -221,8 +221,8 @@ fn parse_databricks_struct_function() {
             .projection[0],
         SelectItem::UnnamedExpr(Expr::Struct {
             values: vec![
-                Expr::Value(number("1")),
-                Expr::Value(Value::SingleQuotedString("foo".to_string()))
+                Expr::Value((number("1")).with_empty_span()),
+                Expr::Value((Value::SingleQuotedString("foo".to_string())).with_empty_span())
             ],
             fields: vec![]
         })
@@ -234,14 +234,14 @@ fn parse_databricks_struct_function() {
         SelectItem::UnnamedExpr(Expr::Struct {
             values: vec![
                 Expr::Named {
-                    expr: Expr::Value(number("1")).into(),
+                    expr: Expr::Value((number("1")).with_empty_span()).into(),
                     name: Ident::new("one")
                 },
                 Expr::Named {
-                    expr: Expr::Value(Value::SingleQuotedString("foo".to_string())).into(),
+                    expr: Expr::Value((Value::SingleQuotedString("foo".to_string())).with_empty_span()).into(),
                     name: Ident::new("foo")
                 },
-                Expr::Value(Value::Boolean(false))
+                Expr::Value((Value::Boolean(false)).with_empty_span())
             ],
             fields: vec![]
         })

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -64,9 +64,9 @@ fn test_databricks_exists() {
                 call(
                     "array",
                     [
-                        Expr::Value((number("1")).with_empty_span()),
-                        Expr::Value((number("2")).with_empty_span()),
-                        Expr::Value((number("3")).with_empty_span())
+                        Expr::value(number("1")),
+                        Expr::value(number("2")),
+                        Expr::value(number("3"))
                     ]
                 ),
                 Expr::Lambda(LambdaFunction {
@@ -92,11 +92,11 @@ fn test_values_clause() {
         rows: vec![
             vec![
                 Expr::Value((Value::DoubleQuotedString("one".to_owned())).with_empty_span()),
-                Expr::Value((number("1")).with_empty_span()),
+                Expr::value(number("1")),
             ],
             vec![
                 Expr::Value((Value::SingleQuotedString("two".to_owned())).with_empty_span()),
-                Expr::Value((number("2")).with_empty_span()),
+                Expr::value(number("2")),
             ],
         ],
     };
@@ -223,7 +223,7 @@ fn parse_databricks_struct_function() {
             .projection[0],
         SelectItem::UnnamedExpr(Expr::Struct {
             values: vec![
-                Expr::Value((number("1")).with_empty_span()),
+                Expr::value(number("1")),
                 Expr::Value((Value::SingleQuotedString("foo".to_string())).with_empty_span())
             ],
             fields: vec![]
@@ -236,7 +236,7 @@ fn parse_databricks_struct_function() {
         SelectItem::UnnamedExpr(Expr::Struct {
             values: vec![
                 Expr::Named {
-                    expr: Expr::Value((number("1")).with_empty_span()).into(),
+                    expr: Expr::value(number("1")).into(),
                     name: Ident::new("one")
                 },
                 Expr::Named {

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -47,7 +47,9 @@ fn test_databricks_identifiers() {
         databricks()
             .verified_only_select(r#"SELECT "Ä""#)
             .projection[0],
-        SelectItem::UnnamedExpr(Expr::Value((Value::DoubleQuotedString("Ä".to_owned())).with_empty_span()))
+        SelectItem::UnnamedExpr(Expr::Value(
+            (Value::DoubleQuotedString("Ä".to_owned())).with_empty_span()
+        ))
     );
 }
 
@@ -238,7 +240,10 @@ fn parse_databricks_struct_function() {
                     name: Ident::new("one")
                 },
                 Expr::Named {
-                    expr: Expr::Value((Value::SingleQuotedString("foo".to_string())).with_empty_span()).into(),
+                    expr: Expr::Value(
+                        (Value::SingleQuotedString("foo".to_string())).with_empty_span()
+                    )
+                    .into(),
                     name: Ident::new("foo")
                 },
                 Expr::Value((Value::Boolean(false)).with_empty_span())

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -210,7 +210,7 @@ fn test_create_macro_default_args() {
             MacroArg::new("a"),
             MacroArg {
                 name: Ident::new("b"),
-                default_expr: Some(Expr::Value(number("5"))),
+                default_expr: Some(Expr::Value((number("5")).with_empty_span())),
             },
         ]),
         definition: MacroDefinition::Expr(Expr::BinaryOp {
@@ -363,15 +363,15 @@ fn test_duckdb_struct_literal() {
         &Expr::Dictionary(vec![
             DictionaryField {
                 key: Ident::with_quote('\'', "a"),
-                value: Box::new(Expr::Value(number("1"))),
+                value: Box::new(Expr::Value((number("1")).with_empty_span())),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "b"),
-                value: Box::new(Expr::Value(number("2"))),
+                value: Box::new(Expr::Value((number("2")).with_empty_span())),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "c"),
-                value: Box::new(Expr::Value(number("3"))),
+                value: Box::new(Expr::Value((number("3")).with_empty_span())),
             },
         ],),
         expr_from_projection(&select.projection[0])
@@ -381,7 +381,7 @@ fn test_duckdb_struct_literal() {
         &Expr::Array(Array {
             elem: vec![Expr::Dictionary(vec![DictionaryField {
                 key: Ident::with_quote('\'', "a"),
-                value: Box::new(Expr::Value(Value::SingleQuotedString("abc".to_string()))),
+                value: Box::new(Expr::Value((Value::SingleQuotedString("abc".to_string())).with_empty_span())),
             },],)],
             named: false
         }),
@@ -391,7 +391,7 @@ fn test_duckdb_struct_literal() {
         &Expr::Dictionary(vec![
             DictionaryField {
                 key: Ident::with_quote('\'', "a"),
-                value: Box::new(Expr::Value(number("1"))),
+                value: Box::new(Expr::Value((number("1")).with_empty_span())),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "b"),
@@ -410,11 +410,11 @@ fn test_duckdb_struct_literal() {
         &Expr::Dictionary(vec![
             DictionaryField {
                 key: Ident::with_quote('\'', "a"),
-                value: Expr::Value(number("1")).into(),
+                value: Expr::Value((number("1")).with_empty_span()).into(),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "b"),
-                value: Expr::Value(Value::SingleQuotedString("abc".to_string())).into(),
+                value: Expr::Value((Value::SingleQuotedString("abc".to_string())).with_empty_span()).into(),
             },
         ],),
         expr_from_projection(&select.projection[3])
@@ -431,7 +431,7 @@ fn test_duckdb_struct_literal() {
             key: Ident::with_quote('\'', "a"),
             value: Expr::Dictionary(vec![DictionaryField {
                 key: Ident::with_quote('\'', "aa"),
-                value: Expr::Value(number("1")).into(),
+                value: Expr::Value((number("1")).with_empty_span()).into(),
             }],)
             .into(),
         }],),
@@ -594,16 +594,16 @@ fn test_duckdb_named_argument_function_with_assignment_operator() {
                 args: vec![
                     FunctionArg::Named {
                         name: Ident::new("a"),
-                        arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                             "1".to_owned()
-                        ))),
+                        )).with_empty_span())),
                         operator: FunctionArgOperator::Assignment
                     },
                     FunctionArg::Named {
                         name: Ident::new("b"),
-                        arg: FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(
+                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
                             "2".to_owned()
-                        ))),
+                        )).with_empty_span())),
                         operator: FunctionArgOperator::Assignment
                     },
                 ],
@@ -632,14 +632,14 @@ fn test_array_index() {
         &Expr::CompoundFieldAccess {
             root: Box::new(Expr::Array(Array {
                 elem: vec![
-                    Expr::Value(Value::SingleQuotedString("a".to_owned())),
-                    Expr::Value(Value::SingleQuotedString("b".to_owned())),
-                    Expr::Value(Value::SingleQuotedString("c".to_owned()))
+                    Expr::Value((Value::SingleQuotedString("a".to_owned())).with_empty_span()),
+                    Expr::Value((Value::SingleQuotedString("b".to_owned())).with_empty_span()),
+                    Expr::Value((Value::SingleQuotedString("c".to_owned())).with_empty_span())
                 ],
                 named: false
             })),
             access_chain: vec![AccessExpr::Subscript(Subscript::Index {
-                index: Expr::Value(number("3"))
+                index: Expr::Value((number("3")).with_empty_span())
             })]
         },
         expr

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -381,7 +381,9 @@ fn test_duckdb_struct_literal() {
         &Expr::Array(Array {
             elem: vec![Expr::Dictionary(vec![DictionaryField {
                 key: Ident::with_quote('\'', "a"),
-                value: Box::new(Expr::Value((Value::SingleQuotedString("abc".to_string())).with_empty_span())),
+                value: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("abc".to_string())).with_empty_span()
+                )),
             },],)],
             named: false
         }),
@@ -414,7 +416,10 @@ fn test_duckdb_struct_literal() {
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "b"),
-                value: Expr::Value((Value::SingleQuotedString("abc".to_string())).with_empty_span()).into(),
+                value: Expr::Value(
+                    (Value::SingleQuotedString("abc".to_string())).with_empty_span()
+                )
+                .into(),
             },
         ],),
         expr_from_projection(&select.projection[3])
@@ -594,16 +599,16 @@ fn test_duckdb_named_argument_function_with_assignment_operator() {
                 args: vec![
                     FunctionArg::Named {
                         name: Ident::new("a"),
-                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                            "1".to_owned()
-                        )).with_empty_span())),
+                        arg: FunctionArgExpr::Expr(Expr::Value(
+                            (Value::SingleQuotedString("1".to_owned())).with_empty_span()
+                        )),
                         operator: FunctionArgOperator::Assignment
                     },
                     FunctionArg::Named {
                         name: Ident::new("b"),
-                        arg: FunctionArgExpr::Expr(Expr::Value((Value::SingleQuotedString(
-                            "2".to_owned()
-                        )).with_empty_span())),
+                        arg: FunctionArgExpr::Expr(Expr::Value(
+                            (Value::SingleQuotedString("2".to_owned())).with_empty_span()
+                        )),
                         operator: FunctionArgOperator::Assignment
                     },
                 ],

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -210,7 +210,7 @@ fn test_create_macro_default_args() {
             MacroArg::new("a"),
             MacroArg {
                 name: Ident::new("b"),
-                default_expr: Some(Expr::Value((number("5")).with_empty_span())),
+                default_expr: Some(Expr::value(number("5"))),
             },
         ]),
         definition: MacroDefinition::Expr(Expr::BinaryOp {
@@ -363,15 +363,15 @@ fn test_duckdb_struct_literal() {
         &Expr::Dictionary(vec![
             DictionaryField {
                 key: Ident::with_quote('\'', "a"),
-                value: Box::new(Expr::Value((number("1")).with_empty_span())),
+                value: Box::new(Expr::value(number("1"))),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "b"),
-                value: Box::new(Expr::Value((number("2")).with_empty_span())),
+                value: Box::new(Expr::value(number("2"))),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "c"),
-                value: Box::new(Expr::Value((number("3")).with_empty_span())),
+                value: Box::new(Expr::value(number("3"))),
             },
         ],),
         expr_from_projection(&select.projection[0])
@@ -393,7 +393,7 @@ fn test_duckdb_struct_literal() {
         &Expr::Dictionary(vec![
             DictionaryField {
                 key: Ident::with_quote('\'', "a"),
-                value: Box::new(Expr::Value((number("1")).with_empty_span())),
+                value: Box::new(Expr::value(number("1"))),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "b"),
@@ -412,7 +412,7 @@ fn test_duckdb_struct_literal() {
         &Expr::Dictionary(vec![
             DictionaryField {
                 key: Ident::with_quote('\'', "a"),
-                value: Expr::Value((number("1")).with_empty_span()).into(),
+                value: Expr::value(number("1")).into(),
             },
             DictionaryField {
                 key: Ident::with_quote('\'', "b"),
@@ -436,7 +436,7 @@ fn test_duckdb_struct_literal() {
             key: Ident::with_quote('\'', "a"),
             value: Expr::Dictionary(vec![DictionaryField {
                 key: Ident::with_quote('\'', "aa"),
-                value: Expr::Value((number("1")).with_empty_span()).into(),
+                value: Expr::value(number("1")).into(),
             }],)
             .into(),
         }],),
@@ -644,7 +644,7 @@ fn test_array_index() {
                 named: false
             })),
             access_chain: vec![AccessExpr::Subscript(Subscript::Index {
-                index: Expr::Value((number("3")).with_empty_span())
+                index: Expr::value(number("3"))
             })]
         },
         expr

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -404,9 +404,10 @@ fn parse_create_function() {
             assert_eq!(name.to_string(), "mydb.myfunc");
             assert_eq!(
                 function_body,
-                Some(CreateFunctionBody::AsBeforeOptions(Expr::Value((
-                    Value::SingleQuotedString("org.random.class.Name".to_string())
-                ).with_empty_span())))
+                Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+                    (Value::SingleQuotedString("org.random.class.Name".to_string()))
+                        .with_empty_span()
+                )))
             );
             assert_eq!(
                 using,

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -404,9 +404,9 @@ fn parse_create_function() {
             assert_eq!(name.to_string(), "mydb.myfunc");
             assert_eq!(
                 function_body,
-                Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+                Some(CreateFunctionBody::AsBeforeOptions(Expr::Value((
                     Value::SingleQuotedString("org.random.class.Name".to_string())
-                )))
+                ).with_empty_span())))
             );
             assert_eq!(
                 using,

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -746,7 +746,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[0],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
+                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
                     arg: FunctionArgExpr::Expr(Expr::Function(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -762,7 +762,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[2],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
+                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
                     arg: FunctionArgExpr::Expr(Expr::Subquery(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -793,7 +793,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[0],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
+                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
                     arg: FunctionArgExpr::Expr(Expr::CompoundIdentifier(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -801,7 +801,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[1],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
+                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
                     arg: FunctionArgExpr::Expr(Expr::CompoundIdentifier(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -809,7 +809,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[2],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
+                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
                     arg: FunctionArgExpr::Expr(Expr::CompoundIdentifier(_)),
                     operator: FunctionArgOperator::Colon
                 }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -67,9 +67,9 @@ fn parse_table_time_travel() {
                 alias: None,
                 args: None,
                 with_hints: vec![],
-                version: Some(TableVersion::ForSystemTimeAsOf(Expr::Value((
-                    Value::SingleQuotedString(version)
-                ).with_empty_span()))),
+                version: Some(TableVersion::ForSystemTimeAsOf(Expr::Value(
+                    (Value::SingleQuotedString(version)).with_empty_span()
+                ))),
                 partitions: vec![],
                 with_ordinality: false,
                 json_path: None,
@@ -121,7 +121,9 @@ fn parse_create_procedure() {
                     distinct: None,
                     top: None,
                     top_before_distinct: false,
-                    projection: vec![SelectItem::UnnamedExpr(Expr::Value((number("1")).with_empty_span()))],
+                    projection: vec![SelectItem::UnnamedExpr(Expr::Value(
+                        (number("1")).with_empty_span()
+                    ))],
                     into: None,
                     from: vec![],
                     lateral_views: vec![],
@@ -473,7 +475,9 @@ fn parse_mssql_top_paren() {
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
     assert_eq!(
-        Some(TopQuantity::Expr(Expr::Value((number("5")).with_empty_span()))),
+        Some(TopQuantity::Expr(Expr::Value(
+            (number("5")).with_empty_span()
+        ))),
         top.quantity
     );
     assert!(!top.percent);
@@ -485,7 +489,9 @@ fn parse_mssql_top_percent() {
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
     assert_eq!(
-        Some(TopQuantity::Expr(Expr::Value((number("5")).with_empty_span()))),
+        Some(TopQuantity::Expr(Expr::Value(
+            (number("5")).with_empty_span()
+        ))),
         top.quantity
     );
     assert!(top.percent);
@@ -497,7 +503,9 @@ fn parse_mssql_top_with_ties() {
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
     assert_eq!(
-        Some(TopQuantity::Expr(Expr::Value((number("5")).with_empty_span()))),
+        Some(TopQuantity::Expr(Expr::Value(
+            (number("5")).with_empty_span()
+        ))),
         top.quantity
     );
     assert!(top.with_ties);
@@ -509,7 +517,9 @@ fn parse_mssql_top_percent_with_ties() {
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
     assert_eq!(
-        Some(TopQuantity::Expr(Expr::Value((number("10")).with_empty_span()))),
+        Some(TopQuantity::Expr(Expr::Value(
+            (number("10")).with_empty_span()
+        ))),
         top.quantity
     );
     assert!(top.percent);
@@ -746,7 +756,10 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[0],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
+                    name: Expr::Value(ValueWithSpan {
+                        value: Value::SingleQuotedString(_),
+                        span: _
+                    }),
                     arg: FunctionArgExpr::Expr(Expr::Function(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -762,7 +775,10 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[2],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
+                    name: Expr::Value(ValueWithSpan {
+                        value: Value::SingleQuotedString(_),
+                        span: _
+                    }),
                     arg: FunctionArgExpr::Expr(Expr::Subquery(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -793,7 +809,10 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[0],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
+                    name: Expr::Value(ValueWithSpan {
+                        value: Value::SingleQuotedString(_),
+                        span: _
+                    }),
                     arg: FunctionArgExpr::Expr(Expr::CompoundIdentifier(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -801,7 +820,10 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[1],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
+                    name: Expr::Value(ValueWithSpan {
+                        value: Value::SingleQuotedString(_),
+                        span: _
+                    }),
                     arg: FunctionArgExpr::Expr(Expr::CompoundIdentifier(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -809,7 +831,10 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[2],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(_), span: _}),
+                    name: Expr::Value(ValueWithSpan {
+                        value: Value::SingleQuotedString(_),
+                        span: _
+                    }),
                     arg: FunctionArgExpr::Expr(Expr::CompoundIdentifier(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -829,12 +854,18 @@ fn parse_mssql_json_array() {
         }) => {
             assert_eq!(
                 &[
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
-                        Value::SingleQuotedString("a".into())
-                    ).with_empty_span()))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span()))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((Value::Null).with_empty_span()))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("2")).with_empty_span()))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        (Value::SingleQuotedString("a".into())).with_empty_span()
+                    ))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        (number("1")).with_empty_span()
+                    ))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        (Value::Null).with_empty_span()
+                    ))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        (number("2")).with_empty_span()
+                    ))),
                 ],
                 &args[..]
             );
@@ -855,12 +886,18 @@ fn parse_mssql_json_array() {
         }) => {
             assert_eq!(
                 &[
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
-                        Value::SingleQuotedString("a".into())
-                    ).with_empty_span()))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span()))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((Value::Null).with_empty_span()))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("2")).with_empty_span()))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        (Value::SingleQuotedString("a".into())).with_empty_span()
+                    ))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        (number("1")).with_empty_span()
+                    ))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        (Value::Null).with_empty_span()
+                    ))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                        (number("2")).with_empty_span()
+                    ))),
                 ],
                 &args[..]
             );
@@ -914,9 +951,9 @@ fn parse_mssql_json_array() {
             ..
         }) => {
             assert_eq!(
-                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
-                    Value::SingleQuotedString("a".into())
-                ).with_empty_span()))),
+                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                    (Value::SingleQuotedString("a".into())).with_empty_span()
+                ))),
                 &args[0]
             );
             assert!(matches!(
@@ -941,9 +978,9 @@ fn parse_mssql_json_array() {
             ..
         }) => {
             assert_eq!(
-                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
-                    Value::SingleQuotedString("a".into())
-                ).with_empty_span()))),
+                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                    (Value::SingleQuotedString("a".into())).with_empty_span()
+                ))),
                 &args[0]
             );
             assert!(matches!(
@@ -964,7 +1001,9 @@ fn parse_mssql_json_array() {
             ..
         }) => {
             assert_eq!(
-                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span()))),
+                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                    (number("1")).with_empty_span()
+                ))),
                 &args[0]
             );
             assert!(matches!(
@@ -1089,8 +1128,12 @@ fn parse_substring_in_select() {
                                 quote_style: None,
                                 span: Span::empty(),
                             })),
-                            substring_from: Some(Box::new(Expr::Value((number("0")).with_empty_span()))),
-                            substring_for: Some(Box::new(Expr::Value((number("1")).with_empty_span()))),
+                            substring_from: Some(Box::new(Expr::Value(
+                                (number("0")).with_empty_span()
+                            ))),
+                            substring_for: Some(Box::new(Expr::Value(
+                                (number("1")).with_empty_span()
+                            ))),
                             special: true,
                         })],
                         into: None,
@@ -1179,9 +1222,9 @@ fn parse_mssql_declare() {
                         span: Span::empty(),
                     }],
                     data_type: Some(Text),
-                    assignment: Some(MsSqlAssignment(Box::new(Expr::Value((SingleQuotedString(
-                        "foobar".to_string()
-                    )).with_empty_span())))),
+                    assignment: Some(MsSqlAssignment(Box::new(Expr::Value(
+                        (SingleQuotedString("foobar".to_string())).with_empty_span()
+                    )))),
                     declare_type: None,
                     binary: None,
                     sensitive: None,
@@ -1215,7 +1258,9 @@ fn parse_mssql_declare() {
                 local: false,
                 hivevar: false,
                 variables: OneOrManyWithParens::One(ObjectName::from(vec![Ident::new("@bar")])),
-                value: vec![Expr::Value((Value::Number("2".parse().unwrap(), false)).with_empty_span())],
+                value: vec![Expr::Value(
+                    (Value::Number("2".parse().unwrap(), false)).with_empty_span()
+                )],
             },
             Statement::Query(Box::new(Query {
                 with: None,
@@ -1236,7 +1281,9 @@ fn parse_mssql_declare() {
                     projection: vec![SelectItem::UnnamedExpr(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("@bar"))),
                         op: BinaryOperator::Multiply,
-                        right: Box::new(Expr::Value((Value::Number("4".parse().unwrap(), false)).with_empty_span())),
+                        right: Box::new(Expr::Value(
+                            (Value::Number("4".parse().unwrap(), false)).with_empty_span()
+                        )),
                     })],
                     into: None,
                     from: vec![],
@@ -1268,11 +1315,15 @@ fn test_parse_raiserror() {
     assert_eq!(
         s,
         Statement::RaisError {
-            message: Box::new(Expr::Value((Value::SingleQuotedString(
-                "This is a test".to_string()
-            )).with_empty_span())),
-            severity: Box::new(Expr::Value((Value::Number("16".parse().unwrap(), false)).with_empty_span())),
-            state: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
+            message: Box::new(Expr::Value(
+                (Value::SingleQuotedString("This is a test".to_string())).with_empty_span()
+            )),
+            severity: Box::new(Expr::Value(
+                (Value::Number("16".parse().unwrap(), false)).with_empty_span()
+            )),
+            state: Box::new(Expr::Value(
+                (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+            )),
             arguments: vec![],
             options: vec![],
         }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -67,9 +67,9 @@ fn parse_table_time_travel() {
                 alias: None,
                 args: None,
                 with_hints: vec![],
-                version: Some(TableVersion::ForSystemTimeAsOf(Expr::Value(
+                version: Some(TableVersion::ForSystemTimeAsOf(Expr::Value((
                     Value::SingleQuotedString(version)
-                ))),
+                ).with_empty_span()))),
                 partitions: vec![],
                 with_ordinality: false,
                 json_path: None,
@@ -121,7 +121,7 @@ fn parse_create_procedure() {
                     distinct: None,
                     top: None,
                     top_before_distinct: false,
-                    projection: vec![SelectItem::UnnamedExpr(Expr::Value(number("1")))],
+                    projection: vec![SelectItem::UnnamedExpr(Expr::Value((number("1")).with_empty_span()))],
                     into: None,
                     from: vec![],
                     lateral_views: vec![],
@@ -473,7 +473,7 @@ fn parse_mssql_top_paren() {
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
     assert_eq!(
-        Some(TopQuantity::Expr(Expr::Value(number("5")))),
+        Some(TopQuantity::Expr(Expr::Value((number("5")).with_empty_span()))),
         top.quantity
     );
     assert!(!top.percent);
@@ -485,7 +485,7 @@ fn parse_mssql_top_percent() {
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
     assert_eq!(
-        Some(TopQuantity::Expr(Expr::Value(number("5")))),
+        Some(TopQuantity::Expr(Expr::Value((number("5")).with_empty_span()))),
         top.quantity
     );
     assert!(top.percent);
@@ -497,7 +497,7 @@ fn parse_mssql_top_with_ties() {
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
     assert_eq!(
-        Some(TopQuantity::Expr(Expr::Value(number("5")))),
+        Some(TopQuantity::Expr(Expr::Value((number("5")).with_empty_span()))),
         top.quantity
     );
     assert!(top.with_ties);
@@ -509,7 +509,7 @@ fn parse_mssql_top_percent_with_ties() {
     let select = ms_and_generic().verified_only_select(sql);
     let top = select.top.unwrap();
     assert_eq!(
-        Some(TopQuantity::Expr(Expr::Value(number("10")))),
+        Some(TopQuantity::Expr(Expr::Value((number("10")).with_empty_span()))),
         top.quantity
     );
     assert!(top.percent);
@@ -746,7 +746,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[0],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString(_)),
+                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
                     arg: FunctionArgExpr::Expr(Expr::Function(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -762,7 +762,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[2],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString(_)),
+                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
                     arg: FunctionArgExpr::Expr(Expr::Subquery(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -793,7 +793,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[0],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString(_)),
+                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
                     arg: FunctionArgExpr::Expr(Expr::CompoundIdentifier(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -801,7 +801,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[1],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString(_)),
+                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
                     arg: FunctionArgExpr::Expr(Expr::CompoundIdentifier(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -809,7 +809,7 @@ fn parse_mssql_json_object() {
             assert!(matches!(
                 args[2],
                 FunctionArg::ExprNamed {
-                    name: Expr::Value(Value::SingleQuotedString(_)),
+                    name: Expr::Value((Value::SingleQuotedString(_)).with_empty_span()),
                     arg: FunctionArgExpr::Expr(Expr::CompoundIdentifier(_)),
                     operator: FunctionArgOperator::Colon
                 }
@@ -829,12 +829,12 @@ fn parse_mssql_json_array() {
         }) => {
             assert_eq!(
                 &[
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
                         Value::SingleQuotedString("a".into())
-                    ))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(number("1")))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(Value::Null))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(number("2")))),
+                    ).with_empty_span()))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span()))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((Value::Null).with_empty_span()))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("2")).with_empty_span()))),
                 ],
                 &args[..]
             );
@@ -855,12 +855,12 @@ fn parse_mssql_json_array() {
         }) => {
             assert_eq!(
                 &[
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
                         Value::SingleQuotedString("a".into())
-                    ))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(number("1")))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(Value::Null))),
-                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(number("2")))),
+                    ).with_empty_span()))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span()))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((Value::Null).with_empty_span()))),
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("2")).with_empty_span()))),
                 ],
                 &args[..]
             );
@@ -914,9 +914,9 @@ fn parse_mssql_json_array() {
             ..
         }) => {
             assert_eq!(
-                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
                     Value::SingleQuotedString("a".into())
-                ))),
+                ).with_empty_span()))),
                 &args[0]
             );
             assert!(matches!(
@@ -941,9 +941,9 @@ fn parse_mssql_json_array() {
             ..
         }) => {
             assert_eq!(
-                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(
+                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((
                     Value::SingleQuotedString("a".into())
-                ))),
+                ).with_empty_span()))),
                 &args[0]
             );
             assert!(matches!(
@@ -964,7 +964,7 @@ fn parse_mssql_json_array() {
             ..
         }) => {
             assert_eq!(
-                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(number("1")))),
+                &FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value((number("1")).with_empty_span()))),
                 &args[0]
             );
             assert!(matches!(
@@ -1042,15 +1042,15 @@ fn parse_convert() {
         unreachable!()
     };
     assert!(!is_try);
-    assert_eq!(Expr::Value(number("1")), *expr);
+    assert_eq!(Expr::Value((number("1")).with_empty_span()), *expr);
     assert_eq!(Some(DataType::Int(None)), data_type);
     assert!(charset.is_none());
     assert!(target_before_value);
     assert_eq!(
         vec![
-            Expr::Value(number("2")),
-            Expr::Value(number("3")),
-            Expr::Value(Value::Null),
+            Expr::Value((number("2")).with_empty_span()),
+            Expr::Value((number("3")).with_empty_span()),
+            Expr::Value((Value::Null).with_empty_span()),
         ],
         styles
     );
@@ -1089,8 +1089,8 @@ fn parse_substring_in_select() {
                                 quote_style: None,
                                 span: Span::empty(),
                             })),
-                            substring_from: Some(Box::new(Expr::Value(number("0")))),
-                            substring_for: Some(Box::new(Expr::Value(number("1")))),
+                            substring_from: Some(Box::new(Expr::Value((number("0")).with_empty_span()))),
+                            substring_for: Some(Box::new(Expr::Value((number("1")).with_empty_span()))),
                             special: true,
                         })],
                         into: None,
@@ -1179,9 +1179,9 @@ fn parse_mssql_declare() {
                         span: Span::empty(),
                     }],
                     data_type: Some(Text),
-                    assignment: Some(MsSqlAssignment(Box::new(Expr::Value(SingleQuotedString(
+                    assignment: Some(MsSqlAssignment(Box::new(Expr::Value((SingleQuotedString(
                         "foobar".to_string()
-                    ))))),
+                    )).with_empty_span())))),
                     declare_type: None,
                     binary: None,
                     sensitive: None,
@@ -1215,7 +1215,7 @@ fn parse_mssql_declare() {
                 local: false,
                 hivevar: false,
                 variables: OneOrManyWithParens::One(ObjectName::from(vec![Ident::new("@bar")])),
-                value: vec![Expr::Value(Value::Number("2".parse().unwrap(), false))],
+                value: vec![Expr::Value((Value::Number("2".parse().unwrap(), false)).with_empty_span())],
             },
             Statement::Query(Box::new(Query {
                 with: None,
@@ -1236,7 +1236,7 @@ fn parse_mssql_declare() {
                     projection: vec![SelectItem::UnnamedExpr(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident::new("@bar"))),
                         op: BinaryOperator::Multiply,
-                        right: Box::new(Expr::Value(Value::Number("4".parse().unwrap(), false))),
+                        right: Box::new(Expr::Value((Value::Number("4".parse().unwrap(), false)).with_empty_span())),
                     })],
                     into: None,
                     from: vec![],
@@ -1268,11 +1268,11 @@ fn test_parse_raiserror() {
     assert_eq!(
         s,
         Statement::RaisError {
-            message: Box::new(Expr::Value(Value::SingleQuotedString(
+            message: Box::new(Expr::Value((Value::SingleQuotedString(
                 "This is a test".to_string()
-            ))),
-            severity: Box::new(Expr::Value(Value::Number("16".parse().unwrap(), false))),
-            state: Box::new(Expr::Value(Value::Number("1".parse().unwrap(), false))),
+            )).with_empty_span())),
+            severity: Box::new(Expr::Value((Value::Number("16".parse().unwrap(), false)).with_empty_span())),
+            state: Box::new(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
             arguments: vec![],
             options: vec![],
         }
@@ -1347,7 +1347,7 @@ fn parse_create_table_with_valid_options() {
                 SqlOption::Partition {
                     column_name: "column_a".into(),
                     range_direction: None,
-                    for_values: vec![Expr::Value(test_utils::number("10")), Expr::Value(test_utils::number("11"))] ,
+                    for_values: vec![Expr::Value((test_utils::number("10")).with_empty_span()), Expr::Value((test_utils::number("11")).with_empty_span())] ,
                 },
             ],
         ),
@@ -1358,8 +1358,8 @@ fn parse_create_table_with_valid_options() {
                         column_name: "column_a".into(),
                         range_direction: Some(PartitionRangeDirection::Left),
                         for_values: vec![
-                            Expr::Value(test_utils::number("10")),
-                            Expr::Value(test_utils::number("11")),
+                            Expr::Value((test_utils::number("10")).with_empty_span()),
+                            Expr::Value((test_utils::number("11")).with_empty_span()),
                         ],
                     }
             ],
@@ -1630,8 +1630,8 @@ fn parse_create_table_with_identity_column() {
                         IdentityProperty {
                             parameters: Some(IdentityPropertyFormatKind::FunctionCall(
                                 IdentityParameters {
-                                    seed: Expr::Value(number("1")),
-                                    increment: Expr::Value(number("1")),
+                                    seed: Expr::Value((number("1")).with_empty_span()),
+                                    increment: Expr::Value((number("1")).with_empty_span()),
                                 },
                             )),
                             order: None,

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1081,14 +1081,14 @@ fn parse_convert() {
         unreachable!()
     };
     assert!(!is_try);
-    assert_eq!(Expr::Value((number("1")).with_empty_span()), *expr);
+    assert_eq!(Expr::value(number("1")), *expr);
     assert_eq!(Some(DataType::Int(None)), data_type);
     assert!(charset.is_none());
     assert!(target_before_value);
     assert_eq!(
         vec![
-            Expr::Value((number("2")).with_empty_span()),
-            Expr::Value((number("3")).with_empty_span()),
+            Expr::value(number("2")),
+            Expr::value(number("3")),
             Expr::Value((Value::Null).with_empty_span()),
         ],
         styles
@@ -1681,8 +1681,8 @@ fn parse_create_table_with_identity_column() {
                         IdentityProperty {
                             parameters: Some(IdentityPropertyFormatKind::FunctionCall(
                                 IdentityParameters {
-                                    seed: Expr::Value((number("1")).with_empty_span()),
-                                    increment: Expr::Value((number("1")).with_empty_span()),
+                                    seed: Expr::value(number("1")),
+                                    increment: Expr::value(number("1")),
                                 },
                             )),
                             order: None,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -621,7 +621,7 @@ fn parse_set_variables() {
             local: true,
             hivevar: false,
             variables: OneOrManyWithParens::One(ObjectName::from(vec!["autocommit".into()])),
-            value: vec![Expr::Value((number("1")).with_empty_span())],
+            value: vec![Expr::value(number("1"))],
         }
     );
 }
@@ -1419,21 +1419,21 @@ fn parse_simple_insert() {
                                     (Value::SingleQuotedString("Test Some Inserts".to_string()))
                                         .with_empty_span()
                                 ),
-                                Expr::Value((number("1")).with_empty_span())
+                                Expr::value(number("1"))
                             ],
                             vec![
                                 Expr::Value(
                                     (Value::SingleQuotedString("Test Entry 2".to_string()))
                                         .with_empty_span()
                                 ),
-                                Expr::Value((number("2")).with_empty_span())
+                                Expr::value(number("2"))
                             ],
                             vec![
                                 Expr::Value(
                                     (Value::SingleQuotedString("Test Entry 3".to_string()))
                                         .with_empty_span()
                                 ),
-                                Expr::Value((number("3")).with_empty_span())
+                                Expr::value(number("3"))
                             ]
                         ]
                     })),
@@ -1484,7 +1484,7 @@ fn parse_ignore_insert() {
                                 (Value::SingleQuotedString("Test Some Inserts".to_string()))
                                     .with_empty_span()
                             ),
-                            Expr::Value((number("1")).with_empty_span())
+                            Expr::value(number("1"))
                         ]]
                     })),
                     order_by: None,
@@ -1534,7 +1534,7 @@ fn parse_priority_insert() {
                                 (Value::SingleQuotedString("Test Some Inserts".to_string()))
                                     .with_empty_span()
                             ),
-                            Expr::Value((number("1")).with_empty_span())
+                            Expr::value(number("1"))
                         ]]
                     })),
                     order_by: None,
@@ -1581,7 +1581,7 @@ fn parse_priority_insert() {
                                 (Value::SingleQuotedString("Test Some Inserts".to_string()))
                                     .with_empty_span()
                             ),
-                            Expr::Value((number("1")).with_empty_span())
+                            Expr::value(number("1"))
                         ]]
                     })),
                     order_by: None,
@@ -1690,7 +1690,7 @@ fn parse_insert_as() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value((number("1")).with_empty_span()),
+                            Expr::value(number("1")),
                             Expr::Value(
                                 (Value::SingleQuotedString("2024-01-01".to_string()))
                                     .with_empty_span()
@@ -1745,7 +1745,7 @@ fn parse_replace_insert() {
                                 (Value::SingleQuotedString("Test Some Inserts".to_string()))
                                     .with_empty_span()
                             ),
-                            Expr::Value((number("1")).with_empty_span())
+                            Expr::value(number("1"))
                         ]]
                     })),
                     order_by: None,
@@ -1974,7 +1974,7 @@ fn parse_select_with_concatenation_of_exp_number_and_numeric_prefix_column() {
                     top: None,
                     top_before_distinct: false,
                     projection: vec![
-                        SelectItem::UnnamedExpr(Expr::Value((number("123e4")).with_empty_span())),
+                        SelectItem::UnnamedExpr(Expr::value(number("123e4"))),
                         SelectItem::UnnamedExpr(Expr::Identifier(Ident::new("123col_$@123abc")))
                     ],
                     into: None,
@@ -2142,7 +2142,7 @@ fn parse_delete_with_limit() {
     let sql = "DELETE FROM customers LIMIT 100";
     match mysql().verified_stmt(sql) {
         Statement::Delete(Delete { limit, .. }) => {
-            assert_eq!(Some(Expr::Value((number("100")).with_empty_span())), limit);
+            assert_eq!(Some(Expr::value(number("100"))), limit);
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -986,7 +986,9 @@ fn parse_create_table_both_options_and_as_query() {
             assert_eq!(collation, Some("utf8mb4_0900_ai_ci".to_string()));
             assert_eq!(
                 query.unwrap().body.as_select().unwrap().projection,
-                vec![SelectItem::UnnamedExpr(Expr::Value((number("1")).with_empty_span()))]
+                vec![SelectItem::UnnamedExpr(Expr::Value(
+                    (number("1")).with_empty_span()
+                ))]
             );
         }
         _ => unreachable!(),
@@ -1413,17 +1415,24 @@ fn parse_simple_insert() {
                         explicit_row: false,
                         rows: vec![
                             vec![
-                                Expr::Value((Value::SingleQuotedString(
-                                    "Test Some Inserts".to_string()
-                                )).with_empty_span()),
+                                Expr::Value(
+                                    (Value::SingleQuotedString("Test Some Inserts".to_string()))
+                                        .with_empty_span()
+                                ),
                                 Expr::Value((number("1")).with_empty_span())
                             ],
                             vec![
-                                Expr::Value((Value::SingleQuotedString("Test Entry 2".to_string())).with_empty_span()),
+                                Expr::Value(
+                                    (Value::SingleQuotedString("Test Entry 2".to_string()))
+                                        .with_empty_span()
+                                ),
                                 Expr::Value((number("2")).with_empty_span())
                             ],
                             vec![
-                                Expr::Value((Value::SingleQuotedString("Test Entry 3".to_string())).with_empty_span()),
+                                Expr::Value(
+                                    (Value::SingleQuotedString("Test Entry 3".to_string()))
+                                        .with_empty_span()
+                                ),
                                 Expr::Value((number("3")).with_empty_span())
                             ]
                         ]
@@ -1471,7 +1480,10 @@ fn parse_ignore_insert() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value((Value::SingleQuotedString("Test Some Inserts".to_string())).with_empty_span()),
+                            Expr::Value(
+                                (Value::SingleQuotedString("Test Some Inserts".to_string()))
+                                    .with_empty_span()
+                            ),
                             Expr::Value((number("1")).with_empty_span())
                         ]]
                     })),
@@ -1518,7 +1530,10 @@ fn parse_priority_insert() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value((Value::SingleQuotedString("Test Some Inserts".to_string())).with_empty_span()),
+                            Expr::Value(
+                                (Value::SingleQuotedString("Test Some Inserts".to_string()))
+                                    .with_empty_span()
+                            ),
                             Expr::Value((number("1")).with_empty_span())
                         ]]
                     })),
@@ -1562,7 +1577,10 @@ fn parse_priority_insert() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value((Value::SingleQuotedString("Test Some Inserts".to_string())).with_empty_span()),
+                            Expr::Value(
+                                (Value::SingleQuotedString("Test Some Inserts".to_string()))
+                                    .with_empty_span()
+                            ),
                             Expr::Value((number("1")).with_empty_span())
                         ]]
                     })),
@@ -1611,9 +1629,9 @@ fn parse_insert_as() {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
-                        rows: vec![vec![Expr::Value((Value::SingleQuotedString(
-                            "2024-01-01".to_string()
-                        )).with_empty_span())]]
+                        rows: vec![vec![Expr::Value(
+                            (Value::SingleQuotedString("2024-01-01".to_string())).with_empty_span()
+                        )]]
                     })),
                     order_by: None,
                     limit: None,
@@ -1673,7 +1691,10 @@ fn parse_insert_as() {
                         explicit_row: false,
                         rows: vec![vec![
                             Expr::Value((number("1")).with_empty_span()),
-                            Expr::Value((Value::SingleQuotedString("2024-01-01".to_string())).with_empty_span())
+                            Expr::Value(
+                                (Value::SingleQuotedString("2024-01-01".to_string()))
+                                    .with_empty_span()
+                            )
                         ]]
                     })),
                     order_by: None,
@@ -1720,7 +1741,10 @@ fn parse_replace_insert() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value((Value::SingleQuotedString("Test Some Inserts".to_string())).with_empty_span()),
+                            Expr::Value(
+                                (Value::SingleQuotedString("Test Some Inserts".to_string()))
+                                    .with_empty_span()
+                            ),
                             Expr::Value((number("1")).with_empty_span())
                         ]]
                     })),
@@ -1816,12 +1840,16 @@ fn parse_insert_with_on_duplicate_update() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value((Value::SingleQuotedString(
-                                "accounting_manager".to_string()
-                            )).with_empty_span()),
-                            Expr::Value((Value::SingleQuotedString(
-                                "Some description about the group".to_string()
-                            )).with_empty_span()),
+                            Expr::Value(
+                                (Value::SingleQuotedString("accounting_manager".to_string()))
+                                    .with_empty_span()
+                            ),
+                            Expr::Value(
+                                (Value::SingleQuotedString(
+                                    "Some description about the group".to_string()
+                                ))
+                                .with_empty_span()
+                            ),
                             Expr::Value((Value::Boolean(true)).with_empty_span()),
                             Expr::Value((Value::Boolean(true)).with_empty_span()),
                             Expr::Value((Value::Boolean(true)).with_empty_span()),
@@ -2074,7 +2102,9 @@ fn parse_update_with_joins() {
                         Ident::new("firstname")
                     ])),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value((Value::SingleQuotedString("Peter".to_string())).with_empty_span()))
+                    right: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("Peter".to_string())).with_empty_span()
+                    ))
                 }),
                 selection
             );
@@ -2460,8 +2490,12 @@ fn parse_substring_in_select() {
                                 quote_style: None,
                                 span: Span::empty(),
                             })),
-                            substring_from: Some(Box::new(Expr::Value((number("0")).with_empty_span()))),
-                            substring_for: Some(Box::new(Expr::Value((number("1")).with_empty_span()))),
+                            substring_from: Some(Box::new(Expr::Value(
+                                (number("0")).with_empty_span()
+                            ))),
+                            substring_for: Some(Box::new(Expr::Value(
+                                (number("1")).with_empty_span()
+                            ))),
                             special: true,
                         })],
                         into: None,
@@ -3010,9 +3044,9 @@ fn parse_bitstring_literal() {
     let select = mysql_and_generic().verified_only_select("SELECT B'111'");
     assert_eq!(
         select.projection,
-        vec![SelectItem::UnnamedExpr(Expr::Value((
-            Value::SingleQuotedByteStringLiteral("111".to_string())
-        ).with_empty_span()))]
+        vec![SelectItem::UnnamedExpr(Expr::Value(
+            (Value::SingleQuotedByteStringLiteral("111".to_string())).with_empty_span()
+        ))]
     );
 }
 

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -52,11 +52,11 @@ fn parse_literal_string() {
     let select = mysql().verified_only_select(sql);
     assert_eq!(2, select.projection.len());
     assert_eq!(
-        &Expr::Value(Value::SingleQuotedString("single".to_string())),
+        &Expr::Value((Value::SingleQuotedString("single".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
-        &Expr::Value(Value::DoubleQuotedString("double".to_string())),
+        &Expr::Value((Value::DoubleQuotedString("double".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[1])
     );
 }
@@ -621,7 +621,7 @@ fn parse_set_variables() {
             local: true,
             hivevar: false,
             variables: OneOrManyWithParens::One(ObjectName::from(vec!["autocommit".into()])),
-            value: vec![Expr::Value(number("1"))],
+            value: vec![Expr::Value((number("1")).with_empty_span())],
         }
     );
 }
@@ -986,7 +986,7 @@ fn parse_create_table_both_options_and_as_query() {
             assert_eq!(collation, Some("utf8mb4_0900_ai_ci".to_string()));
             assert_eq!(
                 query.unwrap().body.as_select().unwrap().projection,
-                vec![SelectItem::UnnamedExpr(Expr::Value(number("1")))]
+                vec![SelectItem::UnnamedExpr(Expr::Value((number("1")).with_empty_span()))]
             );
         }
         _ => unreachable!(),
@@ -1413,18 +1413,18 @@ fn parse_simple_insert() {
                         explicit_row: false,
                         rows: vec![
                             vec![
-                                Expr::Value(Value::SingleQuotedString(
+                                Expr::Value((Value::SingleQuotedString(
                                     "Test Some Inserts".to_string()
-                                )),
-                                Expr::Value(number("1"))
+                                )).with_empty_span()),
+                                Expr::Value((number("1")).with_empty_span())
                             ],
                             vec![
-                                Expr::Value(Value::SingleQuotedString("Test Entry 2".to_string())),
-                                Expr::Value(number("2"))
+                                Expr::Value((Value::SingleQuotedString("Test Entry 2".to_string())).with_empty_span()),
+                                Expr::Value((number("2")).with_empty_span())
                             ],
                             vec![
-                                Expr::Value(Value::SingleQuotedString("Test Entry 3".to_string())),
-                                Expr::Value(number("3"))
+                                Expr::Value((Value::SingleQuotedString("Test Entry 3".to_string())).with_empty_span()),
+                                Expr::Value((number("3")).with_empty_span())
                             ]
                         ]
                     })),
@@ -1471,8 +1471,8 @@ fn parse_ignore_insert() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value(Value::SingleQuotedString("Test Some Inserts".to_string())),
-                            Expr::Value(number("1"))
+                            Expr::Value((Value::SingleQuotedString("Test Some Inserts".to_string())).with_empty_span()),
+                            Expr::Value((number("1")).with_empty_span())
                         ]]
                     })),
                     order_by: None,
@@ -1518,8 +1518,8 @@ fn parse_priority_insert() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value(Value::SingleQuotedString("Test Some Inserts".to_string())),
-                            Expr::Value(number("1"))
+                            Expr::Value((Value::SingleQuotedString("Test Some Inserts".to_string())).with_empty_span()),
+                            Expr::Value((number("1")).with_empty_span())
                         ]]
                     })),
                     order_by: None,
@@ -1562,8 +1562,8 @@ fn parse_priority_insert() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value(Value::SingleQuotedString("Test Some Inserts".to_string())),
-                            Expr::Value(number("1"))
+                            Expr::Value((Value::SingleQuotedString("Test Some Inserts".to_string())).with_empty_span()),
+                            Expr::Value((number("1")).with_empty_span())
                         ]]
                     })),
                     order_by: None,
@@ -1611,9 +1611,9 @@ fn parse_insert_as() {
                     with: None,
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
-                        rows: vec![vec![Expr::Value(Value::SingleQuotedString(
+                        rows: vec![vec![Expr::Value((Value::SingleQuotedString(
                             "2024-01-01".to_string()
-                        ))]]
+                        )).with_empty_span())]]
                     })),
                     order_by: None,
                     limit: None,
@@ -1672,8 +1672,8 @@ fn parse_insert_as() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value(number("1")),
-                            Expr::Value(Value::SingleQuotedString("2024-01-01".to_string()))
+                            Expr::Value((number("1")).with_empty_span()),
+                            Expr::Value((Value::SingleQuotedString("2024-01-01".to_string())).with_empty_span())
                         ]]
                     })),
                     order_by: None,
@@ -1720,8 +1720,8 @@ fn parse_replace_insert() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value(Value::SingleQuotedString("Test Some Inserts".to_string())),
-                            Expr::Value(number("1"))
+                            Expr::Value((Value::SingleQuotedString("Test Some Inserts".to_string())).with_empty_span()),
+                            Expr::Value((number("1")).with_empty_span())
                         ]]
                     })),
                     order_by: None,
@@ -1816,16 +1816,16 @@ fn parse_insert_with_on_duplicate_update() {
                     body: Box::new(SetExpr::Values(Values {
                         explicit_row: false,
                         rows: vec![vec![
-                            Expr::Value(Value::SingleQuotedString(
+                            Expr::Value((Value::SingleQuotedString(
                                 "accounting_manager".to_string()
-                            )),
-                            Expr::Value(Value::SingleQuotedString(
+                            )).with_empty_span()),
+                            Expr::Value((Value::SingleQuotedString(
                                 "Some description about the group".to_string()
-                            )),
-                            Expr::Value(Value::Boolean(true)),
-                            Expr::Value(Value::Boolean(true)),
-                            Expr::Value(Value::Boolean(true)),
-                            Expr::Value(Value::Boolean(true)),
+                            )).with_empty_span()),
+                            Expr::Value((Value::Boolean(true)).with_empty_span()),
+                            Expr::Value((Value::Boolean(true)).with_empty_span()),
+                            Expr::Value((Value::Boolean(true)).with_empty_span()),
+                            Expr::Value((Value::Boolean(true)).with_empty_span()),
                         ]]
                     })),
                     order_by: None,
@@ -1946,7 +1946,7 @@ fn parse_select_with_concatenation_of_exp_number_and_numeric_prefix_column() {
                     top: None,
                     top_before_distinct: false,
                     projection: vec![
-                        SelectItem::UnnamedExpr(Expr::Value(number("123e4"))),
+                        SelectItem::UnnamedExpr(Expr::Value((number("123e4")).with_empty_span())),
                         SelectItem::UnnamedExpr(Expr::Identifier(Ident::new("123col_$@123abc")))
                     ],
                     into: None,
@@ -2063,7 +2063,7 @@ fn parse_update_with_joins() {
                         Ident::new("o"),
                         Ident::new("completed")
                     ])),
-                    value: Expr::Value(Value::Boolean(true))
+                    value: Expr::Value((Value::Boolean(true)).with_empty_span())
                 }],
                 assignments
             );
@@ -2074,7 +2074,7 @@ fn parse_update_with_joins() {
                         Ident::new("firstname")
                     ])),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value(Value::SingleQuotedString("Peter".to_string())))
+                    right: Box::new(Expr::Value((Value::SingleQuotedString("Peter".to_string())).with_empty_span()))
                 }),
                 selection
             );
@@ -2112,7 +2112,7 @@ fn parse_delete_with_limit() {
     let sql = "DELETE FROM customers LIMIT 100";
     match mysql().verified_stmt(sql) {
         Statement::Delete(Delete { limit, .. }) => {
-            assert_eq!(Some(Expr::Value(number("100"))), limit);
+            assert_eq!(Some(Expr::Value((number("100")).with_empty_span())), limit);
         }
         _ => unreachable!(),
     }
@@ -2460,8 +2460,8 @@ fn parse_substring_in_select() {
                                 quote_style: None,
                                 span: Span::empty(),
                             })),
-                            substring_from: Some(Box::new(Expr::Value(number("0")))),
-                            substring_for: Some(Box::new(Expr::Value(number("1")))),
+                            substring_from: Some(Box::new(Expr::Value((number("0")).with_empty_span()))),
+                            substring_for: Some(Box::new(Expr::Value((number("1")).with_empty_span()))),
                             special: true,
                         })],
                         into: None,
@@ -2935,7 +2935,7 @@ fn parse_json_table() {
             .from[0]
             .relation,
         TableFactor::JsonTable {
-            json_expr: Expr::Value(Value::SingleQuotedString("[1,2]".to_string())),
+            json_expr: Expr::Value((Value::SingleQuotedString("[1,2]".to_string())).with_empty_span()),
             json_path: Value::SingleQuotedString("$[*]".to_string()),
             columns: vec![
                 JsonTableColumn::Named(JsonTableNamedColumn {
@@ -2973,33 +2973,33 @@ fn parse_logical_xor() {
     let select = mysql_and_generic().verified_only_select(sql);
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::BinaryOp {
-            left: Box::new(Expr::Value(Value::Boolean(true))),
+            left: Box::new(Expr::Value((Value::Boolean(true)).with_empty_span())),
             op: BinaryOperator::Xor,
-            right: Box::new(Expr::Value(Value::Boolean(true))),
+            right: Box::new(Expr::Value((Value::Boolean(true)).with_empty_span())),
         }),
         select.projection[0]
     );
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::BinaryOp {
-            left: Box::new(Expr::Value(Value::Boolean(false))),
+            left: Box::new(Expr::Value((Value::Boolean(false)).with_empty_span())),
             op: BinaryOperator::Xor,
-            right: Box::new(Expr::Value(Value::Boolean(false))),
+            right: Box::new(Expr::Value((Value::Boolean(false)).with_empty_span())),
         }),
         select.projection[1]
     );
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::BinaryOp {
-            left: Box::new(Expr::Value(Value::Boolean(true))),
+            left: Box::new(Expr::Value((Value::Boolean(true)).with_empty_span())),
             op: BinaryOperator::Xor,
-            right: Box::new(Expr::Value(Value::Boolean(false))),
+            right: Box::new(Expr::Value((Value::Boolean(false)).with_empty_span())),
         }),
         select.projection[2]
     );
     assert_eq!(
         SelectItem::UnnamedExpr(Expr::BinaryOp {
-            left: Box::new(Expr::Value(Value::Boolean(false))),
+            left: Box::new(Expr::Value((Value::Boolean(false)).with_empty_span())),
             op: BinaryOperator::Xor,
-            right: Box::new(Expr::Value(Value::Boolean(true))),
+            right: Box::new(Expr::Value((Value::Boolean(true)).with_empty_span())),
         }),
         select.projection[3]
     );
@@ -3010,9 +3010,9 @@ fn parse_bitstring_literal() {
     let select = mysql_and_generic().verified_only_select("SELECT B'111'");
     assert_eq!(
         select.projection,
-        vec![SelectItem::UnnamedExpr(Expr::Value(
+        vec![SelectItem::UnnamedExpr(Expr::Value((
             Value::SingleQuotedByteStringLiteral("111".to_string())
-        ))]
+        ).with_empty_span()))]
     );
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -768,7 +768,7 @@ fn parse_alter_table_alter_column() {
     ) {
         AlterTableOperation::AlterColumn { column_name, op } => {
             assert_eq!("is_active", column_name.to_string());
-            let using_expr = Expr::Value(Value::SingleQuotedString("text".to_string()));
+            let using_expr = Expr::Value(Value::SingleQuotedString("text".to_string()).with_empty_span());
             assert_eq!(
                 op,
                 AlterColumnOperation::SetDataType {
@@ -2201,7 +2201,7 @@ fn parse_pg_like_match_ops() {
 #[test]
 fn parse_array_index_expr() {
     let num: Vec<Expr> = (0..=10)
-        .map(|s| Expr::Value(number(&s.to_string())))
+        .map(|s| Expr::Value(number(&s.to_string()).with_empty_span()))
         .collect();
 
     let sql = "SELECT foo[0] FROM foos";
@@ -2312,7 +2312,7 @@ fn parse_array_subscript() {
         (
             "(ARRAY[1, 2, 3, 4, 5, 6])[2]",
             Subscript::Index {
-                index: Expr::Value(number("2")),
+                index: Expr::Value(number("2").with_empty_span()),
             },
         ),
         (
@@ -2324,17 +2324,17 @@ fn parse_array_subscript() {
         (
             "(ARRAY[1, 2, 3, 4, 5, 6])[2:5]",
             Subscript::Slice {
-                lower_bound: Some(Expr::Value(number("2"))),
-                upper_bound: Some(Expr::Value(number("5"))),
+                lower_bound: Some(Expr::Value(number("2").with_empty_span())),
+                upper_bound: Some(Expr::Value(number("5").with_empty_span())),
                 stride: None,
             },
         ),
         (
             "(ARRAY[1, 2, 3, 4, 5, 6])[2:5:3]",
             Subscript::Slice {
-                lower_bound: Some(Expr::Value(number("2"))),
-                upper_bound: Some(Expr::Value(number("5"))),
-                stride: Some(Expr::Value(number("3"))),
+                lower_bound: Some(Expr::Value(number("2").with_empty_span())),
+                upper_bound: Some(Expr::Value(number("5").with_empty_span())),
+                stride: Some(Expr::Value(number("3").with_empty_span())),
             },
         ),
         (
@@ -2343,12 +2343,12 @@ fn parse_array_subscript() {
                 lower_bound: Some(Expr::BinaryOp {
                     left: Box::new(call("array_length", [Expr::Identifier(Ident::new("arr"))])),
                     op: BinaryOperator::Minus,
-                    right: Box::new(Expr::Value(number("3"))),
+                    right: Box::new(Expr::Value(number("3").with_empty_span())),
                 }),
                 upper_bound: Some(Expr::BinaryOp {
                     left: Box::new(call("array_length", [Expr::Identifier(Ident::new("arr"))])),
                     op: BinaryOperator::Minus,
-                    right: Box::new(Expr::Value(number("1"))),
+                    right: Box::new(Expr::Value(number("1").with_empty_span())),
                 }),
                 stride: None,
             },
@@ -2357,14 +2357,14 @@ fn parse_array_subscript() {
             "(ARRAY[1, 2, 3, 4, 5, 6])[:5]",
             Subscript::Slice {
                 lower_bound: None,
-                upper_bound: Some(Expr::Value(number("5"))),
+                upper_bound: Some(Expr::Value(number("5").with_empty_span())),
                 stride: None,
             },
         ),
         (
             "(ARRAY[1, 2, 3, 4, 5, 6])[2:]",
             Subscript::Slice {
-                lower_bound: Some(Expr::Value(number("2"))),
+                lower_bound: Some(Expr::Value(number("2").with_empty_span())),
                 upper_bound: None,
                 stride: None,
             },
@@ -4652,7 +4652,7 @@ fn parse_at_time_zone() {
                 kind: CastKind::DoubleColon,
                 expr: Box::new(Expr::Value(Value::SingleQuotedString(
                     "America/Los_Angeles".to_owned(),
-                ))),
+                ).with_empty_span())),
                 data_type: DataType::Text,
                 format: None,
             }),
@@ -4661,7 +4661,7 @@ fn parse_at_time_zone() {
         right: Box::new(Expr::Interval(Interval {
             value: Box::new(Expr::Value(Value::SingleQuotedString(
                 "23 hours".to_owned(),
-            ))),
+            ).with_empty_span())),
             leading_field: None,
             leading_precision: None,
             last_field: None,
@@ -4790,7 +4790,7 @@ fn parse_create_after_update_trigger_with_condition() {
                 Ident::new("balance"),
             ])),
             op: BinaryOperator::Gt,
-            right: Box::new(Expr::Value(number("10000"))),
+            right: Box::new(Expr::Value(number("10000").with_empty_span())),
         }))),
         exec_body: TriggerExecBody {
             exec_type: TriggerExecBodyType::Function,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -436,7 +436,9 @@ fn parse_create_table_with_defaults() {
                         options: vec![
                             ColumnOptionDef {
                                 name: None,
-                                option: ColumnOption::Default(Expr::Value((Value::Boolean(true)).with_empty_span())),
+                                option: ColumnOption::Default(Expr::Value(
+                                    (Value::Boolean(true)).with_empty_span()
+                                )),
                             },
                             ColumnOptionDef {
                                 name: None,
@@ -768,7 +770,8 @@ fn parse_alter_table_alter_column() {
     ) {
         AlterTableOperation::AlterColumn { column_name, op } => {
             assert_eq!("is_active", column_name.to_string());
-            let using_expr = Expr::Value(Value::SingleQuotedString("text".to_string()).with_empty_span());
+            let using_expr =
+                Expr::Value(Value::SingleQuotedString("text".to_string()).with_empty_span());
             assert_eq!(
                 op,
                 AlterColumnOperation::SetDataType {
@@ -1288,7 +1291,9 @@ fn parse_copy_to() {
                             },
                         },
                         SelectItem::ExprWithAlias {
-                            expr: Expr::Value((Value::SingleQuotedString("hello".into())).with_empty_span()),
+                            expr: Expr::Value(
+                                (Value::SingleQuotedString("hello".into())).with_empty_span()
+                            ),
                             alias: Ident {
                                 value: "b".into(),
                                 quote_style: None,
@@ -1446,7 +1451,9 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variables: OneOrManyWithParens::One(ObjectName::from(vec![Ident::new("a")])),
-            value: vec![Expr::Value((Value::SingleQuotedString("b".into())).with_empty_span())],
+            value: vec![Expr::Value(
+                (Value::SingleQuotedString("b".into())).with_empty_span()
+            )],
         }
     );
 
@@ -1692,7 +1699,9 @@ fn parse_execute() {
                 ExprWithAlias {
                     expr: Expr::Cast {
                         kind: CastKind::Cast,
-                        expr: Box::new(Expr::Value((Value::Number("1337".parse().unwrap(), false)).with_empty_span())),
+                        expr: Box::new(Expr::Value(
+                            (Value::Number("1337".parse().unwrap(), false)).with_empty_span()
+                        )),
                         data_type: DataType::SmallInt(None),
                         format: None
                     },
@@ -1701,7 +1710,9 @@ fn parse_execute() {
                 ExprWithAlias {
                     expr: Expr::Cast {
                         kind: CastKind::Cast,
-                        expr: Box::new(Expr::Value((Value::Number("7331".parse().unwrap(), false)).with_empty_span())),
+                        expr: Box::new(Expr::Value(
+                            (Value::Number("7331".parse().unwrap(), false)).with_empty_span()
+                        )),
                         data_type: DataType::SmallInt(None),
                         format: None
                     },
@@ -1899,7 +1910,9 @@ fn parse_pg_on_conflict() {
                         target: AssignmentTarget::ColumnName(ObjectName::from(
                             vec!["dname".into()]
                         )),
-                        value: Expr::Value((Value::Placeholder("$1".to_string())).with_empty_span())
+                        value: Expr::Value(
+                            (Value::Placeholder("$1".to_string())).with_empty_span()
+                        )
                     },],
                     selection: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident {
@@ -1908,7 +1921,9 @@ fn parse_pg_on_conflict() {
                             span: Span::empty(),
                         })),
                         op: BinaryOperator::Gt,
-                        right: Box::new(Expr::Value((Value::Placeholder("$2".to_string())).with_empty_span()))
+                        right: Box::new(Expr::Value(
+                            (Value::Placeholder("$2".to_string())).with_empty_span()
+                        ))
                     })
                 }),
                 action
@@ -1942,7 +1957,9 @@ fn parse_pg_on_conflict() {
                         target: AssignmentTarget::ColumnName(ObjectName::from(
                             vec!["dname".into()]
                         )),
-                        value: Expr::Value((Value::Placeholder("$1".to_string())).with_empty_span())
+                        value: Expr::Value(
+                            (Value::Placeholder("$1".to_string())).with_empty_span()
+                        )
                     },],
                     selection: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident {
@@ -1951,7 +1968,9 @@ fn parse_pg_on_conflict() {
                             span: Span::empty(),
                         })),
                         op: BinaryOperator::Gt,
-                        right: Box::new(Expr::Value((Value::Placeholder("$2".to_string())).with_empty_span()))
+                        right: Box::new(Expr::Value(
+                            (Value::Placeholder("$2".to_string())).with_empty_span()
+                        ))
                     })
                 }),
                 action
@@ -2167,9 +2186,13 @@ fn parse_pg_regex_match_ops() {
         let select = pg().verified_only_select(&format!("SELECT 'abc' {} '^a'", &str_op));
         assert_eq!(
             SelectItem::UnnamedExpr(Expr::BinaryOp {
-                left: Box::new(Expr::Value((Value::SingleQuotedString("abc".into())).with_empty_span())),
+                left: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("abc".into())).with_empty_span()
+                )),
                 op: op.clone(),
-                right: Box::new(Expr::Value((Value::SingleQuotedString("^a".into())).with_empty_span())),
+                right: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("^a".into())).with_empty_span()
+                )),
             }),
             select.projection[0]
         );
@@ -2189,9 +2212,13 @@ fn parse_pg_like_match_ops() {
         let select = pg().verified_only_select(&format!("SELECT 'abc' {} 'a_c%'", &str_op));
         assert_eq!(
             SelectItem::UnnamedExpr(Expr::BinaryOp {
-                left: Box::new(Expr::Value((Value::SingleQuotedString("abc".into())).with_empty_span())),
+                left: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("abc".into())).with_empty_span()
+                )),
                 op: op.clone(),
-                right: Box::new(Expr::Value((Value::SingleQuotedString("a_c%".into())).with_empty_span())),
+                right: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("a_c%".into())).with_empty_span()
+                )),
             }),
             select.projection[0]
         );
@@ -2655,7 +2682,9 @@ fn parse_array_subquery_expr() {
                         distinct: None,
                         top: None,
                         top_before_distinct: false,
-                        projection: vec![SelectItem::UnnamedExpr(Expr::Value((number("1")).with_empty_span()))],
+                        projection: vec![SelectItem::UnnamedExpr(Expr::Value(
+                            (number("1")).with_empty_span()
+                        ))],
                         into: None,
                         from: vec![],
                         lateral_views: vec![],
@@ -2678,7 +2707,9 @@ fn parse_array_subquery_expr() {
                         distinct: None,
                         top: None,
                         top_before_distinct: false,
-                        projection: vec![SelectItem::UnnamedExpr(Expr::Value((number("2")).with_empty_span()))],
+                        projection: vec![SelectItem::UnnamedExpr(Expr::Value(
+                            (number("2")).with_empty_span()
+                        ))],
                         into: None,
                         from: vec![],
                         lateral_views: vec![],
@@ -2750,7 +2781,9 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("params"))),
             op: BinaryOperator::LongArrow,
-            right: Box::new(Expr::Value((Value::SingleQuotedString("name".to_string())).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("name".to_string())).with_empty_span()
+            )),
         }),
         select.projection[0]
     );
@@ -2761,7 +2794,9 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("params"))),
             op: BinaryOperator::Arrow,
-            right: Box::new(Expr::Value((Value::SingleQuotedString("name".to_string())).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("name".to_string())).with_empty_span()
+            )),
         }),
         select.projection[0]
     );
@@ -2773,12 +2808,14 @@ fn test_json() {
             left: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("info"))),
                 op: BinaryOperator::Arrow,
-                right: Box::new(Expr::Value((Value::SingleQuotedString("items".to_string())).with_empty_span()))
+                right: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("items".to_string())).with_empty_span()
+                ))
             }),
             op: BinaryOperator::LongArrow,
-            right: Box::new(Expr::Value((Value::SingleQuotedString(
-                "product".to_string()
-            )).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("product".to_string())).with_empty_span()
+            )),
         }),
         select.projection[0]
     );
@@ -2829,9 +2866,9 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("info"))),
             op: BinaryOperator::HashArrow,
-            right: Box::new(Expr::Value((Value::SingleQuotedString(
-                "{a,b,c}".to_string()
-            )).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("{a,b,c}".to_string())).with_empty_span()
+            )),
         }),
         select.projection[0]
     );
@@ -2842,9 +2879,9 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("info"))),
             op: BinaryOperator::HashLongArrow,
-            right: Box::new(Expr::Value((Value::SingleQuotedString(
-                "{a,b,c}".to_string()
-            )).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("{a,b,c}".to_string())).with_empty_span()
+            )),
         }),
         select.projection[0]
     );
@@ -2855,9 +2892,9 @@ fn test_json() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("info"))),
             op: BinaryOperator::AtArrow,
-            right: Box::new(Expr::Value((Value::SingleQuotedString(
-                "{\"a\": 1}".to_string()
-            )).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("{\"a\": 1}".to_string())).with_empty_span()
+            )),
         },
         select.selection.unwrap(),
     );
@@ -2866,9 +2903,9 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         Expr::BinaryOp {
-            left: Box::new(Expr::Value((Value::SingleQuotedString(
-                "{\"a\": 1}".to_string()
-            )).with_empty_span())),
+            left: Box::new(Expr::Value(
+                (Value::SingleQuotedString("{\"a\": 1}".to_string())).with_empty_span()
+            )),
             op: BinaryOperator::ArrowAt,
             right: Box::new(Expr::Identifier(Ident::new("info"))),
         },
@@ -2898,7 +2935,9 @@ fn test_json() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::from("info"))),
             op: BinaryOperator::AtQuestion,
-            right: Box::new(Expr::Value((Value::SingleQuotedString("$.a".to_string())).with_empty_span()),),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("$.a".to_string())).with_empty_span()
+            ),),
         },
         select.selection.unwrap(),
     );
@@ -2909,7 +2948,9 @@ fn test_json() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::from("info"))),
             op: BinaryOperator::AtAt,
-            right: Box::new(Expr::Value((Value::SingleQuotedString("$.a".to_string())).with_empty_span()),),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("$.a".to_string())).with_empty_span()
+            ),),
         },
         select.selection.unwrap(),
     );
@@ -2920,7 +2961,9 @@ fn test_json() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("info"))),
             op: BinaryOperator::Question,
-            right: Box::new(Expr::Value((Value::SingleQuotedString("b".to_string())).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("b".to_string())).with_empty_span()
+            )),
         },
         select.selection.unwrap(),
     );
@@ -3045,8 +3088,12 @@ fn test_composite_value() {
                     args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Array(
                         Array {
                             elem: vec![
-                                Expr::Value((Value::SingleQuotedString("i".to_string())).with_empty_span()),
-                                Expr::Value((Value::SingleQuotedString("i".to_string())).with_empty_span()),
+                                Expr::Value(
+                                    (Value::SingleQuotedString("i".to_string())).with_empty_span()
+                                ),
+                                Expr::Value(
+                                    (Value::SingleQuotedString("i".to_string())).with_empty_span()
+                                ),
                             ],
                             named: true
                         }
@@ -3310,7 +3357,9 @@ fn parse_custom_operator() {
                 "pg_catalog".into(),
                 "~".into()
             ]),
-            right: Box::new(Expr::Value((Value::SingleQuotedString("^(table)$".into())).with_empty_span()))
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("^(table)$".into())).with_empty_span()
+            ))
         })
     );
 
@@ -3326,7 +3375,9 @@ fn parse_custom_operator() {
                 span: Span::empty(),
             })),
             op: BinaryOperator::PGCustomBinaryOperator(vec!["pg_catalog".into(), "~".into()]),
-            right: Box::new(Expr::Value((Value::SingleQuotedString("^(table)$".into())).with_empty_span()))
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("^(table)$".into())).with_empty_span()
+            ))
         })
     );
 
@@ -3342,7 +3393,9 @@ fn parse_custom_operator() {
                 span: Span::empty(),
             })),
             op: BinaryOperator::PGCustomBinaryOperator(vec!["~".into()]),
-            right: Box::new(Expr::Value((Value::SingleQuotedString("^(table)$".into())).with_empty_span()))
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("^(table)$".into())).with_empty_span()
+            ))
         })
     );
 }
@@ -3428,9 +3481,9 @@ fn parse_create_role() {
             assert_eq!(*bypassrls, Some(true));
             assert_eq!(
                 *password,
-                Some(Password::Password(Expr::Value((Value::SingleQuotedString(
-                    "abcdef".into()
-                )).with_empty_span())))
+                Some(Password::Password(Expr::Value(
+                    (Value::SingleQuotedString("abcdef".into())).with_empty_span()
+                )))
             );
             assert_eq!(*superuser, Some(true));
             assert_eq!(*create_db, Some(false));
@@ -3439,7 +3492,9 @@ fn parse_create_role() {
             assert_eq!(*connection_limit, None);
             assert_eq!(
                 *valid_until,
-                Some(Expr::Value((Value::SingleQuotedString("2025-01-01".into())).with_empty_span()))
+                Some(Expr::Value(
+                    (Value::SingleQuotedString("2025-01-01".into())).with_empty_span()
+                ))
             );
             assert_eq_vec(&["role1", "role2"], in_role);
             assert!(in_group.is_empty());
@@ -3523,11 +3578,13 @@ fn parse_alter_role() {
                     RoleOption::BypassRLS(true),
                     RoleOption::ConnectionLimit(Expr::Value((number("100")).with_empty_span())),
                     RoleOption::Password({
-                        Password::Password(Expr::Value((Value::SingleQuotedString("abcdef".into())).with_empty_span()))
+                        Password::Password(Expr::Value(
+                            (Value::SingleQuotedString("abcdef".into())).with_empty_span(),
+                        ))
                     }),
-                    RoleOption::ValidUntil(Expr::Value((Value::SingleQuotedString(
-                        "2025-01-01".into(),
-                    )).with_empty_span()))
+                    RoleOption::ValidUntil(Expr::Value(
+                        (Value::SingleQuotedString("2025-01-01".into(),)).with_empty_span()
+                    ))
                 ]
             },
         }
@@ -3593,7 +3650,9 @@ fn parse_alter_role() {
                     quote_style: None,
                     span: Span::empty(),
                 }]),
-                config_value: SetConfigValue::Value(Expr::Value((number("100000")).with_empty_span())),
+                config_value: SetConfigValue::Value(Expr::Value(
+                    (number("100000")).with_empty_span()
+                )),
                 in_database: Some(ObjectName::from(vec![Ident {
                     value: "database_name".into(),
                     quote_style: None,
@@ -3618,7 +3677,9 @@ fn parse_alter_role() {
                     quote_style: None,
                     span: Span::empty(),
                 }]),
-                config_value: SetConfigValue::Value(Expr::Value((number("100000")).with_empty_span())),
+                config_value: SetConfigValue::Value(Expr::Value(
+                    (number("100000")).with_empty_span()
+                )),
                 in_database: Some(ObjectName::from(vec![Ident {
                     value: "database_name".into(),
                     quote_style: None,
@@ -3798,9 +3859,9 @@ fn parse_create_function() {
             behavior: Some(FunctionBehavior::Immutable),
             called_on_null: Some(FunctionCalledOnNull::Strict),
             parallel: Some(FunctionParallel::Safe),
-            function_body: Some(CreateFunctionBody::AsBeforeOptions(Expr::Value((
-                Value::SingleQuotedString("select $1 + $2;".into())
-            ).with_empty_span()))),
+            function_body: Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+                (Value::SingleQuotedString("select $1 + $2;".into())).with_empty_span()
+            ))),
             if_not_exists: false,
             using: None,
             determinism_specifier: None,
@@ -3862,7 +3923,9 @@ fn parse_drop_function() {
                         mode: Some(ArgMode::In),
                         name: Some("b".into()),
                         data_type: DataType::Integer(None),
-                        default_expr: Some(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
+                        default_expr: Some(Expr::Value(
+                            (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                        )),
                     }
                 ]),
             }],
@@ -3888,10 +3951,9 @@ fn parse_drop_function() {
                             mode: Some(ArgMode::In),
                             name: Some("b".into()),
                             data_type: DataType::Integer(None),
-                            default_expr: Some(Expr::Value((Value::Number(
-                                "1".parse().unwrap(),
-                                false
-                            )).with_empty_span())),
+                            default_expr: Some(Expr::Value(
+                                (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                            )),
                         }
                     ]),
                 },
@@ -3907,10 +3969,9 @@ fn parse_drop_function() {
                             mode: Some(ArgMode::In),
                             name: Some("b".into()),
                             data_type: DataType::Integer(None),
-                            default_expr: Some(Expr::Value((Value::Number(
-                                "1".parse().unwrap(),
-                                false
-                            )).with_empty_span())),
+                            default_expr: Some(Expr::Value(
+                                (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                            )),
                         }
                     ]),
                 }
@@ -3956,7 +4017,9 @@ fn parse_drop_procedure() {
                         mode: Some(ArgMode::In),
                         name: Some("b".into()),
                         data_type: DataType::Integer(None),
-                        default_expr: Some(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
+                        default_expr: Some(Expr::Value(
+                            (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                        )),
                     }
                 ]),
             }],
@@ -3982,10 +4045,9 @@ fn parse_drop_procedure() {
                             mode: Some(ArgMode::In),
                             name: Some("b".into()),
                             data_type: DataType::Integer(None),
-                            default_expr: Some(Expr::Value((Value::Number(
-                                "1".parse().unwrap(),
-                                false
-                            )).with_empty_span())),
+                            default_expr: Some(Expr::Value(
+                                (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                            )),
                         }
                     ]),
                 },
@@ -4001,10 +4063,9 @@ fn parse_drop_procedure() {
                             mode: Some(ArgMode::In),
                             name: Some("b".into()),
                             data_type: DataType::Integer(None),
-                            default_expr: Some(Expr::Value((Value::Number(
-                                "1".parse().unwrap(),
-                                false
-                            )).with_empty_span())),
+                            default_expr: Some(Expr::Value(
+                                (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                            )),
                         }
                     ]),
                 }
@@ -4041,36 +4102,48 @@ fn parse_dollar_quoted_string() {
     };
 
     assert_eq!(
-        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
-            tag: None,
-            value: "hello".into()
-        })).with_empty_span()),
+        &Expr::Value(
+            (Value::DollarQuotedString(DollarQuotedString {
+                tag: None,
+                value: "hello".into()
+            }))
+            .with_empty_span()
+        ),
         expr_from_projection(&projection[0])
     );
 
     assert_eq!(
-        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
-            tag: Some("tag_name".into()),
-            value: "world".into()
-        })).with_empty_span()),
+        &Expr::Value(
+            (Value::DollarQuotedString(DollarQuotedString {
+                tag: Some("tag_name".into()),
+                value: "world".into()
+            }))
+            .with_empty_span()
+        ),
         expr_from_projection(&projection[1])
     );
 
     assert_eq!(
-        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
-            tag: None,
-            value: "Foo$Bar".into()
-        })).with_empty_span()),
+        &Expr::Value(
+            (Value::DollarQuotedString(DollarQuotedString {
+                tag: None,
+                value: "Foo$Bar".into()
+            }))
+            .with_empty_span()
+        ),
         expr_from_projection(&projection[2])
     );
 
     assert_eq!(
         projection[3],
         SelectItem::ExprWithAlias {
-            expr: Expr::Value((Value::DollarQuotedString(DollarQuotedString {
-                tag: None,
-                value: "Foo$Bar".into(),
-            })).with_empty_span()),
+            expr: Expr::Value(
+                (Value::DollarQuotedString(DollarQuotedString {
+                    tag: None,
+                    value: "Foo$Bar".into(),
+                }))
+                .with_empty_span()
+            ),
             alias: Ident {
                 value: "col_name".into(),
                 quote_style: None,
@@ -4081,18 +4154,24 @@ fn parse_dollar_quoted_string() {
 
     assert_eq!(
         expr_from_projection(&projection[4]),
-        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
-            tag: None,
-            value: "".into()
-        })).with_empty_span()),
+        &Expr::Value(
+            (Value::DollarQuotedString(DollarQuotedString {
+                tag: None,
+                value: "".into()
+            }))
+            .with_empty_span()
+        ),
     );
 
     assert_eq!(
         expr_from_projection(&projection[5]),
-        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
-            tag: Some("tag_name".into()),
-            value: "".into()
-        })).with_empty_span()),
+        &Expr::Value(
+            (Value::DollarQuotedString(DollarQuotedString {
+                tag: Some("tag_name".into()),
+                value: "".into()
+            }))
+            .with_empty_span()
+        ),
     );
 }
 
@@ -4508,10 +4587,10 @@ fn test_simple_postgres_insert_with_alias() {
                     explicit_row: false,
                     rows: vec![vec![
                         Expr::Identifier(Ident::new("DEFAULT")),
-                        Expr::Value((Value::Number(
-                            bigdecimal::BigDecimal::new(123.into(), 0),
-                            false
-                        )).with_empty_span())
+                        Expr::Value(
+                            (Value::Number(bigdecimal::BigDecimal::new(123.into(), 0), false))
+                                .with_empty_span()
+                        )
                     ]]
                 })),
                 order_by: None,
@@ -4580,7 +4659,9 @@ fn test_simple_insert_with_quoted_alias() {
                     explicit_row: false,
                     rows: vec![vec![
                         Expr::Identifier(Ident::new("DEFAULT")),
-                        Expr::Value((Value::SingleQuotedString("0123".to_string())).with_empty_span())
+                        Expr::Value(
+                            (Value::SingleQuotedString("0123".to_string())).with_empty_span()
+                        )
                     ]]
                 })),
                 order_by: None,
@@ -4650,18 +4731,18 @@ fn parse_at_time_zone() {
             }),
             time_zone: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value(Value::SingleQuotedString(
-                    "America/Los_Angeles".to_owned(),
-                ).with_empty_span())),
+                expr: Box::new(Expr::Value(
+                    Value::SingleQuotedString("America/Los_Angeles".to_owned()).with_empty_span(),
+                )),
                 data_type: DataType::Text,
                 format: None,
             }),
         }),
         op: BinaryOperator::Plus,
         right: Box::new(Expr::Interval(Interval {
-            value: Box::new(Expr::Value(Value::SingleQuotedString(
-                "23 hours".to_owned(),
-            ).with_empty_span())),
+            value: Box::new(Expr::Value(
+                Value::SingleQuotedString("23 hours".to_owned()).with_empty_span(),
+            )),
             leading_field: None,
             leading_precision: None,
             last_field: None,
@@ -4685,7 +4766,9 @@ fn parse_create_table_with_options() {
                 vec![
                     SqlOption::KeyValue {
                         key: "foo".into(),
-                        value: Expr::Value((Value::SingleQuotedString("bar".into())).with_empty_span()),
+                        value: Expr::Value(
+                            (Value::SingleQuotedString("bar".into())).with_empty_span()
+                        ),
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
@@ -4735,7 +4818,10 @@ fn test_table_unnest_with_ordinality() {
 #[test]
 fn test_escaped_string_literal() {
     match pg().verified_expr(r#"E'\n'"#) {
-        Expr::Value(ValueWithSpan{value: Value::EscapedStringLiteral(s), span: _}) => {
+        Expr::Value(ValueWithSpan {
+            value: Value::EscapedStringLiteral(s),
+            span: _,
+        }) => {
             assert_eq!("\n", s);
         }
         _ => unreachable!(),
@@ -5231,7 +5317,10 @@ fn test_unicode_string_literal() {
     ];
     for (input, expected) in pairs {
         match pg_and_generic().verified_expr(input) {
-            Expr::Value(ValueWithSpan{value: Value::UnicodeStringLiteral(s), span: _}) => {
+            Expr::Value(ValueWithSpan {
+                value: Value::UnicodeStringLiteral(s),
+                span: _,
+            }) => {
                 assert_eq!(expected, s);
             }
             _ => unreachable!(),
@@ -5250,10 +5339,14 @@ fn check_arrow_precedence(sql: &str, arrow_operator: BinaryOperator) {
                     span: Span::empty(),
                 })),
                 op: arrow_operator,
-                right: Box::new(Expr::Value((Value::SingleQuotedString("bar".to_string())).with_empty_span())),
+                right: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("bar".to_string())).with_empty_span()
+                )),
             }),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value((Value::SingleQuotedString("spam".to_string())).with_empty_span())),
+            right: Box::new(Expr::Value(
+                (Value::SingleQuotedString("spam".to_string())).with_empty_span()
+            )),
         }
     )
 }
@@ -5283,7 +5376,9 @@ fn arrow_cast_precedence() {
             op: BinaryOperator::Arrow,
             right: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value((Value::SingleQuotedString("bar".to_string())).with_empty_span())),
+                expr: Box::new(Expr::Value(
+                    (Value::SingleQuotedString("bar".to_string())).with_empty_span()
+                )),
                 data_type: DataType::Text,
                 format: None,
             }),
@@ -5409,9 +5504,9 @@ fn parse_bitstring_literal() {
     let select = pg_and_generic().verified_only_select("SELECT B'111'");
     assert_eq!(
         select.projection,
-        vec![SelectItem::UnnamedExpr(Expr::Value((
-            Value::SingleQuotedByteStringLiteral("111".to_string())
-        ).with_empty_span()))]
+        vec![SelectItem::UnnamedExpr(Expr::Value(
+            (Value::SingleQuotedByteStringLiteral("111".to_string())).with_empty_span()
+        ))]
     );
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -436,7 +436,7 @@ fn parse_create_table_with_defaults() {
                         options: vec![
                             ColumnOptionDef {
                                 name: None,
-                                option: ColumnOption::Default(Expr::Value(Value::Boolean(true))),
+                                option: ColumnOption::Default(Expr::Value((Value::Boolean(true)).with_empty_span())),
                             },
                             ColumnOptionDef {
                                 name: None,
@@ -488,15 +488,15 @@ fn parse_create_table_with_defaults() {
                 vec![
                     SqlOption::KeyValue {
                         key: "fillfactor".into(),
-                        value: Expr::Value(number("20"))
+                        value: Expr::Value((number("20")).with_empty_span())
                     },
                     SqlOption::KeyValue {
                         key: "user_catalog_table".into(),
-                        value: Expr::Value(Value::Boolean(true))
+                        value: Expr::Value((Value::Boolean(true)).with_empty_span())
                     },
                     SqlOption::KeyValue {
                         key: "autovacuum_vacuum_threshold".into(),
-                        value: Expr::Value(number("100"))
+                        value: Expr::Value((number("100")).with_empty_span())
                     },
                 ]
             );
@@ -1280,7 +1280,7 @@ fn parse_copy_to() {
                     top_before_distinct: false,
                     projection: vec![
                         SelectItem::ExprWithAlias {
-                            expr: Expr::Value(number("42")),
+                            expr: Expr::Value((number("42")).with_empty_span()),
                             alias: Ident {
                                 value: "a".into(),
                                 quote_style: None,
@@ -1288,7 +1288,7 @@ fn parse_copy_to() {
                             },
                         },
                         SelectItem::ExprWithAlias {
-                            expr: Expr::Value(Value::SingleQuotedString("hello".into())),
+                            expr: Expr::Value((Value::SingleQuotedString("hello".into())).with_empty_span()),
                             alias: Ident {
                                 value: "b".into(),
                                 quote_style: None,
@@ -1446,7 +1446,7 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variables: OneOrManyWithParens::One(ObjectName::from(vec![Ident::new("a")])),
-            value: vec![Expr::Value(Value::SingleQuotedString("b".into()))],
+            value: vec![Expr::Value((Value::SingleQuotedString("b".into())).with_empty_span())],
         }
     );
 
@@ -1457,7 +1457,7 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variables: OneOrManyWithParens::One(ObjectName::from(vec![Ident::new("a")])),
-            value: vec![Expr::Value(number("0"))],
+            value: vec![Expr::Value((number("0")).with_empty_span())],
         }
     );
 
@@ -1518,7 +1518,7 @@ fn parse_set() {
                 Ident::new("reducer"),
                 Ident::new("parallelism")
             ])),
-            value: vec![Expr::Value(Value::Boolean(false))],
+            value: vec![Expr::Value((Value::Boolean(false)).with_empty_span())],
         }
     );
 
@@ -1670,8 +1670,8 @@ fn parse_execute() {
         Statement::Execute {
             name: Some(ObjectName::from(vec!["a".into()])),
             parameters: vec![
-                Expr::Value(number("1")),
-                Expr::Value(Value::SingleQuotedString("t".to_string()))
+                Expr::Value((number("1")).with_empty_span()),
+                Expr::Value((Value::SingleQuotedString("t".to_string())).with_empty_span())
             ],
             has_parentheses: true,
             using: vec![],
@@ -1692,7 +1692,7 @@ fn parse_execute() {
                 ExprWithAlias {
                     expr: Expr::Cast {
                         kind: CastKind::Cast,
-                        expr: Box::new(Expr::Value(Value::Number("1337".parse().unwrap(), false))),
+                        expr: Box::new(Expr::Value((Value::Number("1337".parse().unwrap(), false)).with_empty_span())),
                         data_type: DataType::SmallInt(None),
                         format: None
                     },
@@ -1701,7 +1701,7 @@ fn parse_execute() {
                 ExprWithAlias {
                     expr: Expr::Cast {
                         kind: CastKind::Cast,
-                        expr: Box::new(Expr::Value(Value::Number("7331".parse().unwrap(), false))),
+                        expr: Box::new(Expr::Value((Value::Number("7331".parse().unwrap(), false)).with_empty_span())),
                         data_type: DataType::SmallInt(None),
                         format: None
                     },
@@ -1899,7 +1899,7 @@ fn parse_pg_on_conflict() {
                         target: AssignmentTarget::ColumnName(ObjectName::from(
                             vec!["dname".into()]
                         )),
-                        value: Expr::Value(Value::Placeholder("$1".to_string()))
+                        value: Expr::Value((Value::Placeholder("$1".to_string())).with_empty_span())
                     },],
                     selection: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident {
@@ -1908,7 +1908,7 @@ fn parse_pg_on_conflict() {
                             span: Span::empty(),
                         })),
                         op: BinaryOperator::Gt,
-                        right: Box::new(Expr::Value(Value::Placeholder("$2".to_string())))
+                        right: Box::new(Expr::Value((Value::Placeholder("$2".to_string())).with_empty_span()))
                     })
                 }),
                 action
@@ -1942,7 +1942,7 @@ fn parse_pg_on_conflict() {
                         target: AssignmentTarget::ColumnName(ObjectName::from(
                             vec!["dname".into()]
                         )),
-                        value: Expr::Value(Value::Placeholder("$1".to_string()))
+                        value: Expr::Value((Value::Placeholder("$1".to_string())).with_empty_span())
                     },],
                     selection: Some(Expr::BinaryOp {
                         left: Box::new(Expr::Identifier(Ident {
@@ -1951,7 +1951,7 @@ fn parse_pg_on_conflict() {
                             span: Span::empty(),
                         })),
                         op: BinaryOperator::Gt,
-                        right: Box::new(Expr::Value(Value::Placeholder("$2".to_string())))
+                        right: Box::new(Expr::Value((Value::Placeholder("$2".to_string())).with_empty_span()))
                     })
                 }),
                 action
@@ -2167,9 +2167,9 @@ fn parse_pg_regex_match_ops() {
         let select = pg().verified_only_select(&format!("SELECT 'abc' {} '^a'", &str_op));
         assert_eq!(
             SelectItem::UnnamedExpr(Expr::BinaryOp {
-                left: Box::new(Expr::Value(Value::SingleQuotedString("abc".into()))),
+                left: Box::new(Expr::Value((Value::SingleQuotedString("abc".into())).with_empty_span())),
                 op: op.clone(),
-                right: Box::new(Expr::Value(Value::SingleQuotedString("^a".into()))),
+                right: Box::new(Expr::Value((Value::SingleQuotedString("^a".into())).with_empty_span())),
             }),
             select.projection[0]
         );
@@ -2189,9 +2189,9 @@ fn parse_pg_like_match_ops() {
         let select = pg().verified_only_select(&format!("SELECT 'abc' {} 'a_c%'", &str_op));
         assert_eq!(
             SelectItem::UnnamedExpr(Expr::BinaryOp {
-                left: Box::new(Expr::Value(Value::SingleQuotedString("abc".into()))),
+                left: Box::new(Expr::Value((Value::SingleQuotedString("abc".into())).with_empty_span())),
                 op: op.clone(),
-                right: Box::new(Expr::Value(Value::SingleQuotedString("a_c%".into()))),
+                right: Box::new(Expr::Value((Value::SingleQuotedString("a_c%".into())).with_empty_span())),
             }),
             select.projection[0]
         );
@@ -2400,19 +2400,19 @@ fn parse_array_multi_subscript() {
             root: Box::new(call(
                 "make_array",
                 vec![
-                    Expr::Value(number("1")),
-                    Expr::Value(number("2")),
-                    Expr::Value(number("3"))
+                    Expr::Value((number("1")).with_empty_span()),
+                    Expr::Value((number("2")).with_empty_span()),
+                    Expr::Value((number("3")).with_empty_span())
                 ]
             )),
             access_chain: vec![
                 AccessExpr::Subscript(Subscript::Slice {
-                    lower_bound: Some(Expr::Value(number("1"))),
-                    upper_bound: Some(Expr::Value(number("2"))),
+                    lower_bound: Some(Expr::Value((number("1")).with_empty_span())),
+                    upper_bound: Some(Expr::Value((number("2")).with_empty_span())),
                     stride: None,
                 }),
                 AccessExpr::Subscript(Subscript::Index {
-                    index: Expr::Value(number("2")),
+                    index: Expr::Value((number("2")).with_empty_span()),
                 }),
             ],
         },
@@ -2655,7 +2655,7 @@ fn parse_array_subquery_expr() {
                         distinct: None,
                         top: None,
                         top_before_distinct: false,
-                        projection: vec![SelectItem::UnnamedExpr(Expr::Value(number("1")))],
+                        projection: vec![SelectItem::UnnamedExpr(Expr::Value((number("1")).with_empty_span()))],
                         into: None,
                         from: vec![],
                         lateral_views: vec![],
@@ -2678,7 +2678,7 @@ fn parse_array_subquery_expr() {
                         distinct: None,
                         top: None,
                         top_before_distinct: false,
-                        projection: vec![SelectItem::UnnamedExpr(Expr::Value(number("2")))],
+                        projection: vec![SelectItem::UnnamedExpr(Expr::Value((number("2")).with_empty_span()))],
                         into: None,
                         from: vec![],
                         lateral_views: vec![],
@@ -2750,7 +2750,7 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("params"))),
             op: BinaryOperator::LongArrow,
-            right: Box::new(Expr::Value(Value::SingleQuotedString("name".to_string()))),
+            right: Box::new(Expr::Value((Value::SingleQuotedString("name".to_string())).with_empty_span())),
         }),
         select.projection[0]
     );
@@ -2761,7 +2761,7 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("params"))),
             op: BinaryOperator::Arrow,
-            right: Box::new(Expr::Value(Value::SingleQuotedString("name".to_string()))),
+            right: Box::new(Expr::Value((Value::SingleQuotedString("name".to_string())).with_empty_span())),
         }),
         select.projection[0]
     );
@@ -2773,12 +2773,12 @@ fn test_json() {
             left: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("info"))),
                 op: BinaryOperator::Arrow,
-                right: Box::new(Expr::Value(Value::SingleQuotedString("items".to_string())))
+                right: Box::new(Expr::Value((Value::SingleQuotedString("items".to_string())).with_empty_span()))
             }),
             op: BinaryOperator::LongArrow,
-            right: Box::new(Expr::Value(Value::SingleQuotedString(
+            right: Box::new(Expr::Value((Value::SingleQuotedString(
                 "product".to_string()
-            ))),
+            )).with_empty_span())),
         }),
         select.projection[0]
     );
@@ -2790,7 +2790,7 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("obj"))),
             op: BinaryOperator::Arrow,
-            right: Box::new(Expr::Value(number("42"))),
+            right: Box::new(Expr::Value((number("42")).with_empty_span())),
         }),
         select.projection[0]
     );
@@ -2815,9 +2815,9 @@ fn test_json() {
             left: Box::new(Expr::Identifier(Ident::new("obj"))),
             op: BinaryOperator::Arrow,
             right: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value(number("3"))),
+                left: Box::new(Expr::Value((number("3")).with_empty_span())),
                 op: BinaryOperator::Multiply,
-                right: Box::new(Expr::Value(number("2"))),
+                right: Box::new(Expr::Value((number("2")).with_empty_span())),
             }),
         }),
         select.projection[0]
@@ -2829,9 +2829,9 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("info"))),
             op: BinaryOperator::HashArrow,
-            right: Box::new(Expr::Value(Value::SingleQuotedString(
+            right: Box::new(Expr::Value((Value::SingleQuotedString(
                 "{a,b,c}".to_string()
-            ))),
+            )).with_empty_span())),
         }),
         select.projection[0]
     );
@@ -2842,9 +2842,9 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("info"))),
             op: BinaryOperator::HashLongArrow,
-            right: Box::new(Expr::Value(Value::SingleQuotedString(
+            right: Box::new(Expr::Value((Value::SingleQuotedString(
                 "{a,b,c}".to_string()
-            ))),
+            )).with_empty_span())),
         }),
         select.projection[0]
     );
@@ -2855,9 +2855,9 @@ fn test_json() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("info"))),
             op: BinaryOperator::AtArrow,
-            right: Box::new(Expr::Value(Value::SingleQuotedString(
+            right: Box::new(Expr::Value((Value::SingleQuotedString(
                 "{\"a\": 1}".to_string()
-            ))),
+            )).with_empty_span())),
         },
         select.selection.unwrap(),
     );
@@ -2866,9 +2866,9 @@ fn test_json() {
     let select = pg().verified_only_select(sql);
     assert_eq!(
         Expr::BinaryOp {
-            left: Box::new(Expr::Value(Value::SingleQuotedString(
+            left: Box::new(Expr::Value((Value::SingleQuotedString(
                 "{\"a\": 1}".to_string()
-            ))),
+            )).with_empty_span())),
             op: BinaryOperator::ArrowAt,
             right: Box::new(Expr::Identifier(Ident::new("info"))),
         },
@@ -2883,8 +2883,8 @@ fn test_json() {
             op: BinaryOperator::HashMinus,
             right: Box::new(Expr::Array(Array {
                 elem: vec![
-                    Expr::Value(Value::SingleQuotedString("a".to_string())),
-                    Expr::Value(Value::SingleQuotedString("b".to_string())),
+                    Expr::Value((Value::SingleQuotedString("a".to_string())).with_empty_span()),
+                    Expr::Value((Value::SingleQuotedString("b".to_string())).with_empty_span()),
                 ],
                 named: true,
             })),
@@ -2898,7 +2898,7 @@ fn test_json() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::from("info"))),
             op: BinaryOperator::AtQuestion,
-            right: Box::new(Expr::Value(Value::SingleQuotedString("$.a".to_string())),),
+            right: Box::new(Expr::Value((Value::SingleQuotedString("$.a".to_string())).with_empty_span()),),
         },
         select.selection.unwrap(),
     );
@@ -2909,7 +2909,7 @@ fn test_json() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::from("info"))),
             op: BinaryOperator::AtAt,
-            right: Box::new(Expr::Value(Value::SingleQuotedString("$.a".to_string())),),
+            right: Box::new(Expr::Value((Value::SingleQuotedString("$.a".to_string())).with_empty_span()),),
         },
         select.selection.unwrap(),
     );
@@ -2920,7 +2920,7 @@ fn test_json() {
         Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("info"))),
             op: BinaryOperator::Question,
-            right: Box::new(Expr::Value(Value::SingleQuotedString("b".to_string()))),
+            right: Box::new(Expr::Value((Value::SingleQuotedString("b".to_string())).with_empty_span())),
         },
         select.selection.unwrap(),
     );
@@ -2933,8 +2933,8 @@ fn test_json() {
             op: BinaryOperator::QuestionAnd,
             right: Box::new(Expr::Array(Array {
                 elem: vec![
-                    Expr::Value(Value::SingleQuotedString("b".to_string())),
-                    Expr::Value(Value::SingleQuotedString("c".to_string()))
+                    Expr::Value((Value::SingleQuotedString("b".to_string())).with_empty_span()),
+                    Expr::Value((Value::SingleQuotedString("c".to_string())).with_empty_span())
                 ],
                 named: true
             }))
@@ -2950,8 +2950,8 @@ fn test_json() {
             op: BinaryOperator::QuestionPipe,
             right: Box::new(Expr::Array(Array {
                 elem: vec![
-                    Expr::Value(Value::SingleQuotedString("b".to_string())),
-                    Expr::Value(Value::SingleQuotedString("c".to_string()))
+                    Expr::Value((Value::SingleQuotedString("b".to_string())).with_empty_span()),
+                    Expr::Value((Value::SingleQuotedString("c".to_string())).with_empty_span())
                 ],
                 named: true
             }))
@@ -3025,7 +3025,7 @@ fn test_composite_value() {
                 access_chain: vec![AccessExpr::Dot(Expr::Identifier(Ident::new("price")))]
             }),
             op: BinaryOperator::Gt,
-            right: Box::new(Expr::Value(number("9")))
+            right: Box::new(Expr::Value((number("9")).with_empty_span()))
         }
     );
 
@@ -3045,8 +3045,8 @@ fn test_composite_value() {
                     args: vec![FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Array(
                         Array {
                             elem: vec![
-                                Expr::Value(Value::SingleQuotedString("i".to_string())),
-                                Expr::Value(Value::SingleQuotedString("i".to_string())),
+                                Expr::Value((Value::SingleQuotedString("i".to_string())).with_empty_span()),
+                                Expr::Value((Value::SingleQuotedString("i".to_string())).with_empty_span()),
                             ],
                             named: true
                         }
@@ -3106,27 +3106,27 @@ fn parse_escaped_literal_string() {
     let select = pg_and_generic().verified_only_select(sql);
     assert_eq!(6, select.projection.len());
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("s1 \n s1".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("s1 \n s1".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("s2 \\n s2".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("s2 \\n s2".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[1])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("s3 \\\n s3".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("s3 \\\n s3".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[2])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("s4 \\\\n s4".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("s4 \\\\n s4".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[3])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("'".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("'".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[4])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("foo \\".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("foo \\".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[5])
     );
 
@@ -3144,31 +3144,31 @@ fn parse_escaped_literal_string() {
     let select = pg_and_generic().verified_only_select_with_canonical(sql, canonical);
     assert_eq!(7, select.projection.len());
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("\u{0001}".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("\u{0001}".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[0])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("\u{10ffff}".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("\u{10ffff}".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[1])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("\u{000c}".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("\u{000c}".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[2])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("%".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("%".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[3])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("\u{0002}".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("\u{0002}".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[4])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("%".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("%".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[5])
     );
     assert_eq!(
-        &Expr::Value(Value::EscapedStringLiteral("%".to_string())),
+        &Expr::Value((Value::EscapedStringLiteral("%".to_string())).with_empty_span()),
         expr_from_projection(&select.projection[6])
     );
 
@@ -3310,7 +3310,7 @@ fn parse_custom_operator() {
                 "pg_catalog".into(),
                 "~".into()
             ]),
-            right: Box::new(Expr::Value(Value::SingleQuotedString("^(table)$".into())))
+            right: Box::new(Expr::Value((Value::SingleQuotedString("^(table)$".into())).with_empty_span()))
         })
     );
 
@@ -3326,7 +3326,7 @@ fn parse_custom_operator() {
                 span: Span::empty(),
             })),
             op: BinaryOperator::PGCustomBinaryOperator(vec!["pg_catalog".into(), "~".into()]),
-            right: Box::new(Expr::Value(Value::SingleQuotedString("^(table)$".into())))
+            right: Box::new(Expr::Value((Value::SingleQuotedString("^(table)$".into())).with_empty_span()))
         })
     );
 
@@ -3342,7 +3342,7 @@ fn parse_custom_operator() {
                 span: Span::empty(),
             })),
             op: BinaryOperator::PGCustomBinaryOperator(vec!["~".into()]),
-            right: Box::new(Expr::Value(Value::SingleQuotedString("^(table)$".into())))
+            right: Box::new(Expr::Value((Value::SingleQuotedString("^(table)$".into())).with_empty_span()))
         })
     );
 }
@@ -3428,9 +3428,9 @@ fn parse_create_role() {
             assert_eq!(*bypassrls, Some(true));
             assert_eq!(
                 *password,
-                Some(Password::Password(Expr::Value(Value::SingleQuotedString(
+                Some(Password::Password(Expr::Value((Value::SingleQuotedString(
                     "abcdef".into()
-                ))))
+                )).with_empty_span())))
             );
             assert_eq!(*superuser, Some(true));
             assert_eq!(*create_db, Some(false));
@@ -3439,7 +3439,7 @@ fn parse_create_role() {
             assert_eq!(*connection_limit, None);
             assert_eq!(
                 *valid_until,
-                Some(Expr::Value(Value::SingleQuotedString("2025-01-01".into())))
+                Some(Expr::Value((Value::SingleQuotedString("2025-01-01".into())).with_empty_span()))
             );
             assert_eq_vec(&["role1", "role2"], in_role);
             assert!(in_group.is_empty());
@@ -3521,13 +3521,13 @@ fn parse_alter_role() {
                     RoleOption::Login(true),
                     RoleOption::Replication(true),
                     RoleOption::BypassRLS(true),
-                    RoleOption::ConnectionLimit(Expr::Value(number("100"))),
+                    RoleOption::ConnectionLimit(Expr::Value((number("100")).with_empty_span())),
                     RoleOption::Password({
-                        Password::Password(Expr::Value(Value::SingleQuotedString("abcdef".into())))
+                        Password::Password(Expr::Value((Value::SingleQuotedString("abcdef".into())).with_empty_span()))
                     }),
-                    RoleOption::ValidUntil(Expr::Value(Value::SingleQuotedString(
+                    RoleOption::ValidUntil(Expr::Value((Value::SingleQuotedString(
                         "2025-01-01".into(),
-                    )))
+                    )).with_empty_span()))
                 ]
             },
         }
@@ -3593,7 +3593,7 @@ fn parse_alter_role() {
                     quote_style: None,
                     span: Span::empty(),
                 }]),
-                config_value: SetConfigValue::Value(Expr::Value(number("100000"))),
+                config_value: SetConfigValue::Value(Expr::Value((number("100000")).with_empty_span())),
                 in_database: Some(ObjectName::from(vec![Ident {
                     value: "database_name".into(),
                     quote_style: None,
@@ -3618,7 +3618,7 @@ fn parse_alter_role() {
                     quote_style: None,
                     span: Span::empty(),
                 }]),
-                config_value: SetConfigValue::Value(Expr::Value(number("100000"))),
+                config_value: SetConfigValue::Value(Expr::Value((number("100000")).with_empty_span())),
                 in_database: Some(ObjectName::from(vec![Ident {
                     value: "database_name".into(),
                     quote_style: None,
@@ -3798,9 +3798,9 @@ fn parse_create_function() {
             behavior: Some(FunctionBehavior::Immutable),
             called_on_null: Some(FunctionCalledOnNull::Strict),
             parallel: Some(FunctionParallel::Safe),
-            function_body: Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+            function_body: Some(CreateFunctionBody::AsBeforeOptions(Expr::Value((
                 Value::SingleQuotedString("select $1 + $2;".into())
-            ))),
+            ).with_empty_span()))),
             if_not_exists: false,
             using: None,
             determinism_specifier: None,
@@ -3862,7 +3862,7 @@ fn parse_drop_function() {
                         mode: Some(ArgMode::In),
                         name: Some("b".into()),
                         data_type: DataType::Integer(None),
-                        default_expr: Some(Expr::Value(Value::Number("1".parse().unwrap(), false))),
+                        default_expr: Some(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
                     }
                 ]),
             }],
@@ -3888,10 +3888,10 @@ fn parse_drop_function() {
                             mode: Some(ArgMode::In),
                             name: Some("b".into()),
                             data_type: DataType::Integer(None),
-                            default_expr: Some(Expr::Value(Value::Number(
+                            default_expr: Some(Expr::Value((Value::Number(
                                 "1".parse().unwrap(),
                                 false
-                            ))),
+                            )).with_empty_span())),
                         }
                     ]),
                 },
@@ -3907,10 +3907,10 @@ fn parse_drop_function() {
                             mode: Some(ArgMode::In),
                             name: Some("b".into()),
                             data_type: DataType::Integer(None),
-                            default_expr: Some(Expr::Value(Value::Number(
+                            default_expr: Some(Expr::Value((Value::Number(
                                 "1".parse().unwrap(),
                                 false
-                            ))),
+                            )).with_empty_span())),
                         }
                     ]),
                 }
@@ -3956,7 +3956,7 @@ fn parse_drop_procedure() {
                         mode: Some(ArgMode::In),
                         name: Some("b".into()),
                         data_type: DataType::Integer(None),
-                        default_expr: Some(Expr::Value(Value::Number("1".parse().unwrap(), false))),
+                        default_expr: Some(Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())),
                     }
                 ]),
             }],
@@ -3982,10 +3982,10 @@ fn parse_drop_procedure() {
                             mode: Some(ArgMode::In),
                             name: Some("b".into()),
                             data_type: DataType::Integer(None),
-                            default_expr: Some(Expr::Value(Value::Number(
+                            default_expr: Some(Expr::Value((Value::Number(
                                 "1".parse().unwrap(),
                                 false
-                            ))),
+                            )).with_empty_span())),
                         }
                     ]),
                 },
@@ -4001,10 +4001,10 @@ fn parse_drop_procedure() {
                             mode: Some(ArgMode::In),
                             name: Some("b".into()),
                             data_type: DataType::Integer(None),
-                            default_expr: Some(Expr::Value(Value::Number(
+                            default_expr: Some(Expr::Value((Value::Number(
                                 "1".parse().unwrap(),
                                 false
-                            ))),
+                            )).with_empty_span())),
                         }
                     ]),
                 }
@@ -4041,36 +4041,36 @@ fn parse_dollar_quoted_string() {
     };
 
     assert_eq!(
-        &Expr::Value(Value::DollarQuotedString(DollarQuotedString {
+        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
             tag: None,
             value: "hello".into()
-        })),
+        })).with_empty_span()),
         expr_from_projection(&projection[0])
     );
 
     assert_eq!(
-        &Expr::Value(Value::DollarQuotedString(DollarQuotedString {
+        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
             tag: Some("tag_name".into()),
             value: "world".into()
-        })),
+        })).with_empty_span()),
         expr_from_projection(&projection[1])
     );
 
     assert_eq!(
-        &Expr::Value(Value::DollarQuotedString(DollarQuotedString {
+        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
             tag: None,
             value: "Foo$Bar".into()
-        })),
+        })).with_empty_span()),
         expr_from_projection(&projection[2])
     );
 
     assert_eq!(
         projection[3],
         SelectItem::ExprWithAlias {
-            expr: Expr::Value(Value::DollarQuotedString(DollarQuotedString {
+            expr: Expr::Value((Value::DollarQuotedString(DollarQuotedString {
                 tag: None,
                 value: "Foo$Bar".into(),
-            })),
+            })).with_empty_span()),
             alias: Ident {
                 value: "col_name".into(),
                 quote_style: None,
@@ -4081,18 +4081,18 @@ fn parse_dollar_quoted_string() {
 
     assert_eq!(
         expr_from_projection(&projection[4]),
-        &Expr::Value(Value::DollarQuotedString(DollarQuotedString {
+        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
             tag: None,
             value: "".into()
-        })),
+        })).with_empty_span()),
     );
 
     assert_eq!(
         expr_from_projection(&projection[5]),
-        &Expr::Value(Value::DollarQuotedString(DollarQuotedString {
+        &Expr::Value((Value::DollarQuotedString(DollarQuotedString {
             tag: Some("tag_name".into()),
             value: "".into()
-        })),
+        })).with_empty_span()),
     );
 }
 
@@ -4438,7 +4438,7 @@ fn test_simple_postgres_insert_with_alias() {
                     explicit_row: false,
                     rows: vec![vec![
                         Expr::Identifier(Ident::new("DEFAULT")),
-                        Expr::Value(Value::Number("123".to_string(), false))
+                        Expr::Value((Value::Number("123".to_string(), false)).with_empty_span())
                     ]]
                 })),
                 order_by: None,
@@ -4508,10 +4508,10 @@ fn test_simple_postgres_insert_with_alias() {
                     explicit_row: false,
                     rows: vec![vec![
                         Expr::Identifier(Ident::new("DEFAULT")),
-                        Expr::Value(Value::Number(
+                        Expr::Value((Value::Number(
                             bigdecimal::BigDecimal::new(123.into(), 0),
                             false
-                        ))
+                        )).with_empty_span())
                     ]]
                 })),
                 order_by: None,
@@ -4580,7 +4580,7 @@ fn test_simple_insert_with_quoted_alias() {
                     explicit_row: false,
                     rows: vec![vec![
                         Expr::Identifier(Ident::new("DEFAULT")),
-                        Expr::Value(Value::SingleQuotedString("0123".to_string()))
+                        Expr::Value((Value::SingleQuotedString("0123".to_string())).with_empty_span())
                     ]]
                 })),
                 order_by: None,
@@ -4685,11 +4685,11 @@ fn parse_create_table_with_options() {
                 vec![
                     SqlOption::KeyValue {
                         key: "foo".into(),
-                        value: Expr::Value(Value::SingleQuotedString("bar".into())),
+                        value: Expr::Value((Value::SingleQuotedString("bar".into())).with_empty_span()),
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
-                        value: Expr::Value(number("123")),
+                        value: Expr::Value((number("123")).with_empty_span()),
                     },
                 ],
                 with_options
@@ -4735,7 +4735,7 @@ fn test_table_unnest_with_ordinality() {
 #[test]
 fn test_escaped_string_literal() {
     match pg().verified_expr(r#"E'\n'"#) {
-        Expr::Value(Value::EscapedStringLiteral(s)) => {
+        Expr::Value(ValueWithSpan{value: Value::EscapedStringLiteral(s), span: _}) => {
             assert_eq!("\n", s);
         }
         _ => unreachable!(),
@@ -5155,7 +5155,7 @@ fn parse_trigger_related_functions() {
             return_type: Some(DataType::Trigger),
             function_body: Some(
                 CreateFunctionBody::AsBeforeOptions(
-                    Expr::Value(
+                    Expr::Value((
                         Value::DollarQuotedString(
                             DollarQuotedString {
                                 value: "\n        BEGIN\n            -- Check that empname and salary are given\n            IF NEW.empname IS NULL THEN\n                RAISE EXCEPTION 'empname cannot be null';\n            END IF;\n            IF NEW.salary IS NULL THEN\n                RAISE EXCEPTION '% cannot have null salary', NEW.empname;\n            END IF;\n\n            -- Who works for us when they must pay for it?\n            IF NEW.salary < 0 THEN\n                RAISE EXCEPTION '% cannot have a negative salary', NEW.empname;\n            END IF;\n\n            -- Remember who changed the payroll when\n            NEW.last_date := current_timestamp;\n            NEW.last_user := current_user;\n            RETURN NEW;\n        END;\n    ".to_owned(),
@@ -5163,8 +5163,8 @@ fn parse_trigger_related_functions() {
                                     "emp_stamp".to_owned(),
                                 ),
                             },
-                        ),
-                    ),
+                        )
+                    ).with_empty_span()),
                 ),
             ),
             behavior: None,
@@ -5231,7 +5231,7 @@ fn test_unicode_string_literal() {
     ];
     for (input, expected) in pairs {
         match pg_and_generic().verified_expr(input) {
-            Expr::Value(Value::UnicodeStringLiteral(s)) => {
+            Expr::Value(ValueWithSpan{value: Value::UnicodeStringLiteral(s), span: _}) => {
                 assert_eq!(expected, s);
             }
             _ => unreachable!(),
@@ -5250,10 +5250,10 @@ fn check_arrow_precedence(sql: &str, arrow_operator: BinaryOperator) {
                     span: Span::empty(),
                 })),
                 op: arrow_operator,
-                right: Box::new(Expr::Value(Value::SingleQuotedString("bar".to_string()))),
+                right: Box::new(Expr::Value((Value::SingleQuotedString("bar".to_string())).with_empty_span())),
             }),
             op: BinaryOperator::Eq,
-            right: Box::new(Expr::Value(Value::SingleQuotedString("spam".to_string()))),
+            right: Box::new(Expr::Value((Value::SingleQuotedString("spam".to_string())).with_empty_span())),
         }
     )
 }
@@ -5283,7 +5283,7 @@ fn arrow_cast_precedence() {
             op: BinaryOperator::Arrow,
             right: Box::new(Expr::Cast {
                 kind: CastKind::DoubleColon,
-                expr: Box::new(Expr::Value(Value::SingleQuotedString("bar".to_string()))),
+                expr: Box::new(Expr::Value((Value::SingleQuotedString("bar".to_string())).with_empty_span())),
                 data_type: DataType::Text,
                 format: None,
             }),
@@ -5409,9 +5409,9 @@ fn parse_bitstring_literal() {
     let select = pg_and_generic().verified_only_select("SELECT B'111'");
     assert_eq!(
         select.projection,
-        vec![SelectItem::UnnamedExpr(Expr::Value(
+        vec![SelectItem::UnnamedExpr(Expr::Value((
             Value::SingleQuotedByteStringLiteral("111".to_string())
-        ))]
+        ).with_empty_span()))]
     );
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -490,7 +490,7 @@ fn parse_create_table_with_defaults() {
                 vec![
                     SqlOption::KeyValue {
                         key: "fillfactor".into(),
-                        value: Expr::Value((number("20")).with_empty_span())
+                        value: Expr::value(number("20"))
                     },
                     SqlOption::KeyValue {
                         key: "user_catalog_table".into(),
@@ -498,7 +498,7 @@ fn parse_create_table_with_defaults() {
                     },
                     SqlOption::KeyValue {
                         key: "autovacuum_vacuum_threshold".into(),
-                        value: Expr::Value((number("100")).with_empty_span())
+                        value: Expr::value(number("100"))
                     },
                 ]
             );
@@ -1283,7 +1283,7 @@ fn parse_copy_to() {
                     top_before_distinct: false,
                     projection: vec![
                         SelectItem::ExprWithAlias {
-                            expr: Expr::Value((number("42")).with_empty_span()),
+                            expr: Expr::value(number("42")),
                             alias: Ident {
                                 value: "a".into(),
                                 quote_style: None,
@@ -1464,7 +1464,7 @@ fn parse_set() {
             local: false,
             hivevar: false,
             variables: OneOrManyWithParens::One(ObjectName::from(vec![Ident::new("a")])),
-            value: vec![Expr::Value((number("0")).with_empty_span())],
+            value: vec![Expr::value(number("0"))],
         }
     );
 
@@ -1677,7 +1677,7 @@ fn parse_execute() {
         Statement::Execute {
             name: Some(ObjectName::from(vec!["a".into()])),
             parameters: vec![
-                Expr::Value((number("1")).with_empty_span()),
+                Expr::value(number("1")),
                 Expr::Value((Value::SingleQuotedString("t".to_string())).with_empty_span())
             ],
             has_parentheses: true,
@@ -2339,7 +2339,7 @@ fn parse_array_subscript() {
         (
             "(ARRAY[1, 2, 3, 4, 5, 6])[2]",
             Subscript::Index {
-                index: Expr::Value(number("2").with_empty_span()),
+                index: Expr::value(number("2")),
             },
         ),
         (
@@ -2351,17 +2351,17 @@ fn parse_array_subscript() {
         (
             "(ARRAY[1, 2, 3, 4, 5, 6])[2:5]",
             Subscript::Slice {
-                lower_bound: Some(Expr::Value(number("2").with_empty_span())),
-                upper_bound: Some(Expr::Value(number("5").with_empty_span())),
+                lower_bound: Some(Expr::value(number("2"))),
+                upper_bound: Some(Expr::value(number("5"))),
                 stride: None,
             },
         ),
         (
             "(ARRAY[1, 2, 3, 4, 5, 6])[2:5:3]",
             Subscript::Slice {
-                lower_bound: Some(Expr::Value(number("2").with_empty_span())),
-                upper_bound: Some(Expr::Value(number("5").with_empty_span())),
-                stride: Some(Expr::Value(number("3").with_empty_span())),
+                lower_bound: Some(Expr::value(number("2"))),
+                upper_bound: Some(Expr::value(number("5"))),
+                stride: Some(Expr::value(number("3"))),
             },
         ),
         (
@@ -2370,12 +2370,12 @@ fn parse_array_subscript() {
                 lower_bound: Some(Expr::BinaryOp {
                     left: Box::new(call("array_length", [Expr::Identifier(Ident::new("arr"))])),
                     op: BinaryOperator::Minus,
-                    right: Box::new(Expr::Value(number("3").with_empty_span())),
+                    right: Box::new(Expr::value(number("3"))),
                 }),
                 upper_bound: Some(Expr::BinaryOp {
                     left: Box::new(call("array_length", [Expr::Identifier(Ident::new("arr"))])),
                     op: BinaryOperator::Minus,
-                    right: Box::new(Expr::Value(number("1").with_empty_span())),
+                    right: Box::new(Expr::value(number("1"))),
                 }),
                 stride: None,
             },
@@ -2384,14 +2384,14 @@ fn parse_array_subscript() {
             "(ARRAY[1, 2, 3, 4, 5, 6])[:5]",
             Subscript::Slice {
                 lower_bound: None,
-                upper_bound: Some(Expr::Value(number("5").with_empty_span())),
+                upper_bound: Some(Expr::value(number("5"))),
                 stride: None,
             },
         ),
         (
             "(ARRAY[1, 2, 3, 4, 5, 6])[2:]",
             Subscript::Slice {
-                lower_bound: Some(Expr::Value(number("2").with_empty_span())),
+                lower_bound: Some(Expr::value(number("2"))),
                 upper_bound: None,
                 stride: None,
             },
@@ -2427,19 +2427,19 @@ fn parse_array_multi_subscript() {
             root: Box::new(call(
                 "make_array",
                 vec![
-                    Expr::Value((number("1")).with_empty_span()),
-                    Expr::Value((number("2")).with_empty_span()),
-                    Expr::Value((number("3")).with_empty_span())
+                    Expr::value(number("1")),
+                    Expr::value(number("2")),
+                    Expr::value(number("3"))
                 ]
             )),
             access_chain: vec![
                 AccessExpr::Subscript(Subscript::Slice {
-                    lower_bound: Some(Expr::Value((number("1")).with_empty_span())),
-                    upper_bound: Some(Expr::Value((number("2")).with_empty_span())),
+                    lower_bound: Some(Expr::value(number("1"))),
+                    upper_bound: Some(Expr::value(number("2"))),
                     stride: None,
                 }),
                 AccessExpr::Subscript(Subscript::Index {
-                    index: Expr::Value((number("2")).with_empty_span()),
+                    index: Expr::value(number("2")),
                 }),
             ],
         },
@@ -2827,7 +2827,7 @@ fn test_json() {
         SelectItem::UnnamedExpr(Expr::BinaryOp {
             left: Box::new(Expr::Identifier(Ident::new("obj"))),
             op: BinaryOperator::Arrow,
-            right: Box::new(Expr::Value((number("42")).with_empty_span())),
+            right: Box::new(Expr::value(number("42"))),
         }),
         select.projection[0]
     );
@@ -2852,9 +2852,9 @@ fn test_json() {
             left: Box::new(Expr::Identifier(Ident::new("obj"))),
             op: BinaryOperator::Arrow,
             right: Box::new(Expr::BinaryOp {
-                left: Box::new(Expr::Value((number("3")).with_empty_span())),
+                left: Box::new(Expr::value(number("3"))),
                 op: BinaryOperator::Multiply,
-                right: Box::new(Expr::Value((number("2")).with_empty_span())),
+                right: Box::new(Expr::value(number("2"))),
             }),
         }),
         select.projection[0]
@@ -3068,7 +3068,7 @@ fn test_composite_value() {
                 access_chain: vec![AccessExpr::Dot(Expr::Identifier(Ident::new("price")))]
             }),
             op: BinaryOperator::Gt,
-            right: Box::new(Expr::Value((number("9")).with_empty_span()))
+            right: Box::new(Expr::value(number("9")))
         }
     );
 
@@ -3576,7 +3576,7 @@ fn parse_alter_role() {
                     RoleOption::Login(true),
                     RoleOption::Replication(true),
                     RoleOption::BypassRLS(true),
-                    RoleOption::ConnectionLimit(Expr::Value((number("100")).with_empty_span())),
+                    RoleOption::ConnectionLimit(Expr::value(number("100"))),
                     RoleOption::Password({
                         Password::Password(Expr::Value(
                             (Value::SingleQuotedString("abcdef".into())).with_empty_span(),
@@ -4772,7 +4772,7 @@ fn parse_create_table_with_options() {
                     },
                     SqlOption::KeyValue {
                         key: "a".into(),
-                        value: Expr::Value((number("123")).with_empty_span()),
+                        value: Expr::value(number("123")),
                     },
                 ],
                 with_options
@@ -4876,7 +4876,7 @@ fn parse_create_after_update_trigger_with_condition() {
                 Ident::new("balance"),
             ])),
             op: BinaryOperator::Gt,
-            right: Box::new(Expr::Value(number("10000").with_empty_span())),
+            right: Box::new(Expr::value(number("10000"))),
         }))),
         exec_body: TriggerExecBody {
             exec_type: TriggerExecBodyType::Function,

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -208,7 +208,7 @@ fn test_redshift_json_path() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value(number("0"))
+                        key: Expr::Value((number("0")).with_empty_span())
                     },
                     JsonPathElem::Dot {
                         key: "o_orderkey".to_string(),
@@ -231,10 +231,10 @@ fn test_redshift_json_path() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value(number("0"))
+                        key: Expr::Value((number("0")).with_empty_span())
                     },
                     JsonPathElem::Bracket {
-                        key: Expr::Value(Value::SingleQuotedString("id".to_owned()))
+                        key: Expr::Value((Value::SingleQuotedString("id".to_owned())).with_empty_span())
                     }
                 ]
             }
@@ -255,10 +255,10 @@ fn test_redshift_json_path() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value(number("0"))
+                        key: Expr::Value((number("0")).with_empty_span())
                     },
                     JsonPathElem::Bracket {
-                        key: Expr::Value(Value::SingleQuotedString("id".to_owned()))
+                        key: Expr::Value((Value::SingleQuotedString("id".to_owned())).with_empty_span())
                     }
                 ]
             }
@@ -279,7 +279,7 @@ fn test_redshift_json_path() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value(number("0"))
+                        key: Expr::Value((number("0")).with_empty_span())
                     },
                     JsonPathElem::Dot {
                         key: "id".to_string(),
@@ -306,7 +306,7 @@ fn test_parse_json_path_from() {
                 &Some(JsonPath {
                     path: vec![
                         JsonPathElem::Bracket {
-                            key: Expr::Value(number("0"))
+                            key: Expr::Value((number("0")).with_empty_span())
                         },
                         JsonPathElem::Dot {
                             key: "a".to_string(),
@@ -330,14 +330,14 @@ fn test_parse_json_path_from() {
                 &Some(JsonPath {
                     path: vec![
                         JsonPathElem::Bracket {
-                            key: Expr::Value(number("0"))
+                            key: Expr::Value((number("0")).with_empty_span())
                         },
                         JsonPathElem::Dot {
                             key: "a".to_string(),
                             quoted: false
                         },
                         JsonPathElem::Bracket {
-                            key: Expr::Value(Value::Number("1".parse().unwrap(), false))
+                            key: Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())
                         },
                         JsonPathElem::Dot {
                             key: "b".to_string(),

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -234,7 +234,9 @@ fn test_redshift_json_path() {
                         key: Expr::Value((number("0")).with_empty_span())
                     },
                     JsonPathElem::Bracket {
-                        key: Expr::Value((Value::SingleQuotedString("id".to_owned())).with_empty_span())
+                        key: Expr::Value(
+                            (Value::SingleQuotedString("id".to_owned())).with_empty_span()
+                        )
                     }
                 ]
             }
@@ -258,7 +260,9 @@ fn test_redshift_json_path() {
                         key: Expr::Value((number("0")).with_empty_span())
                     },
                     JsonPathElem::Bracket {
-                        key: Expr::Value((Value::SingleQuotedString("id".to_owned())).with_empty_span())
+                        key: Expr::Value(
+                            (Value::SingleQuotedString("id".to_owned())).with_empty_span()
+                        )
                     }
                 ]
             }
@@ -337,7 +341,9 @@ fn test_parse_json_path_from() {
                             quoted: false
                         },
                         JsonPathElem::Bracket {
-                            key: Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span())
+                            key: Expr::Value(
+                                (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                            )
                         },
                         JsonPathElem::Dot {
                             key: "b".to_string(),

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -208,7 +208,7 @@ fn test_redshift_json_path() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value((number("0")).with_empty_span())
+                        key: Expr::value(number("0"))
                     },
                     JsonPathElem::Dot {
                         key: "o_orderkey".to_string(),
@@ -231,7 +231,7 @@ fn test_redshift_json_path() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value((number("0")).with_empty_span())
+                        key: Expr::value(number("0"))
                     },
                     JsonPathElem::Bracket {
                         key: Expr::Value(
@@ -257,7 +257,7 @@ fn test_redshift_json_path() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value((number("0")).with_empty_span())
+                        key: Expr::value(number("0"))
                     },
                     JsonPathElem::Bracket {
                         key: Expr::Value(
@@ -283,7 +283,7 @@ fn test_redshift_json_path() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value((number("0")).with_empty_span())
+                        key: Expr::value(number("0"))
                     },
                     JsonPathElem::Dot {
                         key: "id".to_string(),
@@ -310,7 +310,7 @@ fn test_parse_json_path_from() {
                 &Some(JsonPath {
                     path: vec![
                         JsonPathElem::Bracket {
-                            key: Expr::Value((number("0")).with_empty_span())
+                            key: Expr::value(number("0"))
                         },
                         JsonPathElem::Dot {
                             key: "a".to_string(),
@@ -334,7 +334,7 @@ fn test_parse_json_path_from() {
                 &Some(JsonPath {
                     path: vec![
                         JsonPathElem::Bracket {
-                            key: Expr::Value((number("0")).with_empty_span())
+                            key: Expr::value(number("0"))
                         },
                         JsonPathElem::Dot {
                             key: "a".to_string(),

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -570,8 +570,8 @@ fn test_snowflake_create_table_with_autoincrement_columns() {
                                 IdentityProperty {
                                     parameters: Some(IdentityPropertyFormatKind::FunctionCall(
                                         IdentityParameters {
-                                            seed: Expr::Value((number("100")).with_empty_span()),
-                                            increment: Expr::Value((number("1")).with_empty_span()),
+                                            seed: Expr::value(number("100")),
+                                            increment: Expr::value(number("1")),
                                         }
                                     )),
                                     order: Some(IdentityPropertyOrder::NoOrder),
@@ -1112,9 +1112,9 @@ fn parse_semi_structured_data_traversal() {
             path: JsonPath {
                 path: vec![JsonPathElem::Bracket {
                     key: Expr::BinaryOp {
-                        left: Box::new(Expr::Value((number("2")).with_empty_span())),
+                        left: Box::new(Expr::value(number("2"))),
                         op: BinaryOperator::Plus,
-                        right: Box::new(Expr::Value((number("2")).with_empty_span()))
+                        right: Box::new(Expr::value(number("2")))
                     },
                 }]
             },
@@ -1192,7 +1192,7 @@ fn parse_semi_structured_data_traversal() {
                         quoted: false,
                     },
                     JsonPathElem::Bracket {
-                        key: Expr::Value((number("0")).with_empty_span()),
+                        key: Expr::value(number("0")),
                     },
                     JsonPathElem::Dot {
                         key: "bar".to_owned(),
@@ -1214,7 +1214,7 @@ fn parse_semi_structured_data_traversal() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value((number("0")).with_empty_span()),
+                        key: Expr::value(number("0")),
                     },
                     JsonPathElem::Dot {
                         key: "foo".to_owned(),
@@ -1280,7 +1280,7 @@ fn parse_semi_structured_data_traversal() {
             }),
             path: JsonPath {
                 path: vec![JsonPathElem::Bracket {
-                    key: Expr::Value((number("1")).with_empty_span())
+                    key: Expr::value(number("1"))
                 }]
             }
         }
@@ -1666,14 +1666,14 @@ fn parse_snowflake_declare_result_set() {
             "DECLARE res RESULTSET DEFAULT 42",
             "res",
             Some(DeclareAssignment::Default(
-                Expr::Value(number("42").with_empty_span()).into(),
+                Expr::value(number("42")).into(),
             )),
         ),
         (
             "DECLARE res RESULTSET := 42",
             "res",
             Some(DeclareAssignment::DuckAssignment(
-                Expr::Value(number("42").with_empty_span()).into(),
+                Expr::value(number("42")).into(),
             )),
         ),
         ("DECLARE res RESULTSET", "res", None),
@@ -1723,7 +1723,7 @@ fn parse_snowflake_declare_exception() {
             "ex",
             Some(DeclareAssignment::Expr(
                 Expr::Tuple(vec![
-                    Expr::Value((number("42")).with_empty_span()),
+                    Expr::value(number("42")),
                     Expr::Value((Value::SingleQuotedString("ERROR".to_string())).with_empty_span()),
                 ])
                 .into(),
@@ -1761,7 +1761,7 @@ fn parse_snowflake_declare_variable() {
             "profit",
             Some(DataType::Text),
             Some(DeclareAssignment::Default(
-                Expr::Value(number("42").with_empty_span()).into(),
+                Expr::value(number("42")).into(),
             )),
         ),
         (
@@ -1769,7 +1769,7 @@ fn parse_snowflake_declare_variable() {
             "profit",
             None,
             Some(DeclareAssignment::Default(
-                Expr::Value(number("42").with_empty_span()).into(),
+                Expr::value(number("42")).into(),
             )),
         ),
         ("DECLARE profit TEXT", "profit", Some(DataType::Text), None),
@@ -2690,7 +2690,7 @@ fn parse_comma_outer_join() {
                 "myudf",
                 [Expr::UnaryOp {
                     op: UnaryOperator::Plus,
-                    expr: Box::new(Expr::Value((number("42")).with_empty_span()))
+                    expr: Box::new(Expr::value(number("42")))
                 }]
             )),
         })

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -570,8 +570,8 @@ fn test_snowflake_create_table_with_autoincrement_columns() {
                                 IdentityProperty {
                                     parameters: Some(IdentityPropertyFormatKind::FunctionCall(
                                         IdentityParameters {
-                                            seed: Expr::Value(number("100")),
-                                            increment: Expr::Value(number("1")),
+                                            seed: Expr::Value((number("100")).with_empty_span()),
+                                            increment: Expr::Value((number("1")).with_empty_span()),
                                         }
                                     )),
                                     order: Some(IdentityPropertyOrder::NoOrder),
@@ -602,8 +602,8 @@ fn test_snowflake_create_table_with_autoincrement_columns() {
                                     parameters: Some(
                                         IdentityPropertyFormatKind::StartAndIncrement(
                                             IdentityParameters {
-                                                seed: Expr::Value(number("100")),
-                                                increment: Expr::Value(number("1")),
+                                                seed: Expr::Value((number("100")).with_empty_span()),
+                                                increment: Expr::Value((number("1")).with_empty_span()),
                                             }
                                         )
                                     ),
@@ -1108,9 +1108,9 @@ fn parse_semi_structured_data_traversal() {
             path: JsonPath {
                 path: vec![JsonPathElem::Bracket {
                     key: Expr::BinaryOp {
-                        left: Box::new(Expr::Value(number("2"))),
+                        left: Box::new(Expr::Value((number("2")).with_empty_span())),
                         op: BinaryOperator::Plus,
-                        right: Box::new(Expr::Value(number("2")))
+                        right: Box::new(Expr::Value((number("2")).with_empty_span()))
                     },
                 }]
             },
@@ -1188,7 +1188,7 @@ fn parse_semi_structured_data_traversal() {
                         quoted: false,
                     },
                     JsonPathElem::Bracket {
-                        key: Expr::Value(number("0")),
+                        key: Expr::Value((number("0")).with_empty_span()),
                     },
                     JsonPathElem::Dot {
                         key: "bar".to_owned(),
@@ -1210,7 +1210,7 @@ fn parse_semi_structured_data_traversal() {
             path: JsonPath {
                 path: vec![
                     JsonPathElem::Bracket {
-                        key: Expr::Value(number("0")),
+                        key: Expr::Value((number("0")).with_empty_span()),
                     },
                     JsonPathElem::Dot {
                         key: "foo".to_owned(),
@@ -1276,7 +1276,7 @@ fn parse_semi_structured_data_traversal() {
             }),
             path: JsonPath {
                 path: vec![JsonPathElem::Bracket {
-                    key: Expr::Value(number("1"))
+                    key: Expr::Value((number("1")).with_empty_span())
                 }]
             }
         }
@@ -1717,8 +1717,8 @@ fn parse_snowflake_declare_exception() {
             "ex",
             Some(DeclareAssignment::Expr(
                 Expr::Tuple(vec![
-                    Expr::Value(number("42")),
-                    Expr::Value(Value::SingleQuotedString("ERROR".to_string())),
+                    Expr::Value((number("42")).with_empty_span()),
+                    Expr::Value((Value::SingleQuotedString("ERROR".to_string())).with_empty_span()),
                 ])
                 .into(),
             )),
@@ -2509,10 +2509,10 @@ fn test_snowflake_trim() {
     let select = snowflake().verified_only_select(sql_only_select);
     assert_eq!(
         &Expr::Trim {
-            expr: Box::new(Expr::Value(Value::SingleQuotedString("xyz".to_owned()))),
+            expr: Box::new(Expr::Value((Value::SingleQuotedString("xyz".to_owned())).with_empty_span())),
             trim_where: None,
             trim_what: None,
-            trim_characters: Some(vec![Expr::Value(Value::SingleQuotedString("a".to_owned()))]),
+            trim_characters: Some(vec![Expr::Value((Value::SingleQuotedString("a".to_owned())).with_empty_span())]),
         },
         expr_from_projection(only(&select.projection))
     );
@@ -2530,7 +2530,7 @@ fn test_number_placeholder() {
     let sql_only_select = "SELECT :1";
     let select = snowflake().verified_only_select(sql_only_select);
     assert_eq!(
-        &Expr::Value(Value::Placeholder(":1".into())),
+        &Expr::Value((Value::Placeholder(":1".into())).with_empty_span()),
         expr_from_projection(only(&select.projection))
     );
 
@@ -2676,7 +2676,7 @@ fn parse_comma_outer_join() {
                 "myudf",
                 [Expr::UnaryOp {
                     op: UnaryOperator::Plus,
-                    expr: Box::new(Expr::Value(number("42")))
+                    expr: Box::new(Expr::Value((number("42")).with_empty_span()))
                 }]
             )),
         })

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1661,13 +1661,13 @@ fn parse_snowflake_declare_result_set() {
         (
             "DECLARE res RESULTSET DEFAULT 42",
             "res",
-            Some(DeclareAssignment::Default(Expr::Value(number("42")).into())),
+            Some(DeclareAssignment::Default(Expr::Value(number("42").with_empty_span()).into())),
         ),
         (
             "DECLARE res RESULTSET := 42",
             "res",
             Some(DeclareAssignment::DuckAssignment(
-                Expr::Value(number("42")).into(),
+                Expr::Value(number("42").with_empty_span()).into(),
             )),
         ),
         ("DECLARE res RESULTSET", "res", None),
@@ -1754,13 +1754,13 @@ fn parse_snowflake_declare_variable() {
             "DECLARE profit TEXT DEFAULT 42",
             "profit",
             Some(DataType::Text),
-            Some(DeclareAssignment::Default(Expr::Value(number("42")).into())),
+            Some(DeclareAssignment::Default(Expr::Value(number("42").with_empty_span()).into())),
         ),
         (
             "DECLARE profit DEFAULT 42",
             "profit",
             None,
-            Some(DeclareAssignment::Default(Expr::Value(number("42")).into())),
+            Some(DeclareAssignment::Default(Expr::Value(number("42").with_empty_span()).into())),
         ),
         ("DECLARE profit TEXT", "profit", Some(DataType::Text), None),
         ("DECLARE profit", "profit", None, None),

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -1665,9 +1665,7 @@ fn parse_snowflake_declare_result_set() {
         (
             "DECLARE res RESULTSET DEFAULT 42",
             "res",
-            Some(DeclareAssignment::Default(
-                Expr::value(number("42")).into(),
-            )),
+            Some(DeclareAssignment::Default(Expr::value(number("42")).into())),
         ),
         (
             "DECLARE res RESULTSET := 42",
@@ -1760,17 +1758,13 @@ fn parse_snowflake_declare_variable() {
             "DECLARE profit TEXT DEFAULT 42",
             "profit",
             Some(DataType::Text),
-            Some(DeclareAssignment::Default(
-                Expr::value(number("42")).into(),
-            )),
+            Some(DeclareAssignment::Default(Expr::value(number("42")).into())),
         ),
         (
             "DECLARE profit DEFAULT 42",
             "profit",
             None,
-            Some(DeclareAssignment::Default(
-                Expr::value(number("42")).into(),
-            )),
+            Some(DeclareAssignment::Default(Expr::value(number("42")).into())),
         ),
         ("DECLARE profit TEXT", "profit", Some(DataType::Text), None),
         ("DECLARE profit", "profit", None, None),

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -602,8 +602,12 @@ fn test_snowflake_create_table_with_autoincrement_columns() {
                                     parameters: Some(
                                         IdentityPropertyFormatKind::StartAndIncrement(
                                             IdentityParameters {
-                                                seed: Expr::Value((number("100")).with_empty_span()),
-                                                increment: Expr::Value((number("1")).with_empty_span()),
+                                                seed: Expr::Value(
+                                                    (number("100")).with_empty_span()
+                                                ),
+                                                increment: Expr::Value(
+                                                    (number("1")).with_empty_span()
+                                                ),
                                             }
                                         )
                                     ),
@@ -1661,7 +1665,9 @@ fn parse_snowflake_declare_result_set() {
         (
             "DECLARE res RESULTSET DEFAULT 42",
             "res",
-            Some(DeclareAssignment::Default(Expr::Value(number("42").with_empty_span()).into())),
+            Some(DeclareAssignment::Default(
+                Expr::Value(number("42").with_empty_span()).into(),
+            )),
         ),
         (
             "DECLARE res RESULTSET := 42",
@@ -1754,13 +1760,17 @@ fn parse_snowflake_declare_variable() {
             "DECLARE profit TEXT DEFAULT 42",
             "profit",
             Some(DataType::Text),
-            Some(DeclareAssignment::Default(Expr::Value(number("42").with_empty_span()).into())),
+            Some(DeclareAssignment::Default(
+                Expr::Value(number("42").with_empty_span()).into(),
+            )),
         ),
         (
             "DECLARE profit DEFAULT 42",
             "profit",
             None,
-            Some(DeclareAssignment::Default(Expr::Value(number("42").with_empty_span()).into())),
+            Some(DeclareAssignment::Default(
+                Expr::Value(number("42").with_empty_span()).into(),
+            )),
         ),
         ("DECLARE profit TEXT", "profit", Some(DataType::Text), None),
         ("DECLARE profit", "profit", None, None),
@@ -2509,10 +2519,14 @@ fn test_snowflake_trim() {
     let select = snowflake().verified_only_select(sql_only_select);
     assert_eq!(
         &Expr::Trim {
-            expr: Box::new(Expr::Value((Value::SingleQuotedString("xyz".to_owned())).with_empty_span())),
+            expr: Box::new(Expr::Value(
+                (Value::SingleQuotedString("xyz".to_owned())).with_empty_span()
+            )),
             trim_where: None,
             trim_what: None,
-            trim_characters: Some(vec![Expr::Value((Value::SingleQuotedString("a".to_owned())).with_empty_span())]),
+            trim_characters: Some(vec![Expr::Value(
+                (Value::SingleQuotedString("a".to_owned())).with_empty_span()
+            )]),
         },
         expr_from_projection(only(&select.projection))
     );

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -369,7 +369,7 @@ fn test_placeholder() {
     let ast = sqlite().verified_only_select(sql);
     assert_eq!(
         ast.projection[0],
-        UnnamedExpr(Expr::Value(Value::Placeholder("@xxx".into()))),
+        UnnamedExpr(Expr::Value((Value::Placeholder("@xxx".into())).with_empty_span())),
     );
 }
 
@@ -469,8 +469,8 @@ fn parse_update_tuple_row_values() {
                     ObjectName::from(vec![Ident::new("b"),]),
                 ]),
                 value: Expr::Tuple(vec![
-                    Expr::Value(Value::Number("1".parse().unwrap(), false)),
-                    Expr::Value(Value::Number("2".parse().unwrap(), false))
+                    Expr::Value((Value::Number("1".parse().unwrap(), false)).with_empty_span()),
+                    Expr::Value((Value::Number("2".parse().unwrap(), false)).with_empty_span())
                 ])
             }],
             selection: None,
@@ -547,7 +547,7 @@ fn test_dollar_identifier_as_placeholder() {
         Expr::BinaryOp { op, left, right } => {
             assert_eq!(op, BinaryOperator::Eq);
             assert_eq!(left, Box::new(Expr::Identifier(Ident::new("id"))));
-            assert_eq!(right, Box::new(Expr::Value(Placeholder("$id".to_string()))));
+            assert_eq!(right, Box::new(Expr::Value((Placeholder("$id".to_string())).with_empty_span())));
         }
         _ => unreachable!(),
     }
@@ -557,7 +557,7 @@ fn test_dollar_identifier_as_placeholder() {
         Expr::BinaryOp { op, left, right } => {
             assert_eq!(op, BinaryOperator::Eq);
             assert_eq!(left, Box::new(Expr::Identifier(Ident::new("id"))));
-            assert_eq!(right, Box::new(Expr::Value(Placeholder("$$".to_string()))));
+            assert_eq!(right, Box::new(Expr::Value((Placeholder("$$".to_string())).with_empty_span())));
         }
         _ => unreachable!(),
     }

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -446,7 +446,7 @@ fn parse_attach_database() {
     match verified_stmt {
         Statement::AttachDatabase {
             schema_name,
-            database_file_name: Expr::Value(Value::SingleQuotedString(literal_name)),
+            database_file_name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(literal_name), span: _}),
             database: true,
         } => {
             assert_eq!(schema_name.value, "test");

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -369,7 +369,9 @@ fn test_placeholder() {
     let ast = sqlite().verified_only_select(sql);
     assert_eq!(
         ast.projection[0],
-        UnnamedExpr(Expr::Value((Value::Placeholder("@xxx".into())).with_empty_span())),
+        UnnamedExpr(Expr::Value(
+            (Value::Placeholder("@xxx".into())).with_empty_span()
+        )),
     );
 }
 
@@ -446,7 +448,11 @@ fn parse_attach_database() {
     match verified_stmt {
         Statement::AttachDatabase {
             schema_name,
-            database_file_name: Expr::Value(ValueWithSpan{value: Value::SingleQuotedString(literal_name), span: _}),
+            database_file_name:
+                Expr::Value(ValueWithSpan {
+                    value: Value::SingleQuotedString(literal_name),
+                    span: _,
+                }),
             database: true,
         } => {
             assert_eq!(schema_name.value, "test");
@@ -547,7 +553,12 @@ fn test_dollar_identifier_as_placeholder() {
         Expr::BinaryOp { op, left, right } => {
             assert_eq!(op, BinaryOperator::Eq);
             assert_eq!(left, Box::new(Expr::Identifier(Ident::new("id"))));
-            assert_eq!(right, Box::new(Expr::Value((Placeholder("$id".to_string())).with_empty_span())));
+            assert_eq!(
+                right,
+                Box::new(Expr::Value(
+                    (Placeholder("$id".to_string())).with_empty_span()
+                ))
+            );
         }
         _ => unreachable!(),
     }
@@ -557,7 +568,12 @@ fn test_dollar_identifier_as_placeholder() {
         Expr::BinaryOp { op, left, right } => {
             assert_eq!(op, BinaryOperator::Eq);
             assert_eq!(left, Box::new(Expr::Identifier(Ident::new("id"))));
-            assert_eq!(right, Box::new(Expr::Value((Placeholder("$$".to_string())).with_empty_span())));
+            assert_eq!(
+                right,
+                Box::new(Expr::Value(
+                    (Placeholder("$$".to_string())).with_empty_span()
+                ))
+            );
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
@iffyio @alamb : I allowed edit by maintainers on this PR; help would be very welcome.

I implemented all the required changes in the library itself, but there are still massive (mostly repetitive and probably automatable) changes to make in the tests.

I would love if I could get some help on this, this should greatly decrease missing spans in parsed trees.