### PR TITLE
Snowflake: Support dollar quoted comments

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -245,14 +245,6 @@ impl Dialect for SnowflakeDialect {
                     .map(|p| Some(ColumnOption::Policy(ColumnPolicy::ProjectionPolicy(p)))))
             } else if parser.parse_keywords(&[Keyword::TAG]) {
                 Ok(parse_column_tags(parser, with).map(|p| Some(ColumnOption::Tags(p))))
-            } else if parser.parse_keywords(&[Keyword::COMMENT]) {
-                let next_token = parser.next_token();
-                match next_token.token {
-                    Token::DollarQuotedString(value, ..) => {
-                        Ok(Ok(Some(ColumnOption::Comment(value.value))))
-                    }
-                    _ => Err(ParserError::ParserError("not found match".to_string())),
-                }
             } else {
                 Err(ParserError::ParserError("not found match".to_string()))
             }
@@ -430,7 +422,7 @@ pub fn parse_create_table(
                 Keyword::COMMENT => {
                     // Rewind the COMMENT keyword
                     parser.prev_token();
-                    builder = builder.comment(parser.parse_optional_inline_comment(true)?);
+                    builder = builder.comment(parser.parse_optional_inline_comment()?);
                 }
                 Keyword::AS => {
                     let query = parser.parse_query()?;

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -644,11 +644,7 @@ pub fn parse_create_stage(
     // [ comment ]
     if parser.parse_keyword(Keyword::COMMENT) {
         parser.expect_token(&Token::Eq)?;
-        comment = Some(match parser.next_token().token {
-            Token::SingleQuotedString(word) => Ok(word),
-            Token::DollarQuotedString(word) => Ok(word.value),
-            _ => parser.expected("a comment statement", parser.peek_token()),
-        }?)
+        comment = Some(parser.parse_comment_value()?);
     }
 
     Ok(Statement::CreateStage {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6933,7 +6933,7 @@ impl<'a> Parser<'a> {
         Ok(comment)
     }
 
-    fn parse_comment_value(&mut self) -> Result<String, ParserError> {
+    pub fn parse_comment_value(&mut self) -> Result<String, ParserError> {
         let next_token = self.next_token();
         let value = match next_token.token {
             Token::SingleQuotedString(str) => str,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7078,14 +7078,7 @@ impl<'a> Parser<'a> {
         } else if self.parse_keywords(&[Keyword::NOT, Keyword::NULL]) {
             Ok(Some(ColumnOption::NotNull))
         } else if self.parse_keywords(&[Keyword::COMMENT]) {
-            let next_token = self.next_token();
-            match next_token.token {
-                Token::SingleQuotedString(value, ..) => Ok(Some(ColumnOption::Comment(value))),
-                Token::DollarQuotedString(value, ..) => {
-                    Ok(Some(ColumnOption::Comment(value.value)))
-                }
-                _ => self.expected("string", next_token),
-            }
+            Ok(Some(ColumnOption::Comment(self.parse_comment_value()?)))
         } else if self.parse_keyword(Keyword::NULL) {
             Ok(Some(ColumnOption::Null))
         } else if self.parse_keyword(Keyword::DEFAULT) {

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -977,6 +977,27 @@ fn parse_sf_create_or_replace_with_comment_for_snowflake() {
 }
 
 #[test]
+fn parse_sf_create_table_or_view_with_dollars_comment() {
+    assert!(snowflake()
+        .parse_sql_statements(
+            r#"CREATE OR REPLACE TEMPORARY VIEW foo.bar.baz (
+            "COL_1" COMMENT $$comment 1$$
+        ) COMMENT = $$view comment$$ AS (
+            SELECT 1
+        )"#
+        )
+        .is_ok());
+
+    assert!(snowflake()
+        .parse_sql_statements(
+            r#"CREATE TABLE my_table (
+            a STRING COMMENT $$comment 1$$
+        ) COMMENT = $$table comment$$"#
+        )
+        .is_ok());
+}
+
+#[test]
 fn test_sf_derived_table_in_parenthesis() {
     // Nesting a subquery in an extra set of parentheses is non-standard,
     // but supported in Snowflake SQL

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -977,7 +977,7 @@ fn parse_sf_create_or_replace_with_comment_for_snowflake() {
 }
 
 #[test]
-fn parse_sf_create_table_or_view_with_dollars_comment() {
+fn parse_sf_create_table_or_view_with_dollar_quoted_comment() {
     assert!(snowflake()
         .parse_sql_statements(
             r#"CREATE OR REPLACE TEMPORARY VIEW foo.bar.baz (

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -978,23 +978,17 @@ fn parse_sf_create_or_replace_with_comment_for_snowflake() {
 
 #[test]
 fn parse_sf_create_table_or_view_with_dollar_quoted_comment() {
-    assert!(snowflake()
-        .parse_sql_statements(
-            r#"CREATE OR REPLACE TEMPORARY VIEW foo.bar.baz (
-            "COL_1" COMMENT $$comment 1$$
-        ) COMMENT = $$view comment$$ AS (
-            SELECT 1
-        )"#
-        )
-        .is_ok());
+    // Snowflake transforms dollar quoted comments into a common comment in DDL representation of creation
+    snowflake()
+        .one_statement_parses_to(
+            r#"CREATE OR REPLACE TEMPORARY VIEW foo.bar.baz ("COL_1" COMMENT $$comment 1$$) COMMENT = $$view comment$$ AS (SELECT 1)"#,
+            r#"CREATE OR REPLACE TEMPORARY VIEW foo.bar.baz ("COL_1" COMMENT 'comment 1') COMMENT = 'view comment' AS (SELECT 1)"#
+        );
 
-    assert!(snowflake()
-        .parse_sql_statements(
-            r#"CREATE TABLE my_table (
-            a STRING COMMENT $$comment 1$$
-        ) COMMENT = $$table comment$$"#
-        )
-        .is_ok());
+    snowflake().one_statement_parses_to(
+        r#"CREATE TABLE my_table (a STRING COMMENT $$comment 1$$) COMMENT = $$table comment$$"#,
+        r#"CREATE TABLE my_table (a STRING COMMENT 'comment 1') COMMENT = 'table comment'"#,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Snowflake [supports](https://docs.snowflake.com/en/sql-reference/literals-table) dollar-quoted comments as string literals when creating tables, views, and their fields.

For example:
```
CREATE OR REPLACE TEMPORARY VIEW foo.bar.baz (
    "COL_1" COMMENT $$comment 1$$
) COMMENT = $$view comment$$ AS (
    SELECT 1
)
```

This pull request adds support for this type of comments.