### PR TITLE
Allow literal backslash escapes for string literals in Redshift dialect.

### DIFF
--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -125,4 +125,8 @@ impl Dialect for RedshiftSqlDialect {
     fn allow_extract_single_quotes(&self) -> bool {
         true
     }
+
+    fn supports_string_literal_backslash_escape(&self) -> bool {
+        true
+    }
 }

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -397,3 +397,8 @@ fn parse_extract_single_quotes() {
     let sql = "SELECT EXTRACT('month' FROM my_timestamp) FROM my_table";
     redshift().verified_stmt(sql);
 }
+
+#[test]
+fn parse_string_literal_backslash_escape() {
+    redshift().one_statement_parses_to(r#"SELECT 'l\'auto'"#, "SELECT 'l''auto'");
+}


### PR DESCRIPTION
Redshift supports the literal backslash escape at least for a subset of characters, including single quotes ('), for example
```sql
SELECT 'l\'auto'
```
This is unfortunately not publicly documented (yet?) but used in successful queries.