### PR TITLE
Enable double-dot-notation for mssql.

### DIFF
--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -101,4 +101,9 @@ impl Dialect for MsSqlDialect {
     fn supports_nested_comments(&self) -> bool {
         true
     }
+
+    /// See <https://learn.microsoft.com/en-us/sql/t-sql/queries/from-transact-sql>
+    fn supports_object_name_double_dot_notation(&self) -> bool {
+        true
+    }
 }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1910,6 +1910,11 @@ fn parse_mssql_varbinary_max_length() {
     }
 }
 
+#[test]
+fn parse_mssql_table_identifier_with_default_schema() {
+    ms().verified_stmt("SELECT * FROM mydatabase..MyTable");
+}
+
 fn ms() -> TestedDialects {
     TestedDialects::new(vec![Box::new(MsSqlDialect {})])
 }


### PR DESCRIPTION
Since the schema name is optional in MSQL table identifiers, double-dot notation is supported, in which case the default dbo schema is used. This PR enables double-dot notation for the MSSQL dialect.