### PR TITLE
Prepare for 55.0.0 release: Version and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ technically be breaking and thus will result in a `0.(N+1)` version.
 
 
 - Unreleased: Check https://github.com/sqlparser-rs/sqlparser-rs/commits/main for undocumented changes.
+- `0.55.0`: [changelog/0.55.0.md](changelog/0.55.0.md)
 - `0.54.0`: [changelog/0.54.0.md](changelog/0.54.0.md)
 - `0.53.0`: [changelog/0.53.0.md](changelog/0.53.0.md)
 - `0.52.0`: [changelog/0.52.0.md](changelog/0.52.0.md)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "sqlparser"
 description = "Extensible SQL Lexer and Parser with support for ANSI SQL:2011"
-version = "0.54.0"
+version = "0.55.0"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 homepage = "https://github.com/apache/datafusion-sqlparser-rs"
 documentation = "https://docs.rs/sqlparser/"

--- a/changelog/0.55.0.md
+++ b/changelog/0.55.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # sqlparser-rs 0.55.0 Changelog
 
-This release consists of 56 commits from 25 contributors. See credits at the end of this changelog for more information.
+This release consists of 53 commits from 25 contributors. See credits at the end of this changelog for more information.
 
 **Breaking changes:**
 
@@ -94,12 +94,12 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
     10	Yoav Cohen
      9	Ifeanyi Ubah
      6	Michael Victor Zink
-     4	Andrew Lamb
      3	Hans Ott
      2	Ophir LOJKINE
      2	Paul Grau
      2	Rémy SAISSY
      2	wugeer
+     1	Andrew Lamb
      1	Armin Ronacher
      1	Artem Osipov
      1	AvivDavid-Satori

--- a/changelog/0.55.0.md
+++ b/changelog/0.55.0.md
@@ -19,7 +19,12 @@ under the License.
 
 # sqlparser-rs 0.55.0 Changelog
 
-This release consists of 54 commits from 25 contributors. See credits at the end of this changelog for more information.
+This release consists of 56 commits from 25 contributors. See credits at the end of this changelog for more information.
+
+**Breaking changes:**
+
+- Enhance object name path segments [#1539](https://github.com/apache/datafusion-sqlparser-rs/pull/1539) (ayman-sigma)
+- Store spans for Value expressions [#1738](https://github.com/apache/datafusion-sqlparser-rs/pull/1738) (lovasoa)
 
 **Implemented enhancements:**
 
@@ -37,7 +42,6 @@ This release consists of 54 commits from 25 contributors. See credits at the end
 - National strings: check if dialect supports backslash escape [#1672](https://github.com/apache/datafusion-sqlparser-rs/pull/1672) (hansott)
 - Only support escape literals for Postgres, Redshift and generic dialect [#1674](https://github.com/apache/datafusion-sqlparser-rs/pull/1674) (hansott)
 - BigQuery: Support trailing commas in column definitions list [#1682](https://github.com/apache/datafusion-sqlparser-rs/pull/1682) (iffyio)
-- Enhance object name path segments [#1539](https://github.com/apache/datafusion-sqlparser-rs/pull/1539) (ayman-sigma)
 - Enable GROUP BY exp for Snowflake dialect [#1683](https://github.com/apache/datafusion-sqlparser-rs/pull/1683) (yoavcloud)
 - Add support for parsing empty dictionary expressions [#1684](https://github.com/apache/datafusion-sqlparser-rs/pull/1684) (yoavcloud)
 - Support multiple tables in `UPDATE FROM` clause [#1681](https://github.com/apache/datafusion-sqlparser-rs/pull/1681) (iffyio)
@@ -79,7 +83,6 @@ This release consists of 54 commits from 25 contributors. See credits at the end
 - Parse casting to array using double colon operator in Redshift [#1737](https://github.com/apache/datafusion-sqlparser-rs/pull/1737) (yoavcloud)
 - Replace parallel condition/result vectors with single CaseWhen vector in Expr::Case [#1733](https://github.com/apache/datafusion-sqlparser-rs/pull/1733) (lovasoa)
 - BigQuery: Add support for `BEGIN` [#1718](https://github.com/apache/datafusion-sqlparser-rs/pull/1718) (iffyio)
-- Store spans for Value expressions [#1738](https://github.com/apache/datafusion-sqlparser-rs/pull/1738) (lovasoa)
 - Parse SIGNED INTEGER type in MySQL CAST [#1739](https://github.com/apache/datafusion-sqlparser-rs/pull/1739) (mvzink)
 - Parse MySQL ALTER TABLE ALGORITHM option [#1745](https://github.com/apache/datafusion-sqlparser-rs/pull/1745) (mvzink)
 
@@ -91,8 +94,8 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
     10	Yoav Cohen
      9	Ifeanyi Ubah
      6	Michael Victor Zink
+     4	Andrew Lamb
      3	Hans Ott
-     2	Andrew Lamb
      2	Ophir LOJKINE
      2	Paul Grau
      2	Rémy SAISSY

--- a/changelog/0.55.0.md
+++ b/changelog/0.55.0.md
@@ -21,6 +21,27 @@ under the License.
 
 This release consists of 55 commits from 25 contributors. See credits at the end of this changelog for more information.
 
+## Migrating usages of `Expr::Value`
+
+In v0.55, sqlparser the `Expr::Value` enum variant contains a `ValueWithSpan` instead of a `Value`. Here is how to migrate.
+
+### When pattern matching
+
+```diff
+- Expr::Value(Value::SingleQuotedString(my_string)) => { ... }
++ Expr::Value(ValueWithSpan{ value: Value::SingleQuotedString(my_string), span: _ }) => { ... }
+```
+
+### When creating an `Expr`
+
+Use the new `Expr::value` method (notice the lowercase `v`), which will create a `ValueWithSpan` containing an empty span :
+
+```diff
+- Expr::Value(Value::SingleQuotedString(my_string))
++ Expr::value(Value::SingleQuotedString(my_string))
+```
+
+
 **Breaking changes:**
 
 - Enhance object name path segments [#1539](https://github.com/apache/datafusion-sqlparser-rs/pull/1539) (ayman-sigma)

--- a/changelog/0.55.0.md
+++ b/changelog/0.55.0.md
@@ -1,0 +1,119 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# sqlparser-rs 0.55.0 Changelog
+
+This release consists of 54 commits from 25 contributors. See credits at the end of this changelog for more information.
+
+**Implemented enhancements:**
+
+- feat: adjust create and drop trigger for mysql dialect [#1734](https://github.com/apache/datafusion-sqlparser-rs/pull/1734) (invm)
+
+**Fixed bugs:**
+
+- fix: make `serde` feature no_std [#1730](https://github.com/apache/datafusion-sqlparser-rs/pull/1730) (iajoiner)
+
+**Other:**
+
+- Update rat_exclude_file.txt [#1670](https://github.com/apache/datafusion-sqlparser-rs/pull/1670) (alamb)
+- Add support for Snowflake account privileges [#1666](https://github.com/apache/datafusion-sqlparser-rs/pull/1666) (yoavcloud)
+- Add support for Create Iceberg Table statement for Snowflake parser [#1664](https://github.com/apache/datafusion-sqlparser-rs/pull/1664) (Vedin)
+- National strings: check if dialect supports backslash escape [#1672](https://github.com/apache/datafusion-sqlparser-rs/pull/1672) (hansott)
+- Only support escape literals for Postgres, Redshift and generic dialect [#1674](https://github.com/apache/datafusion-sqlparser-rs/pull/1674) (hansott)
+- BigQuery: Support trailing commas in column definitions list [#1682](https://github.com/apache/datafusion-sqlparser-rs/pull/1682) (iffyio)
+- Enhance object name path segments [#1539](https://github.com/apache/datafusion-sqlparser-rs/pull/1539) (ayman-sigma)
+- Enable GROUP BY exp for Snowflake dialect [#1683](https://github.com/apache/datafusion-sqlparser-rs/pull/1683) (yoavcloud)
+- Add support for parsing empty dictionary expressions [#1684](https://github.com/apache/datafusion-sqlparser-rs/pull/1684) (yoavcloud)
+- Support multiple tables in `UPDATE FROM` clause [#1681](https://github.com/apache/datafusion-sqlparser-rs/pull/1681) (iffyio)
+- Add support for mysql table hints [#1675](https://github.com/apache/datafusion-sqlparser-rs/pull/1675) (AvivDavid-Satori)
+- BigQuery: Add support for select expr star [#1680](https://github.com/apache/datafusion-sqlparser-rs/pull/1680) (iffyio)
+- Support underscore separators in numbers for Clickhouse. Fixes #1659 [#1677](https://github.com/apache/datafusion-sqlparser-rs/pull/1677) (graup)
+- BigQuery: Fix column identifier reserved keywords list [#1678](https://github.com/apache/datafusion-sqlparser-rs/pull/1678) (iffyio)
+- Fix bug when parsing a Snowflake stage with `;` suffix [#1688](https://github.com/apache/datafusion-sqlparser-rs/pull/1688) (yoavcloud)
+- Allow plain JOIN without turning it into INNER [#1692](https://github.com/apache/datafusion-sqlparser-rs/pull/1692) (mvzink)
+- Fix DDL generation in case of an empty arguments function. [#1690](https://github.com/apache/datafusion-sqlparser-rs/pull/1690) (remysaissy)
+- Fix `CREATE FUNCTION` round trip for Hive dialect [#1693](https://github.com/apache/datafusion-sqlparser-rs/pull/1693) (iffyio)
+- Make numeric literal underscore test dialect agnostic [#1685](https://github.com/apache/datafusion-sqlparser-rs/pull/1685) (iffyio)
+- Extend lambda support for ClickHouse and DuckDB dialects [#1686](https://github.com/apache/datafusion-sqlparser-rs/pull/1686) (gstvg)
+- Make TypedString preserve quote style [#1679](https://github.com/apache/datafusion-sqlparser-rs/pull/1679) (graup)
+- Do not parse ASOF and MATCH_CONDITION as table factor aliases [#1698](https://github.com/apache/datafusion-sqlparser-rs/pull/1698) (yoavcloud)
+- Add support for GRANT on some common Snowflake objects [#1699](https://github.com/apache/datafusion-sqlparser-rs/pull/1699) (yoavcloud)
+- Add RETURNS TABLE() support for CREATE FUNCTION in Postgresql [#1687](https://github.com/apache/datafusion-sqlparser-rs/pull/1687) (remysaissy)
+- Add parsing for GRANT ROLE and GRANT DATABASE ROLE in Snowflake dialect [#1689](https://github.com/apache/datafusion-sqlparser-rs/pull/1689) (yoavcloud)
+- Add support for `CREATE/ALTER/DROP CONNECTOR` syntax [#1701](https://github.com/apache/datafusion-sqlparser-rs/pull/1701) (wugeer)
+- Parse Snowflake COPY INTO <location> [#1669](https://github.com/apache/datafusion-sqlparser-rs/pull/1669) (yoavcloud)
+- Require space after -- to start single line comment in MySQL [#1705](https://github.com/apache/datafusion-sqlparser-rs/pull/1705) (hansott)
+- Add suppport for Show Objects statement for the Snowflake parser [#1702](https://github.com/apache/datafusion-sqlparser-rs/pull/1702) (DanCodedThis)
+- Fix incorrect parsing of JsonAccess bracket notation after cast in Snowflake [#1708](https://github.com/apache/datafusion-sqlparser-rs/pull/1708) (yoavcloud)
+- Parse Postgres VARBIT datatype [#1703](https://github.com/apache/datafusion-sqlparser-rs/pull/1703) (mvzink)
+- Implement FROM-first selects [#1713](https://github.com/apache/datafusion-sqlparser-rs/pull/1713) (mitsuhiko)
+- Enable custom dialects to support `MATCH() AGAINST()` [#1719](https://github.com/apache/datafusion-sqlparser-rs/pull/1719) (joocer)
+- Support group by cube/rollup etc in BigQuery [#1720](https://github.com/apache/datafusion-sqlparser-rs/pull/1720) (Groennbeck)
+- Add support for MS Varbinary(MAX) (#1714) [#1715](https://github.com/apache/datafusion-sqlparser-rs/pull/1715) (TylerBrinks)
+- Add supports for Hive's `SELECT ... GROUP BY .. GROUPING SETS` syntax [#1653](https://github.com/apache/datafusion-sqlparser-rs/pull/1653) (wugeer)
+- Differentiate LEFT JOIN from LEFT OUTER JOIN [#1726](https://github.com/apache/datafusion-sqlparser-rs/pull/1726) (mvzink)
+- Add support for Postgres `ALTER TYPE` [#1727](https://github.com/apache/datafusion-sqlparser-rs/pull/1727) (jvatic)
+- Replace `Method` and `CompositeAccess` with `CompoundFieldAccess` [#1716](https://github.com/apache/datafusion-sqlparser-rs/pull/1716) (iffyio)
+- Add support for `EXECUTE IMMEDIATE` [#1717](https://github.com/apache/datafusion-sqlparser-rs/pull/1717) (iffyio)
+- Treat COLLATE like any other column option [#1731](https://github.com/apache/datafusion-sqlparser-rs/pull/1731) (mvzink)
+- Add support for PostgreSQL/Redshift geometric operators [#1723](https://github.com/apache/datafusion-sqlparser-rs/pull/1723) (benrsatori)
+- Implement SnowFlake ALTER SESSION [#1712](https://github.com/apache/datafusion-sqlparser-rs/pull/1712) (osipovartem)
+- Extend Visitor trait for Value type [#1725](https://github.com/apache/datafusion-sqlparser-rs/pull/1725) (tomershaniii)
+- Add support for `ORDER BY ALL` [#1724](https://github.com/apache/datafusion-sqlparser-rs/pull/1724) (PokIsemaine)
+- Parse casting to array using double colon operator in Redshift [#1737](https://github.com/apache/datafusion-sqlparser-rs/pull/1737) (yoavcloud)
+- Replace parallel condition/result vectors with single CaseWhen vector in Expr::Case [#1733](https://github.com/apache/datafusion-sqlparser-rs/pull/1733) (lovasoa)
+- BigQuery: Add support for `BEGIN` [#1718](https://github.com/apache/datafusion-sqlparser-rs/pull/1718) (iffyio)
+- Store spans for Value expressions [#1738](https://github.com/apache/datafusion-sqlparser-rs/pull/1738) (lovasoa)
+- Parse SIGNED INTEGER type in MySQL CAST [#1739](https://github.com/apache/datafusion-sqlparser-rs/pull/1739) (mvzink)
+- Parse MySQL ALTER TABLE ALGORITHM option [#1745](https://github.com/apache/datafusion-sqlparser-rs/pull/1745) (mvzink)
+
+## Credits
+
+Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
+
+```
+    10	Yoav Cohen
+     9	Ifeanyi Ubah
+     6	Michael Victor Zink
+     3	Hans Ott
+     2	Andrew Lamb
+     2	Ophir LOJKINE
+     2	Paul Grau
+     2	Rémy SAISSY
+     2	wugeer
+     1	Armin Ronacher
+     1	Artem Osipov
+     1	AvivDavid-Satori
+     1	Ayman Elkfrawy
+     1	DanCodedThis
+     1	Denys Tsomenko
+     1	Emil
+     1	Ian Alexander Joiner
+     1	Jesse Stuart
+     1	Justin Joyce
+     1	Michael
+     1	SiLe Zhou
+     1	Tyler Brinks
+     1	benrsatori
+     1	gstvg
+     1	tomershaniii
+```
+
+Thank you also to everyone who contributed in other ways such as filing issues, reviewing PRs, and providing feedback on this release.
+

--- a/changelog/0.55.0.md
+++ b/changelog/0.55.0.md
@@ -23,7 +23,7 @@ This release consists of 55 commits from 25 contributors. See credits at the end
 
 ## Migrating usages of `Expr::Value`
 
-In v0.55, sqlparser the `Expr::Value` enum variant contains a `ValueWithSpan` instead of a `Value`. Here is how to migrate.
+In v0.55 of sqlparser the `Expr::Value` enum variant contains a `ValueWithSpan` instead of a `Value`. Here is how to migrate.
 
 ### When pattern matching
 
@@ -34,12 +34,40 @@ In v0.55, sqlparser the `Expr::Value` enum variant contains a `ValueWithSpan` in
 
 ### When creating an `Expr`
 
-Use the new `Expr::value` method (notice the lowercase `v`), which will create a `ValueWithSpan` containing an empty span :
+Use the new `Expr::value` method (notice the lowercase `v`), which will create a `ValueWithSpan` containing an empty span:
 
 ```diff
 - Expr::Value(Value::SingleQuotedString(my_string))
 + Expr::value(Value::SingleQuotedString(my_string))
 ```
+
+## Migrating usages of `ObjectName`
+
+In v0.55 of sqlparser, the `ObjectName` structure has been changed as shown below. Here is now to migrate.
+
+```diff
+- pub struct ObjectName(pub Vec<Ident>);
++ pub struct ObjectName(pub Vec<ObjectNamePart>)
+```
+
+### When constructing `ObjectName`
+
+Use the `From` impl:
+
+```diff
+- name: ObjectName(vec![Ident::new("f")]),
++ name: ObjectName::from(vec![Ident::new("f")]),
+```
+
+### Accessing Spans
+
+Use the `span()` function
+
+```diff
+- name.span
++ name.span()
+```
+
 
 
 **Breaking changes:**

--- a/changelog/0.55.0.md
+++ b/changelog/0.55.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # sqlparser-rs 0.55.0 Changelog
 
-This release consists of 53 commits from 25 contributors. See credits at the end of this changelog for more information.
+This release consists of 55 commits from 25 contributors. See credits at the end of this changelog for more information.
 
 **Breaking changes:**
 
@@ -85,6 +85,8 @@ This release consists of 53 commits from 25 contributors. See credits at the end
 - BigQuery: Add support for `BEGIN` [#1718](https://github.com/apache/datafusion-sqlparser-rs/pull/1718) (iffyio)
 - Parse SIGNED INTEGER type in MySQL CAST [#1739](https://github.com/apache/datafusion-sqlparser-rs/pull/1739) (mvzink)
 - Parse MySQL ALTER TABLE ALGORITHM option [#1745](https://github.com/apache/datafusion-sqlparser-rs/pull/1745) (mvzink)
+- Random test cleanups use Expr::value [#1749](https://github.com/apache/datafusion-sqlparser-rs/pull/1749) (alamb)
+- Parse ALTER TABLE AUTO_INCREMENT operation for MySQL [#1748](https://github.com/apache/datafusion-sqlparser-rs/pull/1748) (mvzink)
 
 ## Credits
 
@@ -93,13 +95,13 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
 ```
     10	Yoav Cohen
      9	Ifeanyi Ubah
-     6	Michael Victor Zink
+     7	Michael Victor Zink
      3	Hans Ott
+     2	Andrew Lamb
      2	Ophir LOJKINE
      2	Paul Grau
      2	Rémy SAISSY
      2	wugeer
-     1	Andrew Lamb
      1	Armin Ronacher
      1	Artem Osipov
      1	AvivDavid-Satori

--- a/changelog/0.55.0.md
+++ b/changelog/0.55.0.md
@@ -81,7 +81,7 @@ This release consists of 53 commits from 25 contributors. See credits at the end
 - Extend Visitor trait for Value type [#1725](https://github.com/apache/datafusion-sqlparser-rs/pull/1725) (tomershaniii)
 - Add support for `ORDER BY ALL` [#1724](https://github.com/apache/datafusion-sqlparser-rs/pull/1724) (PokIsemaine)
 - Parse casting to array using double colon operator in Redshift [#1737](https://github.com/apache/datafusion-sqlparser-rs/pull/1737) (yoavcloud)
-- Replace parallel condition/result vectors with single CaseWhen vector in Expr::Case [#1733](https://github.com/apache/datafusion-sqlparser-rs/pull/1733) (lovasoa)
+- Replace parallel condition/result vectors with single CaseWhen vector in Expr::Case. This fixes the iteration order when using the `Visitor` trait. Expressions are now visited in the same order as they appear in the sql source. [#1733](https://github.com/apache/datafusion-sqlparser-rs/pull/1733) (lovasoa)
 - BigQuery: Add support for `BEGIN` [#1718](https://github.com/apache/datafusion-sqlparser-rs/pull/1718) (iffyio)
 - Parse SIGNED INTEGER type in MySQL CAST [#1739](https://github.com/apache/datafusion-sqlparser-rs/pull/1739) (mvzink)
 - Parse MySQL ALTER TABLE ALGORITHM option [#1745](https://github.com/apache/datafusion-sqlparser-rs/pull/1745) (mvzink)


### PR DESCRIPTION
Part of 
- https://github.com/apache/datafusion-sqlparser-rs/issues/1671

1. Updates the version
2. Adds a changelog. See rendered version here: https://github.com/alamb/sqlparser-rs/blob/alamb/prepare_0.55.0/changelog/0.55.0.md