### PR TITLE
Fix: Snowflake ALTER SESSION cannot be followed by other statements.

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -1013,9 +1013,15 @@ fn parse_session_options(
     let mut options: Vec<KeyValueOption> = Vec::new();
     let empty = String::new;
     loop {
-        match parser.next_token().token {
-            Token::Comma => continue,
+        let next_token = parser.peek_token();
+        match next_token.token {
+            Token::SemiColon | Token::EOF => break,
+            Token::Comma => {
+                parser.advance_token();
+                continue;
+            }
             Token::Word(key) => {
+                parser.advance_token();
                 if set {
                     let option = parse_option(parser, key)?;
                     options.push(option);
@@ -1028,10 +1034,7 @@ fn parse_session_options(
                 }
             }
             _ => {
-                if parser.peek_token().token == Token::EOF {
-                    break;
-                }
-                return parser.expected("another option", parser.peek_token());
+                return parser.expected("another option or end of statement", next_token);
             }
         }
     }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -3505,3 +3505,14 @@ fn test_alter_session() {
     );
     snowflake().one_statement_parses_to("ALTER SESSION UNSET a\nB", "ALTER SESSION UNSET a, B");
 }
+
+#[test]
+fn test_alter_session_followed_by_statement() {
+    let stmts = snowflake()
+        .parse_sql_statements("ALTER SESSION SET QUERY_TAG='hello'; SELECT 42")
+        .unwrap();
+    match stmts[..] {
+        [Statement::AlterSession { .. }, Statement::Query { .. }] => {}
+        _ => panic!("Unexpected statements: {:?}", stmts),
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/datafusion-sqlparser-rs/issues/1775.

Currently `parse_session_options` for Snowflake does not check for semicolons, which makes it impossible to parse multiple statements, where another statement comes after an `ALTER SESSION` statement.