### PR TITLE
Add support for Databricks TIMESTAMP_NTZ.

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -312,6 +312,10 @@ pub enum DataType {
     ///
     /// [1]: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#datetime-type
     Timestamp(Option<u64>, TimezoneInfo),
+    /// Databricks timestamp without time zone. See [1].
+    ///
+    /// [1]: https://docs.databricks.com/aws/en/sql/language-manual/data-types/timestamp-ntz-type
+    TimestampNtz,
     /// Interval
     Interval,
     /// JSON type
@@ -567,6 +571,7 @@ impl fmt::Display for DataType {
             DataType::Timestamp(precision, timezone_info) => {
                 format_datetime_precision_and_tz(f, "TIMESTAMP", precision, timezone_info)
             }
+            DataType::TimestampNtz => write!(f, "TIMESTAMP_NTZ"),
             DataType::Datetime64(precision, timezone) => {
                 format_clickhouse_datetime_precision_and_timezone(
                     f,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -875,6 +875,7 @@ define_keywords!(
     TIME,
     TIMESTAMP,
     TIMESTAMPTZ,
+    TIMESTAMP_NTZ,
     TIMETZ,
     TIMEZONE,
     TIMEZONE_ABBR,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9247,6 +9247,7 @@ impl<'a> Parser<'a> {
                     self.parse_optional_precision()?,
                     TimezoneInfo::Tz,
                 )),
+                Keyword::TIMESTAMP_NTZ => Ok(DataType::TimestampNtz),
                 Keyword::TIME => {
                     let precision = self.parse_optional_precision()?;
                     let tz = if self.parse_keyword(Keyword::WITH) {

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -334,9 +334,9 @@ fn data_type_timestamp_ntz() {
         databricks().verified_expr("(created_at)::TIMESTAMP_NTZ"),
         Expr::Cast {
             kind: CastKind::DoubleColon,
-            expr: Box::new(Expr::Nested(
-                Box::new(Expr::Identifier("created_at".into()))
-            )),
+            expr: Box::new(Expr::Nested(Box::new(Expr::Identifier(
+                "created_at".into()
+            )))),
             data_type: DataType::TimestampNtz,
             format: None
         }
@@ -347,13 +347,11 @@ fn data_type_timestamp_ntz() {
         Statement::CreateTable(CreateTable { columns, .. }) => {
             assert_eq!(
                 columns,
-                vec![
-                    ColumnDef {
-                        name: "x".into(),
-                        data_type: DataType::TimestampNtz,
-                        options: vec![],
-                    }
-                ]
+                vec![ColumnDef {
+                    name: "x".into(),
+                    data_type: DataType::TimestampNtz,
+                    options: vec![],
+                }]
             );
         }
         s => panic!("Unexpected statement: {:?}", s),


### PR DESCRIPTION
This PR adds support for parsing Databricks' [TIMESTAMP_NTZ](https://docs.databricks.com/aws/en/sql/language-manual/data-types/timestamp-ntz-type) data type.