### PR TITLE
Fix clippy lint on rust 1.86

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -868,7 +868,7 @@ impl fmt::Display for AlterColumnOperation {
             AlterColumnOperation::SetDefault { value } => {
                 write!(f, "SET DEFAULT {value}")
             }
-            AlterColumnOperation::DropDefault {} => {
+            AlterColumnOperation::DropDefault => {
                 write!(f, "DROP DEFAULT")
             }
             AlterColumnOperation::SetDataType { data_type, using } => {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -662,17 +662,17 @@ pub enum Expr {
     /// such as maps, arrays, and lists:
     /// - Array
     ///     - A 1-dim array `a[1]` will be represented like:
-    ///         `CompoundFieldAccess(Ident('a'), vec![Subscript(1)]`
+    ///       `CompoundFieldAccess(Ident('a'), vec![Subscript(1)]`
     ///     - A 2-dim array `a[1][2]` will be represented like:
-    ///         `CompoundFieldAccess(Ident('a'), vec![Subscript(1), Subscript(2)]`
+    ///       `CompoundFieldAccess(Ident('a'), vec![Subscript(1), Subscript(2)]`
     /// - Map or Struct (Bracket-style)
     ///     - A map `a['field1']` will be represented like:
-    ///         `CompoundFieldAccess(Ident('a'), vec![Subscript('field')]`
+    ///       `CompoundFieldAccess(Ident('a'), vec![Subscript('field')]`
     ///     - A 2-dim map `a['field1']['field2']` will be represented like:
-    ///         `CompoundFieldAccess(Ident('a'), vec![Subscript('field1'), Subscript('field2')]`
+    ///       `CompoundFieldAccess(Ident('a'), vec![Subscript('field1'), Subscript('field2')]`
     /// - Struct (Dot-style) (only effect when the chain contains both subscript and expr)
     ///     - A struct access `a[field1].field2` will be represented like:
-    ///         `CompoundFieldAccess(Ident('a'), vec![Subscript('field1'), Ident('field2')]`
+    ///       `CompoundFieldAccess(Ident('a'), vec![Subscript('field1'), Ident('field2')]`
     /// - If a struct access likes `a.field1.field2`, it will be represented by CompoundIdentifier([a, field1, field2])
     CompoundFieldAccess {
         root: Box<Expr>,
@@ -7617,7 +7617,7 @@ impl fmt::Display for CopyTarget {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use CopyTarget::*;
         match self {
-            Stdin { .. } => write!(f, "STDIN"),
+            Stdin => write!(f, "STDIN"),
             Stdout => write!(f, "STDOUT"),
             File { filename } => write!(f, "'{}'", value::escape_single_quote_string(filename)),
             Program { command } => write!(

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -1038,14 +1038,13 @@ fn parse_session_options(
             }
         }
     }
-    options
-        .is_empty()
-        .then(|| {
-            Err(ParserError::ParserError(
-                "expected at least one option".to_string(),
-            ))
-        })
-        .unwrap_or(Ok(options))
+    if options.is_empty() {
+        Err(ParserError::ParserError(
+            "expected at least one option".to_string(),
+        ))
+    } else {
+        Ok(options)
+    }
 }
 
 /// Parses options provided within parentheses like:

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -18,14 +18,14 @@
 //! This module defines
 //! 1) a list of constants for every keyword
 //! 2) an `ALL_KEYWORDS` array with every keyword in it
-//!     This is not a list of *reserved* keywords: some of these can be
-//!     parsed as identifiers if the parser decides so. This means that
-//!     new keywords can be added here without affecting the parse result.
+//!    This is not a list of *reserved* keywords: some of these can be
+//!    parsed as identifiers if the parser decides so. This means that
+//!    new keywords can be added here without affecting the parse result.
 //!
-//!     As a matter of fact, most of these keywords are not used at all
-//!     and could be removed.
+//!    As a matter of fact, most of these keywords are not used at all
+//!    and could be removed.
 //! 3) a `RESERVED_FOR_TABLE_ALIAS` array with keywords reserved in a
-//!     "table alias" context.
+//!    "table alias" context.
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -14091,8 +14091,7 @@ fn test_table_sample() {
 
 #[test]
 fn overflow() {
-    let expr = std::iter::repeat("1")
-        .take(1000)
+    let expr = std::iter::repeat_n("1", 1000)
         .collect::<Vec<_>>()
         .join(" + ");
     let sql = format!("SELECT {}", expr);


### PR DESCRIPTION
Fixes [lint failures in CI](https://github.com/apache/datafusion-sqlparser-rs/actions/runs/14236730212/job/39938621832?pr=1790) from the latest rust release