### PR TITLE
Add GreptimeDB to the "Users" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ $ cargo run --features json_example --example cli FILENAME.sql [--dialectname]
 ## Users
 
 This parser is currently being used by the [DataFusion] query engine, [LocustDB],
-[Ballista], [GlueSQL], [Opteryx], [Polars], [PRQL], [Qrlew], [JumpWire], [ParadeDB] and [CipherStash Proxy].
+[Ballista], [GlueSQL], [Opteryx], [Polars], [PRQL], [Qrlew], [JumpWire], [ParadeDB], [CipherStash Proxy],
+and [GreptimeDB].
 
 If your project is using sqlparser-rs feel free to make a PR to add it
 to this list.
@@ -276,3 +277,4 @@ licensed as above, without any additional terms or conditions.
 [`Dialect`]: https://docs.rs/sqlparser/latest/sqlparser/dialect/trait.Dialect.html
 [`GenericDialect`]: https://docs.rs/sqlparser/latest/sqlparser/dialect/struct.GenericDialect.html
 [CipherStash Proxy]: https://github.com/cipherstash/proxy
+[GreptimeDB]: https://github.com/GreptimeTeam/greptimedb


### PR DESCRIPTION
GreptimeDB uses sqlparser in its "RANGE" syntax, and various other places.