### PR TITLE
Add support for `DROP MATERIALIZED VIEW`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -6733,6 +6733,7 @@ impl fmt::Display for HavingBoundKind {
 pub enum ObjectType {
     Table,
     View,
+    MaterializedView,
     Index,
     Schema,
     Database,
@@ -6747,6 +6748,7 @@ impl fmt::Display for ObjectType {
         f.write_str(match self {
             ObjectType::Table => "TABLE",
             ObjectType::View => "VIEW",
+            ObjectType::MaterializedView => "MATERIALIZED VIEW",
             ObjectType::Index => "INDEX",
             ObjectType::Schema => "SCHEMA",
             ObjectType::Database => "DATABASE",

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5806,6 +5806,8 @@ impl<'a> Parser<'a> {
             ObjectType::Table
         } else if self.parse_keyword(Keyword::VIEW) {
             ObjectType::View
+        } else if self.parse_keywords(&[Keyword::MATERIALIZED, Keyword::VIEW]) {
+            ObjectType::MaterializedView
         } else if self.parse_keyword(Keyword::INDEX) {
             ObjectType::Index
         } else if self.parse_keyword(Keyword::ROLE) {
@@ -5836,7 +5838,7 @@ impl<'a> Parser<'a> {
             return self.parse_drop_extension();
         } else {
             return self.expected(
-                "CONNECTOR, DATABASE, EXTENSION, FUNCTION, INDEX, POLICY, PROCEDURE, ROLE, SCHEMA, SECRET, SEQUENCE, STAGE, TABLE, TRIGGER, TYPE, or VIEW after DROP",
+                "CONNECTOR, DATABASE, EXTENSION, FUNCTION, INDEX, POLICY, PROCEDURE, ROLE, SCHEMA, SECRET, SEQUENCE, STAGE, TABLE, TRIGGER, TYPE, VIEW, or MATERIALIZED VIEW after DROP",
                 self.peek_token(),
             );
         };

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8189,6 +8189,9 @@ fn parse_drop_view() {
         }
         _ => unreachable!(),
     }
+
+    verified_stmt("DROP MATERIALIZED VIEW a.b.c");
+    verified_stmt("DROP MATERIALIZED VIEW IF EXISTS a.b.c");
 }
 
 #[test]


### PR DESCRIPTION
Adds support for e.g.

```sql
DROP MATERIALIZED VIEW IF EXISTS a.b.c
```

[BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_materialized_view_statement)