### PR TITLE
Mysql: Add support for := operator

### DIFF
--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -321,6 +321,9 @@ pub enum BinaryOperator {
     /// `~=` Same as? (PostgreSQL/Redshift geometric operator)
     /// See <https://www.postgresql.org/docs/9.5/functions-geometry.html>
     TildeEq,
+    /// ':=' Assignment Operator
+    /// See <https://dev.mysql.com/doc/refman/8.4/en/assignment-operators.html#operator_assign-value>
+    Assignment,
 }
 
 impl fmt::Display for BinaryOperator {
@@ -394,6 +397,7 @@ impl fmt::Display for BinaryOperator {
             BinaryOperator::QuestionDoublePipe => f.write_str("?||"),
             BinaryOperator::At => f.write_str("@"),
             BinaryOperator::TildeEq => f.write_str("~="),
+            BinaryOperator::Assignment => f.write_str(":="),
         }
     }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -620,7 +620,8 @@ pub trait Dialect: Debug + Any {
             Token::Word(w) if w.keyword == Keyword::OPERATOR => Ok(p!(Between)),
             Token::Word(w) if w.keyword == Keyword::DIV => Ok(p!(MulDivModOp)),
             Token::Period => Ok(p!(Period)),
-            Token::Eq
+            Token::Assignment
+            | Token::Eq
             | Token::Lt
             | Token::LtEq
             | Token::Neq

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3233,6 +3233,7 @@ impl<'a> Parser<'a> {
         let regular_binary_operator = match &tok.token {
             Token::Spaceship => Some(BinaryOperator::Spaceship),
             Token::DoubleEq => Some(BinaryOperator::Eq),
+            Token::Assignment => Some(BinaryOperator::Assignment),
             Token::Eq => Some(BinaryOperator::Eq),
             Token::Neq => Some(BinaryOperator::NotEq),
             Token::Gt => Some(BinaryOperator::Gt),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3522,10 +3522,9 @@ fn test_variable_assignment_using_colon_equal() {
                                 span: Span::empty(),
                             })),
                             op: BinaryOperator::Multiply,
-                            right: Box::new(Expr::Value(ValueWithSpan {
-                                value: Value::Number("0.1".to_string(), false),
-                                span: Span::empty(),
-                            })),
+                            right: Box::new(Expr::Value(
+                                (test_utils::number("0.1")).with_empty_span()
+                            )),
                         }),
                     }),
                 ]
@@ -3540,10 +3539,7 @@ fn test_variable_assignment_using_colon_equal() {
                         span: Span::empty(),
                     })),
                     op: BinaryOperator::Eq,
-                    right: Box::new(Expr::Value(ValueWithSpan {
-                        value: Value::Number("1".to_string(), false),
-                        span: Span::empty(),
-                    })),
+                    right: Box::new(Expr::Value((test_utils::number("1")).with_empty_span())),
                 })
             );
         }
@@ -3580,10 +3576,9 @@ fn test_variable_assignment_using_colon_equal() {
                                 span: Span::empty(),
                             })),
                             op: BinaryOperator::Multiply,
-                            right: Box::new(Expr::Value(ValueWithSpan {
-                                value: Value::Number("1.1".to_string(), false),
-                                span: Span::empty(),
-                            })),
+                            right: Box::new(Expr::Value(
+                                (test_utils::number("1.1")).with_empty_span()
+                            )),
                         }),
                     },
                 }]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3454,3 +3454,112 @@ fn parse_cast_integers() {
         .run_parser_method("CAST(foo AS UNSIGNED INTEGER(3))", |p| p.parse_expr())
         .expect_err("CAST doesn't allow display width");
 }
+
+#[test]
+fn test_variable_assignment_using_colon_equal() {
+    let sql_select = "SELECT @price := price, @tax := price * 0.1 FROM products WHERE id = 1";
+    let stmt = mysql().verified_stmt(sql_select);
+    match stmt {
+        Statement::Query(query) => {
+            let select = query.body.as_select().unwrap();
+
+            assert_eq!(
+                select.projection,
+                vec![
+                    SelectItem::UnnamedExpr(Expr::BinaryOp {
+                        left: Box::new(Expr::Identifier(Ident {
+                            value: "@price".to_string(),
+                            quote_style: None,
+                            span: Span::empty(),
+                        })),
+                        op: BinaryOperator::Assignment,
+                        right: Box::new(Expr::Identifier(Ident {
+                            value: "price".to_string(),
+                            quote_style: None,
+                            span: Span::empty(),
+                        })),
+                    }),
+                    SelectItem::UnnamedExpr(Expr::BinaryOp {
+                        left: Box::new(Expr::Identifier(Ident {
+                            value: "@tax".to_string(),
+                            quote_style: None,
+                            span: Span::empty(),
+                        })),
+                        op: BinaryOperator::Assignment,
+                        right: Box::new(Expr::BinaryOp {
+                            left: Box::new(Expr::Identifier(Ident {
+                                value: "price".to_string(),
+                                quote_style: None,
+                                span: Span::empty(),
+                            })),
+                            op: BinaryOperator::Multiply,
+                            right: Box::new(Expr::Value(ValueWithSpan {
+                                value: Value::Number("0.1".to_string(), false),
+                                span: Span::empty(),
+                            })),
+                        }),
+                    }),
+                ]
+            );
+
+            assert_eq!(
+                select.selection,
+                Some(Expr::BinaryOp {
+                    left: Box::new(Expr::Identifier(Ident {
+                        value: "id".to_string(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    })),
+                    op: BinaryOperator::Eq,
+                    right: Box::new(Expr::Value(ValueWithSpan {
+                        value: Value::Number("1".to_string(), false),
+                        span: Span::empty(),
+                    })),
+                })
+            );
+        }
+        _ => panic!("Unexpected statement {stmt}"),
+    }
+
+    let sql_update =
+        "UPDATE products SET price = @new_price := price * 1.1 WHERE category = 'Books'";
+    let stmt = mysql().verified_stmt(sql_update);
+
+    match stmt {
+        Statement::Update { assignments, .. } => {
+            assert_eq!(
+                assignments,
+                vec![Assignment {
+                    target: AssignmentTarget::ColumnName(ObjectName(vec![
+                        ObjectNamePart::Identifier(Ident {
+                            value: "price".to_string(),
+                            quote_style: None,
+                            span: Span::empty(),
+                        })
+                    ])),
+                    value: Expr::BinaryOp {
+                        left: Box::new(Expr::Identifier(Ident {
+                            value: "@new_price".to_string(),
+                            quote_style: None,
+                            span: Span::empty(),
+                        })),
+                        op: BinaryOperator::Assignment,
+                        right: Box::new(Expr::BinaryOp {
+                            left: Box::new(Expr::Identifier(Ident {
+                                value: "price".to_string(),
+                                quote_style: None,
+                                span: Span::empty(),
+                            })),
+                            op: BinaryOperator::Multiply,
+                            right: Box::new(Expr::Value(ValueWithSpan {
+                                value: Value::Number("1.1".to_string(), false),
+                                span: Span::empty(),
+                            })),
+                        }),
+                    },
+                }]
+            )
+        }
+        _ => panic!("Unexpected statement {stmt}"),
+    }
+}

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3455,6 +3455,7 @@ fn parse_cast_integers() {
         .expect_err("CAST doesn't allow display width");
 }
 
+#[test]
 fn parse_match_against_with_alias() {
     let sql = "SELECT tbl.ProjectID FROM surveys.tbl1 AS tbl WHERE MATCH (tbl.ReferenceID) AGAINST ('AAA' IN BOOLEAN MODE)";
     match mysql().verified_stmt(sql) {


### PR DESCRIPTION
add support for := operator-mysql
MySQL dialect supports the := operator to assign values to user-defined variables in expressions, typically used in SELECT or UPDATE queries.
see https://dev.mysql.com/doc/refman/8.4/en/assignment-operators.html#operator_assign-value