### PR TITLE
Add support for `CREATE SCHEMA` options

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3144,6 +3144,22 @@ pub enum Statement {
         /// `<schema name> | AUTHORIZATION <schema authorization identifier>  | <schema name>  AUTHORIZATION <schema authorization identifier>`
         schema_name: SchemaName,
         if_not_exists: bool,
+        /// Schema options.
+        ///
+        /// ```sql
+        /// CREATE SCHEMA myschema OPTIONS(key1='value1');
+        /// ```
+        ///
+        /// [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_schema_statement)
+        options: Option<Vec<SqlOption>>,
+        /// Default collation specification for the schema.
+        ///
+        /// ```sql
+        /// CREATE SCHEMA myschema DEFAULT COLLATE 'und:ci';
+        /// ```
+        ///
+        /// [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_schema_statement)
+        default_collate_spec: Option<Expr>,
     },
     /// ```sql
     /// CREATE DATABASE
@@ -4928,12 +4944,26 @@ impl fmt::Display for Statement {
             Statement::CreateSchema {
                 schema_name,
                 if_not_exists,
-            } => write!(
-                f,
-                "CREATE SCHEMA {if_not_exists}{name}",
-                if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
-                name = schema_name
-            ),
+                options,
+                default_collate_spec,
+            } => {
+                write!(
+                    f,
+                    "CREATE SCHEMA {if_not_exists}{name}",
+                    if_not_exists = if *if_not_exists { "IF NOT EXISTS " } else { "" },
+                    name = schema_name
+                )?;
+
+                if let Some(collate) = default_collate_spec {
+                    write!(f, " DEFAULT COLLATE {collate}")?;
+                }
+
+                if let Some(options) = options {
+                    write!(f, " OPTIONS({})", display_comma_separated(options))?;
+                }
+
+                Ok(())
+            }
             Statement::Assert { condition, message } => {
                 write!(f, "ASSERT {condition}")?;
                 if let Some(m) = message {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4614,9 +4614,23 @@ impl<'a> Parser<'a> {
 
         let schema_name = self.parse_schema_name()?;
 
+        let default_collate_spec = if self.parse_keywords(&[Keyword::DEFAULT, Keyword::COLLATE]) {
+            Some(self.parse_expr()?)
+        } else {
+            None
+        };
+
+        let options = if self.peek_keyword(Keyword::OPTIONS) {
+            Some(self.parse_options(Keyword::OPTIONS)?)
+        } else {
+            None
+        };
+
         Ok(Statement::CreateSchema {
             schema_name,
             if_not_exists,
+            options,
+            default_collate_spec,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4124,6 +4124,11 @@ fn parse_create_schema() {
         }
         _ => unreachable!(),
     }
+
+    verified_stmt(r#"CREATE SCHEMA a.b.c OPTIONS(key1 = 'value1', key2 = 'value2')"#);
+    verified_stmt(r#"CREATE SCHEMA IF NOT EXISTS a OPTIONS(key1 = 'value1')"#);
+    verified_stmt(r#"CREATE SCHEMA IF NOT EXISTS a OPTIONS()"#);
+    verified_stmt(r#"CREATE SCHEMA IF NOT EXISTS a DEFAULT COLLATE 'und:ci' OPTIONS()"#);
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -985,6 +985,7 @@ fn parse_create_schema_if_not_exists() {
         Statement::CreateSchema {
             if_not_exists: true,
             schema_name,
+            ..
         } => assert_eq!("schema_name", schema_name.to_string()),
         _ => unreachable!(),
     }


### PR DESCRIPTION
```sql
CREATE SCHEMA DEFAULT COLLATE 'foo' myschema OPTIONS(key='value');
```

[BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_schema_statement)