### PR TITLE
Snowflake COPY INTO target columns, select items and optional alias

### DIFF
--- a/src/ast/helpers/stmt_data_loading.rs
+++ b/src/ast/helpers/stmt_data_loading.rs
@@ -29,7 +29,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use crate::ast::helpers::key_value_options::KeyValueOptions;
-use crate::ast::{Ident, ObjectName};
+use crate::ast::{Ident, ObjectName, SelectItem};
 #[cfg(feature = "visitor")]
 use sqlparser_derive::{Visit, VisitMut};
 
@@ -42,6 +42,25 @@ pub struct StageParamsObject {
     pub endpoint: Option<String>,
     pub storage_integration: Option<String>,
     pub credentials: KeyValueOptions,
+}
+
+/// This enum enables support for both standard SQL select item expressions
+/// and Snowflake-specific ones for data loading.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum StageLoadSelectItemKind {
+    SelectItem(SelectItem),
+    StageLoadSelectItem(StageLoadSelectItem),
+}
+
+impl fmt::Display for StageLoadSelectItemKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self {
+            StageLoadSelectItemKind::SelectItem(item) => write!(f, "{item}"),
+            StageLoadSelectItemKind::StageLoadSelectItem(item) => write!(f, "{item}"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -350,6 +350,7 @@ impl Spanned for Statement {
             } => source.span(),
             Statement::CopyIntoSnowflake {
                 into: _,
+                into_columns: _,
                 from_obj: _,
                 from_obj_alias: _,
                 stage_params: _,

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -878,14 +878,10 @@ fn parse_select_items_for_data_load(
                 parser.parse_select_item()?,
             )),
         }
-        match parser.next_token().token {
-            Token::Comma => {
-                // continue
-            }
-            _ => {
-                parser.prev_token(); // need to move back
-                break;
-            }
+        if matches!(parser.peek_token_ref().token, Token::Comma) {
+            parser.advance_token();
+        } else {
+            break;
         }
     }
     Ok(Some(select_items))


### PR DESCRIPTION
This PR adds support for the following in Snowflake's COPY INTO:
1. Specifying a list of columns in the destination table:
```sql
COPY INTO [<namespace>.]<table_name> [ ( <col_name> [ , <col_name> ... ] ) ]
```
2. Using regular SQL expressions in the data transformation query, typically for constant or computed values:
```sql
SELECT t1.$1:st AS st, $1:index, t2.$1, 4, '5' AS const_str FROM @schema.general_finished
```
3. The `AS` keyword is optional when specifying an alias for the stage in the data transformation query
```sql
COPY INTO tbl FROM (SELECT t1.$1:st AS st, 4, '5' AS const_str FROM @stage S)
```