### PR TITLE
Add `CREATE FUNCTION` support for SQL Server

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2157,6 +2157,10 @@ impl fmt::Display for ClusteredBy {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct CreateFunction {
+    /// True if this is a `CREATE OR ALTER FUNCTION` statement
+    ///
+    /// [MsSql](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16#or-alter)
+    pub or_alter: bool,
     pub or_replace: bool,
     pub temporary: bool,
     pub if_not_exists: bool,
@@ -2219,9 +2223,10 @@ impl fmt::Display for CreateFunction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "CREATE {or_replace}{temp}FUNCTION {if_not_exists}{name}",
+            "CREATE {or_alter}{or_replace}{temp}FUNCTION {if_not_exists}{name}",
             name = self.name,
             temp = if self.temporary { "TEMPORARY " } else { "" },
+            or_alter = if self.or_alter { "OR ALTER " } else { "" },
             or_replace = if self.or_replace { "OR REPLACE " } else { "" },
             if_not_exists = if self.if_not_exists {
                 "IF NOT EXISTS "

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2277,11 +2277,9 @@ impl fmt::Display for CreateFunction {
         if let Some(CreateFunctionBody::AsAfterOptions(function_body)) = &self.function_body {
             write!(f, " AS {function_body}")?;
         }
-        if let Some(CreateFunctionBody::MultiStatement(statements)) = &self.function_body {
+        if let Some(CreateFunctionBody::AsBeginEnd(bes)) = &self.function_body {
             write!(f, " AS")?;
-            write!(f, " BEGIN")?;
-            write!(f, " {}", display_separated(statements, "; "))?;
-            write!(f, " END")?;
+            write!(f, " {}", bes)?;
         }
         Ok(())
     }

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2278,8 +2278,7 @@ impl fmt::Display for CreateFunction {
             write!(f, " AS {function_body}")?;
         }
         if let Some(CreateFunctionBody::AsBeginEnd(bes)) = &self.function_body {
-            write!(f, " AS")?;
-            write!(f, " {}", bes)?;
+            write!(f, " AS {bes}")?;
         }
         Ok(())
     }

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2272,6 +2272,12 @@ impl fmt::Display for CreateFunction {
         if let Some(CreateFunctionBody::AsAfterOptions(function_body)) = &self.function_body {
             write!(f, " AS {function_body}")?;
         }
+        if let Some(CreateFunctionBody::MultiStatement(statements)) = &self.function_body {
+            write!(f, " AS")?;
+            write!(f, " BEGIN")?;
+            write!(f, " {}", display_separated(statements, "; "))?;
+            write!(f, " END")?;
+        }
         Ok(())
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2318,7 +2318,14 @@ impl fmt::Display for ConditionalStatements {
     }
 }
 
-/// A shared representation of `BEGIN`, multiple statements, and `END` tokens.
+/// Represents a list of statements enclosed within `BEGIN` and `END` keywords.
+/// Example:
+/// ```sql
+/// BEGIN
+///     SELECT 1;
+///     SELECT 2;
+/// END
+/// ```
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
@@ -9273,17 +9280,10 @@ impl fmt::Display for PrintStatement {
     }
 }
 
-/// Return (MsSql)
+/// Represents a `Return` statement.
 ///
-/// for Functions:
-/// RETURN scalar_expression
-///
-/// See <https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql>
-///
-/// for Triggers:
-/// RETURN
-///
-/// See <https://learn.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql>
+/// [MsSql triggers](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql)
+/// [MsSql functions](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql)
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -779,11 +779,9 @@ impl Spanned for ConditionalStatements {
             ConditionalStatements::Sequence { statements } => {
                 union_spans(statements.iter().map(|s| s.span()))
             }
-            ConditionalStatements::BeginEnd {
-                begin_token: AttachedToken(start),
-                statements: _,
-                end_token: AttachedToken(end),
-            } => union_spans([start.span, end.span].into_iter()),
+            ConditionalStatements::BeginEnd(bes) => {
+                union_spans([bes.begin_token.0.span, bes.end_token.0.span].into_iter())
+            }
         }
     }
 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -23,8 +23,8 @@ use crate::tokenizer::Span;
 use super::{
     dcl::SecondaryRoles, value::ValueWithSpan, AccessExpr, AlterColumnOperation,
     AlterIndexOperation, AlterTableOperation, Array, Assignment, AssignmentTarget, AttachedToken,
-    CaseStatement, CloseCursor, ClusteredIndex, ColumnDef, ColumnOption, ColumnOptionDef,
-    ConditionalStatementBlock, ConditionalStatements, ConflictTarget, ConnectBy,
+    BeginEndStatements, CaseStatement, CloseCursor, ClusteredIndex, ColumnDef, ColumnOption,
+    ColumnOptionDef, ConditionalStatementBlock, ConditionalStatements, ConflictTarget, ConnectBy,
     ConstraintCharacteristics, CopySource, CreateIndex, CreateTable, CreateTableOptions, Cte,
     Delete, DoUpdate, ExceptSelectItem, ExcludeSelectItem, Expr, ExprWithAlias, Fetch, FromTable,
     Function, FunctionArg, FunctionArgExpr, FunctionArgumentClause, FunctionArgumentList,
@@ -779,9 +779,7 @@ impl Spanned for ConditionalStatements {
             ConditionalStatements::Sequence { statements } => {
                 union_spans(statements.iter().map(|s| s.span()))
             }
-            ConditionalStatements::BeginEnd(bes) => {
-                union_spans([bes.begin_token.0.span, bes.end_token.0.span].into_iter())
-            }
+            ConditionalStatements::BeginEnd(bes) => bes.span(),
         }
     }
 }
@@ -2277,6 +2275,12 @@ impl Spanned for TableObject {
             }
             TableObject::TableFunction(func) => func.span(),
         }
+    }
+}
+
+impl Spanned for BeginEndStatements {
+    fn span(&self) -> Span {
+        union_spans([self.begin_token.0.span, self.end_token.0.span].into_iter())
     }
 }
 

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -520,6 +520,7 @@ impl Spanned for Statement {
             Statement::RenameTable { .. } => Span::empty(),
             Statement::RaisError { .. } => Span::empty(),
             Statement::Print { .. } => Span::empty(),
+            Statement::Return { .. } => Span::empty(),
             Statement::List(..) | Statement::Remove(..) => Span::empty(),
         }
     }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -2280,7 +2280,16 @@ impl Spanned for TableObject {
 
 impl Spanned for BeginEndStatements {
     fn span(&self) -> Span {
-        union_spans([self.begin_token.0.span, self.end_token.0.span].into_iter())
+        let BeginEndStatements {
+            begin_token,
+            statements,
+            end_token,
+        } = self;
+        union_spans(
+            core::iter::once(begin_token.0.span)
+                .chain(statements.iter().map(|i| i.span()))
+                .chain(core::iter::once(end_token.0.span)),
+        )
     }
 }
 

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -169,8 +169,10 @@ impl MsSqlDialect {
             }
         };
 
+        let mut prior_statement_ended_with_semi_colon = false;
         while let Token::SemiColon = parser.peek_token_ref().token {
             parser.advance_token();
+            prior_statement_ended_with_semi_colon = true;
         }
 
         let mut else_block = None;
@@ -201,6 +203,8 @@ impl MsSqlDialect {
                     },
                 });
             }
+        } else if prior_statement_ended_with_semi_colon {
+            parser.prev_token();
         }
 
         Ok(Statement::If(IfStatement {

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -16,7 +16,9 @@
 // under the License.
 
 use crate::ast::helpers::attached_token::AttachedToken;
-use crate::ast::{ConditionalStatementBlock, ConditionalStatements, IfStatement, Statement};
+use crate::ast::{
+    BeginEndStatements, ConditionalStatementBlock, ConditionalStatements, IfStatement, Statement,
+};
 use crate::dialect::Dialect;
 use crate::keywords::{self, Keyword};
 use crate::parser::{Parser, ParserError};
@@ -149,11 +151,11 @@ impl MsSqlDialect {
                 start_token: AttachedToken(if_token),
                 condition: Some(condition),
                 then_token: None,
-                conditional_statements: ConditionalStatements::BeginEnd {
+                conditional_statements: ConditionalStatements::BeginEnd(BeginEndStatements {
                     begin_token: AttachedToken(begin_token),
                     statements,
                     end_token: AttachedToken(end_token),
-                },
+                }),
             }
         } else {
             let stmt = parser.parse_statement()?;
@@ -182,11 +184,11 @@ impl MsSqlDialect {
                     start_token: AttachedToken(else_token),
                     condition: None,
                     then_token: None,
-                    conditional_statements: ConditionalStatements::BeginEnd {
+                    conditional_statements: ConditionalStatements::BeginEnd(BeginEndStatements {
                         begin_token: AttachedToken(begin_token),
                         statements,
                         end_token: AttachedToken(end_token),
-                    },
+                    }),
                 });
             } else {
                 let stmt = parser.parse_statement()?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15130,15 +15130,11 @@ impl<'a> Parser<'a> {
 
     /// Parse [Statement::Return]
     fn parse_return(&mut self) -> Result<Statement, ParserError> {
-        let current_index = self.index;
-        match self.parse_expr() {
-            Ok(expr) => Ok(Statement::Return(ReturnStatement {
+        match self.maybe_parse(|p| p.parse_expr())? {
+            Some(expr) => Ok(Statement::Return(ReturnStatement {
                 value: Some(ReturnStatementValue::Expr(expr)),
             })),
-            Err(_) => {
-                self.index = current_index;
-                Ok(Statement::Return(ReturnStatement { value: None }))
-            }
+            None => Ok(Statement::Return(ReturnStatement { value: None })),
         }
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4454,16 +4454,7 @@ impl<'a> Parser<'a> {
                 }
             }
             values.push(self.parse_statement()?);
-
-            let semi_colon_expected = match values.last() {
-                Some(Statement::If(if_statement)) => if_statement.end_token.is_some(),
-                Some(_) => true,
-                None => false,
-            };
-
-            if semi_colon_expected {
-                self.expect_token(&Token::SemiColon)?;
-            }
+            self.expect_token(&Token::SemiColon)?;
         }
         Ok(values)
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15130,10 +15130,16 @@ impl<'a> Parser<'a> {
 
     /// Parse [Statement::Return]
     fn parse_return(&mut self) -> Result<Statement, ParserError> {
-        let expr = self.parse_expr()?;
-        Ok(Statement::Return(ReturnStatement {
-            value: Some(ReturnStatementValue::Expr(expr)),
-        }))
+        let current_index = self.index;
+        match self.parse_expr() {
+            Ok(expr) => Ok(Statement::Return(ReturnStatement {
+                value: Some(ReturnStatementValue::Expr(expr)),
+            })),
+            Err(_) => {
+                self.index = current_index;
+                Ok(Statement::Return(ReturnStatement { value: None }))
+            }
+        }
     }
 
     /// Consume the parser and return its underlying token buffer

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5130,11 +5130,8 @@ impl<'a> Parser<'a> {
     ) -> Result<Statement, ParserError> {
         let (name, args) = self.parse_create_function_name_and_params()?;
 
-        let return_type = if self.parse_keyword(Keyword::RETURNS) {
-            Some(self.parse_data_type()?)
-        } else {
-            return parser_err!("Expected RETURNS keyword", self.peek_token().span.start);
-        };
+        self.expect_keyword(Keyword::RETURNS)?;
+        let return_type = Some(self.parse_data_type()?);
 
         self.expect_keyword_is(Keyword::AS)?;
 

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2134,6 +2134,7 @@ fn test_bigquery_create_function() {
     assert_eq!(
         stmt,
         Statement::CreateFunction(CreateFunction {
+            or_alter: false,
             or_replace: true,
             temporary: true,
             if_not_exists: false,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15029,3 +15029,8 @@ fn parse_set_time_zone_alias() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn parse_return() {
+    all_dialects().verified_stmt("RETURN");
+}

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15032,5 +15032,8 @@ fn parse_set_time_zone_alias() {
 
 #[test]
 fn parse_return() {
-    all_dialects().verified_stmt("RETURN");
+    let stmt = all_dialects().verified_stmt("RETURN");
+    assert_eq!(stmt, Statement::Return(ReturnStatement { value: None }));
+
+    let _ = all_dialects().verified_stmt("RETURN 1");
 }

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -25,7 +25,7 @@ use sqlparser::ast::{
     Expr, Function, FunctionArgumentList, FunctionArguments, Ident, ObjectName, OrderByExpr,
     OrderByOptions, SelectItem, Set, Statement, TableFactor, UnaryOperator, Use, Value,
 };
-use sqlparser::dialect::{GenericDialect, HiveDialect, MsSqlDialect};
+use sqlparser::dialect::{AnsiDialect, GenericDialect, HiveDialect};
 use sqlparser::parser::ParserError;
 use sqlparser::test_utils::*;
 
@@ -423,7 +423,7 @@ fn parse_create_function() {
     }
 
     // Test error in dialect that doesn't support parsing CREATE FUNCTION
-    let unsupported_dialects = TestedDialects::new(vec![Box::new(MsSqlDialect {})]);
+    let unsupported_dialects = TestedDialects::new(vec![Box::new(AnsiDialect {})]);
 
     assert_eq!(
         unsupported_dialects.parse_sql_statements(sql).unwrap_err(),

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -198,29 +198,17 @@ fn parse_create_function() {
             or_replace: false,
             temporary: false,
             if_not_exists: false,
-            name: ObjectName::from(vec![Ident {
-                value: "some_scalar_udf".into(),
-                quote_style: None,
-                span: Span::empty(),
-            }]),
+            name: ObjectName::from(vec![Ident::new("some_scalar_udf")]),
             args: Some(vec![
                 OperateFunctionArg {
                     mode: None,
-                    name: Some(Ident {
-                        value: "@foo".into(),
-                        quote_style: None,
-                        span: Span::empty(),
-                    }),
+                    name: Some(Ident::new("@foo")),
                     data_type: DataType::Int(None),
                     default_expr: None,
                 },
                 OperateFunctionArg {
                     mode: None,
-                    name: Some(Ident {
-                        value: "@bar".into(),
-                        quote_style: None,
-                        span: Span::empty(),
-                    }),
+                    name: Some(Ident::new("@bar")),
                     data_type: DataType::Varchar(Some(CharacterLength::IntegerLength {
                         length: 256,
                         unit: None
@@ -230,25 +218,13 @@ fn parse_create_function() {
             ]),
             return_type: Some(DataType::Int(None)),
             function_body: Some(CreateFunctionBody::AsBeginEnd(BeginEndStatements {
-                begin_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(
-                    sqlparser::tokenizer::Word {
-                        value: "BEGIN".to_string(),
-                        quote_style: None,
-                        keyword: Keyword::BEGIN
-                    }
-                ))),
+                begin_token: AttachedToken::empty(),
                 statements: vec![Statement::Return(ReturnStatement {
                     value: Some(ReturnStatementValue::Expr(Expr::Value(
                         (number("1")).with_empty_span()
                     ))),
                 }),],
-                end_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(
-                    sqlparser::tokenizer::Word {
-                        value: "END".to_string(),
-                        quote_style: None,
-                        keyword: Keyword::END
-                    }
-                ))),
+                end_token: AttachedToken::empty(),
             })),
             behavior: None,
             called_on_null: None,
@@ -277,29 +253,17 @@ fn parse_create_function() {
             or_replace: false,
             temporary: false,
             if_not_exists: false,
-            name: ObjectName::from(vec![Ident {
-                value: "some_scalar_udf".into(),
-                quote_style: None,
-                span: Span::empty(),
-            }]),
+            name: ObjectName::from(vec![Ident::new("some_scalar_udf")]),
             args: Some(vec![
                 OperateFunctionArg {
                     mode: None,
-                    name: Some(Ident {
-                        value: "@foo".into(),
-                        quote_style: None,
-                        span: Span::empty(),
-                    }),
+                    name: Some(Ident::new("@foo")),
                     data_type: DataType::Int(None),
                     default_expr: None,
                 },
                 OperateFunctionArg {
                     mode: None,
-                    name: Some(Ident {
-                        value: "@bar".into(),
-                        quote_style: None,
-                        span: Span::empty(),
-                    }),
+                    name: Some(Ident::new("@bar")),
                     data_type: DataType::Varchar(Some(CharacterLength::IntegerLength {
                         length: 256,
                         unit: None
@@ -309,43 +273,25 @@ fn parse_create_function() {
             ]),
             return_type: Some(DataType::Int(None)),
             function_body: Some(CreateFunctionBody::AsBeginEnd(BeginEndStatements {
-                begin_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(
-                    sqlparser::tokenizer::Word {
-                        value: "BEGIN".to_string(),
-                        quote_style: None,
-                        keyword: Keyword::BEGIN
-                    }
-                ))),
+                begin_token: AttachedToken::empty(),
                 statements: vec![
                     Statement::Set(Set::SingleAssignment {
                         scope: None,
                         hivevar: false,
                         variable: ObjectName::from(vec!["@foo".into()]),
                         values: vec![sqlparser::ast::Expr::BinaryOp {
-                            left: Box::new(sqlparser::ast::Expr::Identifier(Ident {
-                                value: "@foo".to_string(),
-                                quote_style: None,
-                                span: Span::empty(),
-                            })),
+                            left: Box::new(sqlparser::ast::Expr::Identifier(Ident::new("@foo"))),
                             op: sqlparser::ast::BinaryOperator::Plus,
                             right: Box::new(Expr::Value(number("1").with_empty_span())),
                         }],
                     }),
                     Statement::Return(ReturnStatement {
-                        value: Some(ReturnStatementValue::Expr(Expr::Identifier(Ident {
-                            value: "@foo".into(),
-                            quote_style: None,
-                            span: Span::empty(),
-                        }))),
+                        value: Some(ReturnStatementValue::Expr(Expr::Identifier(Ident::new(
+                            "@foo"
+                        )))),
                     }),
                 ],
-                end_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(
-                    sqlparser::tokenizer::Word {
-                        value: "END".to_string(),
-                        quote_style: None,
-                        keyword: Keyword::END
-                    }
-                ))),
+                end_token: AttachedToken::empty(),
             })),
             behavior: None,
             called_on_null: None,
@@ -379,21 +325,11 @@ fn parse_create_function() {
             or_replace: false,
             temporary: false,
             if_not_exists: false,
-            name: ObjectName::from(vec![Ident {
-                value: "some_scalar_udf".into(),
-                quote_style: None,
-                span: Span::empty(),
-            }]),
+            name: ObjectName::from(vec![Ident::new("some_scalar_udf")]),
             args: Some(vec![]),
             return_type: Some(DataType::Int(None)),
             function_body: Some(CreateFunctionBody::AsBeginEnd(BeginEndStatements {
-                begin_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(
-                    sqlparser::tokenizer::Word {
-                        value: "BEGIN".to_string(),
-                        quote_style: None,
-                        keyword: Keyword::BEGIN
-                    }
-                ))),
+                begin_token: AttachedToken::empty(),
                 statements: vec![
                     Statement::If(IfStatement {
                         if_block: ConditionalStatementBlock {
@@ -448,13 +384,7 @@ fn parse_create_function() {
                         ))),
                     }),
                 ],
-                end_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(
-                    sqlparser::tokenizer::Word {
-                        value: "END".to_string(),
-                        quote_style: None,
-                        keyword: Keyword::END
-                    }
-                ))),
+                end_token: AttachedToken::empty(),
             })),
             behavior: None,
             called_on_null: None,
@@ -486,29 +416,17 @@ fn parse_mssql_create_function() {
             or_replace: false,
             temporary: false,
             if_not_exists: false,
-            name: ObjectName::from(vec![Ident {
-                value: "some_scalar_udf".into(),
-                quote_style: None,
-                span: Span::empty(),
-            }]),
+            name: ObjectName::from(vec![Ident::new("some_scalar_udf")]),
             args: Some(vec![
                 OperateFunctionArg {
                     mode: None,
-                    name: Some(Ident {
-                        value: "@foo".into(),
-                        quote_style: None,
-                        span: Span::empty(),
-                    }),
+                    name: Some(Ident::new("@foo")),
                     data_type: DataType::Int(None),
                     default_expr: None,
                 },
                 OperateFunctionArg {
                     mode: None,
-                    name: Some(Ident {
-                        value: "@bar".into(),
-                        quote_style: None,
-                        span: Span::empty(),
-                    }),
+                    name: Some(Ident::new("@bar")),
                     data_type: DataType::Varchar(Some(CharacterLength::IntegerLength {
                         length: 256,
                         unit: None
@@ -518,43 +436,25 @@ fn parse_mssql_create_function() {
             ]),
             return_type: Some(DataType::Int(None)),
             function_body: Some(CreateFunctionBody::AsBeginEnd(BeginEndStatements {
-                begin_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(
-                    sqlparser::tokenizer::Word {
-                        value: "BEGIN".to_string(),
-                        quote_style: None,
-                        keyword: Keyword::BEGIN
-                    }
-                ))),
+                begin_token: AttachedToken::empty(),
                 statements: vec![
                     Statement::Set(Set::SingleAssignment {
                         scope: None,
                         hivevar: false,
                         variable: ObjectName::from(vec!["@foo".into()]),
                         values: vec![sqlparser::ast::Expr::BinaryOp {
-                            left: Box::new(sqlparser::ast::Expr::Identifier(Ident {
-                                value: "@foo".to_string(),
-                                quote_style: None,
-                                span: Span::empty(),
-                            })),
+                            left: Box::new(sqlparser::ast::Expr::Identifier(Ident::new("@foo"))),
                             op: sqlparser::ast::BinaryOperator::Plus,
                             right: Box::new(Expr::Value(number("1").with_empty_span())),
                         }],
                     }),
                     Statement::Return(ReturnStatement {
-                        value: Some(ReturnStatementValue::Expr(Expr::Identifier(Ident {
-                            value: "@foo".into(),
-                            quote_style: None,
-                            span: Span::empty(),
-                        }))),
+                        value: Some(ReturnStatementValue::Expr(Expr::Identifier(Ident::new(
+                            "@foo"
+                        )))),
                     }),
                 ],
-                end_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(
-                    sqlparser::tokenizer::Word {
-                        value: "END".to_string(),
-                        quote_style: None,
-                        keyword: Keyword::END
-                    }
-                ))),
+                end_token: AttachedToken::empty(),
             })),
             behavior: None,
             called_on_null: None,

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -193,6 +193,7 @@ fn parse_create_function() {
     assert_eq!(
         ms().verified_stmt(return_expression_function),
         sqlparser::ast::Statement::CreateFunction(CreateFunction {
+            or_alter: false,
             or_replace: false,
             temporary: false,
             if_not_exists: false,
@@ -255,6 +256,93 @@ fn parse_create_function() {
     assert_eq!(
         ms().verified_stmt(multi_statement_function),
         sqlparser::ast::Statement::CreateFunction(CreateFunction {
+            or_alter: false,
+            or_replace: false,
+            temporary: false,
+            if_not_exists: false,
+            name: ObjectName::from(vec![Ident {
+                value: "some_scalar_udf".into(),
+                quote_style: None,
+                span: Span::empty(),
+            }]),
+            args: Some(vec![
+                OperateFunctionArg {
+                    mode: None,
+                    name: Some(Ident {
+                        value: "@foo".into(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    }),
+                    data_type: DataType::Int(None),
+                    default_expr: None,
+                },
+                OperateFunctionArg {
+                    mode: None,
+                    name: Some(Ident {
+                        value: "@bar".into(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    }),
+                    data_type: DataType::Varchar(Some(CharacterLength::IntegerLength {
+                        length: 256,
+                        unit: None
+                    })),
+                    default_expr: None,
+                },
+            ]),
+            return_type: Some(DataType::Int(None)),
+            function_body: Some(CreateFunctionBody::MultiStatement(vec![
+                Statement::Set(Set::SingleAssignment {
+                    scope: None,
+                    hivevar: false,
+                    variable: ObjectName::from(vec!["@foo".into()]),
+                    values: vec![sqlparser::ast::Expr::BinaryOp {
+                        left: Box::new(sqlparser::ast::Expr::Identifier(Ident {
+                            value: "@foo".to_string(),
+                            quote_style: None,
+                            span: Span::empty(),
+                        })),
+                        op: sqlparser::ast::BinaryOperator::Plus,
+                        right: Box::new(Expr::Value(
+                            (Value::Number("1".into(), false)).with_empty_span()
+                        )),
+                    }],
+                }),
+                Statement::Return(ReturnStatement {
+                    value: Some(ReturnStatementValue::Expr(Expr::Identifier(Ident {
+                        value: "@foo".into(),
+                        quote_style: None,
+                        span: Span::empty(),
+                    }))),
+                }),
+            ])),
+            behavior: None,
+            called_on_null: None,
+            parallel: None,
+            using: None,
+            language: None,
+            determinism_specifier: None,
+            options: None,
+            remote_connection: None,
+        }),
+    );
+}
+
+#[test]
+fn parse_mssql_create_function() {
+    let create_or_alter_function = "\
+        CREATE OR ALTER FUNCTION some_scalar_udf(@foo INT, @bar VARCHAR(256)) \
+        RETURNS INT \
+        AS \
+        BEGIN \
+            SET @foo = @foo + 1; \
+            RETURN @foo \
+        END\
+    ";
+    assert_eq!(
+        ms().verified_stmt(create_or_alter_function),
+        sqlparser::ast::Statement::CreateFunction(CreateFunction {
+            or_alter: true,
             or_replace: false,
             temporary: false,
             if_not_exists: false,

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -23,7 +23,8 @@
 mod test_utils;
 
 use helpers::attached_token::AttachedToken;
-use sqlparser::tokenizer::{Location, Span};
+use sqlparser::keywords::Keyword;
+use sqlparser::tokenizer::{Location, Span, TokenWithSpan};
 use test_utils::*;
 
 use sqlparser::ast::DataType::{Int, Text, Varbinary};
@@ -325,6 +326,89 @@ fn parse_create_function() {
             options: None,
             remote_connection: None,
         }),
+    );
+
+    let create_function_with_conditional = r#"
+        CREATE FUNCTION some_scalar_udf()
+        RETURNS INT
+        AS
+        BEGIN
+            IF 1=2
+            BEGIN
+                RETURN 1;
+            END
+
+            RETURN 0;
+        END
+    "#;
+    let create_stmt = ms().one_statement_parses_to(create_function_with_conditional, "");
+    assert_eq!(
+        create_stmt,
+        Statement::CreateFunction(CreateFunction {
+            or_alter: false,
+            or_replace: false,
+            temporary: false,
+            if_not_exists: false,
+            name: ObjectName::from(vec![Ident {
+                value: "some_scalar_udf".into(),
+                quote_style: None,
+                span: Span::empty(),
+            }]),
+            args: Some(vec![]),
+            return_type: Some(DataType::Int(None)),
+            function_body: Some(CreateFunctionBody::MultiStatement(vec![
+                Statement::If(IfStatement {
+                    if_block: ConditionalStatementBlock {
+                        start_token: AttachedToken(TokenWithSpan::wrap(
+                            sqlparser::tokenizer::Token::Word(sqlparser::tokenizer::Word {
+                                value: "IF".to_string(),
+                                quote_style: None,
+                                keyword: Keyword::IF
+                            })
+                        )),
+                        condition: Some(Expr::BinaryOp {
+                            left: Box::new(Expr::Value(
+                                Value::Number("1".to_string(), false).with_empty_span()
+                            )),
+                            op: sqlparser::ast::BinaryOperator::Eq,
+                            right: Box::new(Expr::Value(Value::Number("2".to_string(), false).with_empty_span())),
+                        }),
+                           then_token: None,
+                           conditional_statements: ConditionalStatements::BeginEnd {
+                            begin_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(sqlparser::tokenizer::Word {
+                                value: "BEGIN".to_string(),
+                                quote_style: None,
+                                keyword: Keyword::BEGIN
+                            }))),
+                            statements: vec![Statement::Return(ReturnStatement {
+                                value: Some(ReturnStatementValue::Expr(Expr::Value((number("1")).with_empty_span()))),
+                            })],
+                            end_token: AttachedToken(TokenWithSpan::wrap(sqlparser::tokenizer::Token::Word(sqlparser::tokenizer::Word {
+                                value: "END".to_string(),
+                                quote_style: None,
+                                keyword: Keyword::END
+                            }))),
+                        },
+                    },
+                    elseif_blocks: vec![],
+                    else_block: None,
+                    end_token: None,
+                }),
+                Statement::Return(ReturnStatement {
+                    value: Some(ReturnStatementValue::Expr(Expr::Value(
+                        (number("0")).with_empty_span()
+                    ))),
+                }),
+            ])),
+            behavior: None,
+            called_on_null: None,
+            parallel: None,
+            using: None,
+            language: None,
+            determinism_specifier: None,
+            options: None,
+            remote_connection: None,
+        })
     );
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4104,6 +4104,7 @@ fn parse_create_function() {
     assert_eq!(
         pg_and_generic().verified_stmt(sql),
         Statement::CreateFunction(CreateFunction {
+            or_alter: false,
             or_replace: false,
             temporary: false,
             name: ObjectName::from(vec![Ident::new("add")]),
@@ -5485,6 +5486,7 @@ fn parse_trigger_related_functions() {
     assert_eq!(
         create_function,
         Statement::CreateFunction(CreateFunction {
+            or_alter: false,
             or_replace: false,
             temporary: false,
             if_not_exists: false,


### PR DESCRIPTION
Partially related: https://github.com/apache/datafusion-sqlparser-rs/issues/1800

---

For reference: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16

In SQL Server, functions look a lot like procedures, with begin/end, multiple statements, and a return. To accommodate that here in the parser, `BeginEndStatement` was extracted from the conditional logic to be reused here, along with a `RETURN` statement type

<details>
Formerly, this was a new struct, but was later consolidated in with BeginEndStatement. 
I'm open to suggestions about how this could be improve (now or later). For example, since it's a BEGIN (statements) END construct, should this (and procedures) be using the statement block logic introduced here? https://github.com/apache/datafusion-sqlparser-rs/pull/1791 
</details>

Then also while I was working on this, I noticed that only SQL Server (so far...?) supports `OR ALTER`, so I introduced a new struct field to track that. (Again, very similar to `CREATE PROCEDURE` logic).

I'm not aiming to enable parsing every function type here in this PR -- just trying to get something operational, and the additional capabilities like table expressions, etc, can be added in later.

---

To continue the recent discussion, I noticed that both these new multi statement functions & the existing procedure parsing fails unless the statements are semi-colon delimited. Semi-colons are optional in SQL Server, so for example, this code executes fine for real but fails to parse here in this library, unless that "SET" ends with a `;`...

```mssql
CREATE OR ALTER PROCEDURE test (@foo INT, @bar VARCHAR(256))
AS
BEGIN
    SET @foo = @foo + 1
    SELECT @foo
END
```

I think this is because the procedure body parsing logic is using `parse_statements()`, which requires it? I'm game to tackle the problem with some guidance on what's a good approach to make it parse 🤔