### PR TITLE
Standardize CREATE TABLE options equals signs

### DIFF
--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -362,7 +362,7 @@ impl Display for CreateTable {
             write!(f, " WITH ({})", display_comma_separated(&self.with_options))?;
         }
         if let Some(engine) = &self.engine {
-            write!(f, " ENGINE={engine}")?;
+            write!(f, " ENGINE = {engine}")?;
         }
         if let Some(comment_def) = &self.comment {
             match comment_def {
@@ -378,7 +378,7 @@ impl Display for CreateTable {
         }
 
         if let Some(auto_increment_offset) = self.auto_increment_offset {
-            write!(f, " AUTO_INCREMENT {auto_increment_offset}")?;
+            write!(f, " AUTO_INCREMENT = {auto_increment_offset}")?;
         }
         if let Some(primary_key) = &self.primary_key {
             write!(f, " PRIMARY KEY {}", primary_key)?;
@@ -433,7 +433,7 @@ impl Display for CreateTable {
         if let Some(is_enabled) = self.enable_schema_evolution {
             write!(
                 f,
-                " ENABLE_SCHEMA_EVOLUTION={}",
+                " ENABLE_SCHEMA_EVOLUTION = {}",
                 if is_enabled { "TRUE" } else { "FALSE" }
             )?;
         }
@@ -441,7 +441,7 @@ impl Display for CreateTable {
         if let Some(is_enabled) = self.change_tracking {
             write!(
                 f,
-                " CHANGE_TRACKING={}",
+                " CHANGE_TRACKING = {}",
                 if is_enabled { "TRUE" } else { "FALSE" }
             )?;
         }
@@ -449,19 +449,19 @@ impl Display for CreateTable {
         if let Some(data_retention_time_in_days) = self.data_retention_time_in_days {
             write!(
                 f,
-                " DATA_RETENTION_TIME_IN_DAYS={data_retention_time_in_days}",
+                " DATA_RETENTION_TIME_IN_DAYS = {data_retention_time_in_days}",
             )?;
         }
 
         if let Some(max_data_extension_time_in_days) = self.max_data_extension_time_in_days {
             write!(
                 f,
-                " MAX_DATA_EXTENSION_TIME_IN_DAYS={max_data_extension_time_in_days}",
+                " MAX_DATA_EXTENSION_TIME_IN_DAYS = {max_data_extension_time_in_days}",
             )?;
         }
 
         if let Some(default_ddl_collation) = &self.default_ddl_collation {
-            write!(f, " DEFAULT_DDL_COLLATION='{default_ddl_collation}'",)?;
+            write!(f, " DEFAULT_DDL_COLLATION = '{default_ddl_collation}'",)?;
         }
 
         if let Some(with_aggregation_policy) = &self.with_aggregation_policy {
@@ -477,10 +477,10 @@ impl Display for CreateTable {
         }
 
         if let Some(default_charset) = &self.default_charset {
-            write!(f, " DEFAULT CHARSET={default_charset}")?;
+            write!(f, " DEFAULT CHARSET = {default_charset}")?;
         }
         if let Some(collation) = &self.collation {
-            write!(f, " COLLATE={collation}")?;
+            write!(f, " COLLATE = {collation}")?;
         }
 
         if self.on_commit.is_some() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6730,7 +6730,7 @@ impl<'a> Parser<'a> {
         let table_properties = self.parse_options(Keyword::TBLPROPERTIES)?;
 
         let engine = if self.parse_keyword(Keyword::ENGINE) {
-            self.expect_token(&Token::Eq)?;
+            let _ = self.consume_token(&Token::Eq);
             let next_token = self.next_token();
             match next_token.token {
                 Token::Word(w) => {
@@ -6787,8 +6787,10 @@ impl<'a> Parser<'a> {
 
         let create_table_config = self.parse_optional_create_table_config()?;
 
-        let default_charset = if self.parse_keywords(&[Keyword::DEFAULT, Keyword::CHARSET]) {
-            self.expect_token(&Token::Eq)?;
+        let default_charset = if self.parse_keywords(&[Keyword::DEFAULT, Keyword::CHARSET])
+            || self.parse_keyword(Keyword::CHARSET)
+        {
+            let _ = self.consume_token(&Token::Eq);
             let next_token = self.next_token();
             match next_token.token {
                 Token::Word(w) => Some(w.value),
@@ -6798,8 +6800,10 @@ impl<'a> Parser<'a> {
             None
         };
 
-        let collation = if self.parse_keywords(&[Keyword::COLLATE]) {
-            self.expect_token(&Token::Eq)?;
+        let collation = if self.parse_keywords(&[Keyword::DEFAULT, Keyword::COLLATE])
+            || self.parse_keyword(Keyword::COLLATE)
+        {
+            let _ = self.consume_token(&Token::Eq);
             let next_token = self.next_token();
             match next_token.token {
                 Token::Word(w) => Some(w.value),

--- a/tests/sqlparser_clickhouse.rs
+++ b/tests/sqlparser_clickhouse.rs
@@ -219,10 +219,10 @@ fn parse_delimited_identifiers() {
 
 #[test]
 fn parse_create_table() {
-    clickhouse().verified_stmt(r#"CREATE TABLE "x" ("a" "int") ENGINE=MergeTree ORDER BY ("x")"#);
-    clickhouse().verified_stmt(r#"CREATE TABLE "x" ("a" "int") ENGINE=MergeTree ORDER BY "x""#);
+    clickhouse().verified_stmt(r#"CREATE TABLE "x" ("a" "int") ENGINE = MergeTree ORDER BY ("x")"#);
+    clickhouse().verified_stmt(r#"CREATE TABLE "x" ("a" "int") ENGINE = MergeTree ORDER BY "x""#);
     clickhouse().verified_stmt(
-        r#"CREATE TABLE "x" ("a" "int") ENGINE=MergeTree ORDER BY "x" AS SELECT * FROM "t" WHERE true"#,
+        r#"CREATE TABLE "x" ("a" "int") ENGINE = MergeTree ORDER BY "x" AS SELECT * FROM "t" WHERE true"#,
     );
 }
 
@@ -589,7 +589,7 @@ fn parse_clickhouse_data_types() {
 
 #[test]
 fn parse_create_table_with_nullable() {
-    let sql = r#"CREATE TABLE table (k UInt8, `a` Nullable(String), `b` Nullable(DateTime64(9, 'UTC')), c Nullable(DateTime64(9)), d Date32 NULL) ENGINE=MergeTree ORDER BY (`k`)"#;
+    let sql = r#"CREATE TABLE table (k UInt8, `a` Nullable(String), `b` Nullable(DateTime64(9, 'UTC')), c Nullable(DateTime64(9)), d Date32 NULL) ENGINE = MergeTree ORDER BY (`k`)"#;
     // ClickHouse has a case-sensitive definition of data type, but canonical representation is not
     let canonical_sql = sql.replace("String", "STRING");
 
@@ -638,7 +638,7 @@ fn parse_create_table_with_nested_data_types() {
         " k Array(Tuple(FixedString(128), Int128)),",
         " l Tuple(a DateTime64(9), b Array(UUID)),",
         " m Map(String, UInt16)",
-        ") ENGINE=MergeTree ORDER BY (k)"
+        ") ENGINE = MergeTree ORDER BY (k)"
     );
 
     match clickhouse().one_statement_parses_to(sql, "") {
@@ -714,7 +714,7 @@ fn parse_create_table_with_nested_data_types() {
 fn parse_create_table_with_primary_key() {
     match clickhouse_and_generic().verified_stmt(concat!(
         r#"CREATE TABLE db.table (`i` INT, `k` INT)"#,
-        " ENGINE=SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')",
+        " ENGINE = SharedMergeTree('/clickhouse/tables/{uuid}/{shard}', '{replica}')",
         " PRIMARY KEY tuple(i)",
         " ORDER BY tuple(i)",
     )) {
@@ -798,7 +798,7 @@ fn parse_create_table_with_variant_default_expressions() {
         " b DATETIME EPHEMERAL now(),",
         " c DATETIME EPHEMERAL,",
         " d STRING ALIAS toString(c)",
-        ") ENGINE=MergeTree"
+        ") ENGINE = MergeTree"
     );
     match clickhouse_and_generic().verified_stmt(sql) {
         Statement::CreateTable(CreateTable { columns, .. }) => {

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -115,7 +115,7 @@ fn test_snowflake_create_or_replace_table_copy_grants_cta() {
 
 #[test]
 fn test_snowflake_create_table_enable_schema_evolution() {
-    let sql = "CREATE TABLE my_table (a number) ENABLE_SCHEMA_EVOLUTION=TRUE";
+    let sql = "CREATE TABLE my_table (a number) ENABLE_SCHEMA_EVOLUTION = TRUE";
     match snowflake().verified_stmt(sql) {
         Statement::CreateTable(CreateTable {
             name,
@@ -131,7 +131,7 @@ fn test_snowflake_create_table_enable_schema_evolution() {
 
 #[test]
 fn test_snowflake_create_table_change_tracking() {
-    let sql = "CREATE TABLE my_table (a number) CHANGE_TRACKING=TRUE";
+    let sql = "CREATE TABLE my_table (a number) CHANGE_TRACKING = TRUE";
     match snowflake().verified_stmt(sql) {
         Statement::CreateTable(CreateTable {
             name,
@@ -147,7 +147,7 @@ fn test_snowflake_create_table_change_tracking() {
 
 #[test]
 fn test_snowflake_create_table_data_retention_time_in_days() {
-    let sql = "CREATE TABLE my_table (a number) DATA_RETENTION_TIME_IN_DAYS=5";
+    let sql = "CREATE TABLE my_table (a number) DATA_RETENTION_TIME_IN_DAYS = 5";
     match snowflake().verified_stmt(sql) {
         Statement::CreateTable(CreateTable {
             name,
@@ -163,7 +163,7 @@ fn test_snowflake_create_table_data_retention_time_in_days() {
 
 #[test]
 fn test_snowflake_create_table_max_data_extension_time_in_days() {
-    let sql = "CREATE TABLE my_table (a number) MAX_DATA_EXTENSION_TIME_IN_DAYS=5";
+    let sql = "CREATE TABLE my_table (a number) MAX_DATA_EXTENSION_TIME_IN_DAYS = 5";
     match snowflake().verified_stmt(sql) {
         Statement::CreateTable(CreateTable {
             name,
@@ -303,7 +303,7 @@ fn test_snowflake_create_table_with_tag() {
 
 #[test]
 fn test_snowflake_create_table_default_ddl_collation() {
-    let sql = "CREATE TABLE my_table (a number) DEFAULT_DDL_COLLATION='de'";
+    let sql = "CREATE TABLE my_table (a number) DEFAULT_DDL_COLLATION = 'de'";
     match snowflake().verified_stmt(sql) {
         Statement::CreateTable(CreateTable {
             name,
@@ -856,7 +856,7 @@ fn test_snowflake_create_table_with_several_column_options() {
 fn test_snowflake_create_iceberg_table_all_options() {
     match snowflake().verified_stmt("CREATE ICEBERG TABLE my_table (a INT, b INT) \
     CLUSTER BY (a, b) EXTERNAL_VOLUME = 'volume' CATALOG = 'SNOWFLAKE' BASE_LOCATION = 'relative/path' CATALOG_SYNC = 'OPEN_CATALOG' \
-    STORAGE_SERIALIZATION_POLICY = COMPATIBLE COPY GRANTS CHANGE_TRACKING=TRUE DATA_RETENTION_TIME_IN_DAYS=5 MAX_DATA_EXTENSION_TIME_IN_DAYS=10 \
+    STORAGE_SERIALIZATION_POLICY = COMPATIBLE COPY GRANTS CHANGE_TRACKING = TRUE DATA_RETENTION_TIME_IN_DAYS = 5 MAX_DATA_EXTENSION_TIME_IN_DAYS = 10 \
     WITH AGGREGATION POLICY policy_name WITH ROW ACCESS POLICY policy_name ON (a) WITH TAG (A='TAG A', B='TAG B')") {
         Statement::CreateTable(CreateTable {
             name, cluster_by, base_location,


### PR DESCRIPTION
* Make spaces around equals signs canonical: `ENGINE = InnoDB` instead of `ENGINE=InnoDB`
* Make equals signs canonical: `AUTO_INCREMENT = 100` instead of `AUTO_INCREMENT 100`
* Make equals signs optional for charset, engine, and collation to match MySQl: `COLLATE utf8mb4_unicode_ci` works as well as `COLLATE = utf8mb4_unicode_ci`

In some dialects, some options might require the equals signs, so will be more permissive in some situations. For example, [ClickHouse] requires the equals signs for `ENGINE`. It didn't seem worth special casing this to me.

[ClickHouse]: https://clickhouse.com/docs/en/sql-reference/statements/create/table/#create-table-options