### PR TITLE
Allow single quotes in EXTRACT() for Redshift.

### DIFF
--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -121,4 +121,8 @@ impl Dialect for RedshiftSqlDialect {
     fn supports_array_typedef_with_brackets(&self) -> bool {
         true
     }
+
+    fn allow_extract_single_quotes(&self) -> bool {
+        true
+    }
 }

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -391,3 +391,9 @@ fn test_parse_nested_quoted_identifier() {
         .parse_sql_statements(r#"SELECT 1 AS ["1]"#)
         .is_err());
 }
+
+#[test]
+fn parse_extract_single_quotes() {
+    let sql = "SELECT EXTRACT('month' FROM my_timestamp) FROM my_table";
+    redshift().verified_stmt(&sql);
+}


### PR DESCRIPTION
Just like Postgres, Redshift supports enclosing the `datepart` parameter in single quotes. See also the examples in https://docs.aws.amazon.com/redshift/latest/dg/r_EXTRACT_function.html.