### PR TITLE
Add `CREATE TRIGGER` support for SQL Server

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3802,7 +3802,7 @@ pub enum Statement {
         /// Execute logic block
         exec_body: Option<TriggerExecBody>,
         /// For SQL dialects with statement(s) for a body
-        statements: Option<BeginEndStatements>,
+        statements: Option<ConditionalStatements>,
         /// The characteristic of the trigger, which include whether the trigger is `DEFERRABLE`, `INITIALLY DEFERRED`, or `INITIALLY IMMEDIATE`,
         characteristics: Option<ConstraintCharacteristics>,
     },

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2380,11 +2380,16 @@ impl fmt::Display for BeginEndStatements {
             end_token: AttachedToken(end_token),
         } = self;
 
-        write!(f, "{begin_token} ")?;
+        if begin_token.token != Token::EOF {
+            write!(f, "{begin_token} ")?;
+        }
         if !statements.is_empty() {
             format_statement_list(f, statements)?;
         }
-        write!(f, " {end_token}")
+        if end_token.token != Token::EOF {
+            write!(f, " {end_token}")?;
+        }
+        Ok(())
     }
 }
 
@@ -3729,6 +3734,7 @@ pub enum Statement {
     /// ```
     ///
     /// Postgres: <https://www.postgresql.org/docs/current/sql-createtrigger.html>
+    /// SQL Server: <https://learn.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql>
     CreateTrigger {
         /// The `OR REPLACE` clause is used to re-create the trigger if it already exists.
         ///
@@ -3790,7 +3796,9 @@ pub enum Statement {
         ///  Triggering conditions
         condition: Option<Expr>,
         /// Execute logic block
-        exec_body: TriggerExecBody,
+        exec_body: Option<TriggerExecBody>,
+        /// For SQL dialects with statement(s) for a body
+        statements: Option<BeginEndStatements>,
         /// The characteristic of the trigger, which include whether the trigger is `DEFERRABLE`, `INITIALLY DEFERRED`, or `INITIALLY IMMEDIATE`,
         characteristics: Option<ConstraintCharacteristics>,
     },
@@ -4599,19 +4607,29 @@ impl fmt::Display for Statement {
                 condition,
                 include_each,
                 exec_body,
+                statements,
                 characteristics,
             } => {
                 write!(
                     f,
-                    "CREATE {or_replace}{is_constraint}TRIGGER {name} {period}",
+                    "CREATE {or_replace}{is_constraint}TRIGGER {name} ",
                     or_replace = if *or_replace { "OR REPLACE " } else { "" },
                     is_constraint = if *is_constraint { "CONSTRAINT " } else { "" },
                 )?;
 
-                if !events.is_empty() {
-                    write!(f, " {}", display_separated(events, " OR "))?;
+                if exec_body.is_some() {
+                    write!(f, "{period}")?;
+                    if !events.is_empty() {
+                        write!(f, " {}", display_separated(events, " OR "))?;
+                    }
+                    write!(f, " ON {table_name}")?;
+                } else {
+                    write!(f, "ON {table_name}")?;
+                    write!(f, " {period}")?;
+                    if !events.is_empty() {
+                        write!(f, " {}", display_separated(events, ", "))?;
+                    }
                 }
-                write!(f, " ON {table_name}")?;
 
                 if let Some(referenced_table_name) = referenced_table_name {
                     write!(f, " FROM {referenced_table_name}")?;
@@ -4627,13 +4645,19 @@ impl fmt::Display for Statement {
 
                 if *include_each {
                     write!(f, " FOR EACH {trigger_object}")?;
-                } else {
+                } else if exec_body.is_some() {
                     write!(f, " FOR {trigger_object}")?;
                 }
                 if let Some(condition) = condition {
                     write!(f, " WHEN {condition}")?;
                 }
-                write!(f, " EXECUTE {exec_body}")
+                if let Some(exec_body) = exec_body {
+                    write!(f, " EXECUTE {exec_body}")?;
+                }
+                if let Some(statements) = statements {
+                    write!(f, " AS {statements}")?;
+                }
+                Ok(())
             }
             Statement::DropTrigger {
                 if_exists,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3736,6 +3736,10 @@ pub enum Statement {
     /// Postgres: <https://www.postgresql.org/docs/current/sql-createtrigger.html>
     /// SQL Server: <https://learn.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql>
     CreateTrigger {
+        /// True if this is a `CREATE OR ALTER TRIGGER` statement
+        ///
+        /// [MsSql](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql?view=sql-server-ver16#arguments)
+        or_alter: bool,
         /// The `OR REPLACE` clause is used to re-create the trigger if it already exists.
         ///
         /// Example:
@@ -4595,6 +4599,7 @@ impl fmt::Display for Statement {
             }
             Statement::CreateFunction(create_function) => create_function.fmt(f),
             Statement::CreateTrigger {
+                or_alter,
                 or_replace,
                 is_constraint,
                 name,
@@ -4612,7 +4617,8 @@ impl fmt::Display for Statement {
             } => {
                 write!(
                     f,
-                    "CREATE {or_replace}{is_constraint}TRIGGER {name} ",
+                    "CREATE {or_alter}{or_replace}{is_constraint}TRIGGER {name} ",
+                    or_alter = if *or_alter { "OR ALTER " } else { "" },
                     or_replace = if *or_replace { "OR REPLACE " } else { "" },
                     is_constraint = if *is_constraint { "CONSTRAINT " } else { "" },
                 )?;

--- a/src/ast/trigger.rs
+++ b/src/ast/trigger.rs
@@ -110,6 +110,7 @@ impl fmt::Display for TriggerEvent {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum TriggerPeriod {
+    For,
     After,
     Before,
     InsteadOf,
@@ -118,6 +119,7 @@ pub enum TriggerPeriod {
 impl fmt::Display for TriggerPeriod {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            TriggerPeriod::For => write!(f, "FOR"),
             TriggerPeriod::After => write!(f, "AFTER"),
             TriggerPeriod::Before => write!(f, "BEFORE"),
             TriggerPeriod::InsteadOf => write!(f, "INSTEAD OF"),

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -246,16 +246,14 @@ impl MsSqlDialect {
             let statements = parser.parse_statement_list(&[Keyword::END])?;
             let end_token = parser.expect_keyword(Keyword::END)?;
 
-            BeginEndStatements {
+            ConditionalStatements::BeginEnd(BeginEndStatements {
                 begin_token: AttachedToken(begin_token),
                 statements,
                 end_token: AttachedToken(end_token),
-            }
+            })
         } else {
-            BeginEndStatements {
-                begin_token: AttachedToken::empty(),
+            ConditionalStatements::Sequence {
                 statements: parser.parse_statements()?,
-                end_token: AttachedToken::empty(),
             }
         };
 

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -240,22 +240,7 @@ impl MsSqlDialect {
         let events = parser.parse_comma_separated(Parser::parse_trigger_event)?;
 
         parser.expect_keyword_is(Keyword::AS)?;
-
-        let trigger_statements_body = if parser.peek_keyword(Keyword::BEGIN) {
-            let begin_token = parser.expect_keyword(Keyword::BEGIN)?;
-            let statements = parser.parse_statement_list(&[Keyword::END])?;
-            let end_token = parser.expect_keyword(Keyword::END)?;
-
-            ConditionalStatements::BeginEnd(BeginEndStatements {
-                begin_token: AttachedToken(begin_token),
-                statements,
-                end_token: AttachedToken(end_token),
-            })
-        } else {
-            ConditionalStatements::Sequence {
-                statements: parser.parse_statements()?,
-            }
-        };
+        let statements = Some(parser.parse_conditional_statements(&[Keyword::END])?);
 
         Ok(Statement::CreateTrigger {
             or_alter,
@@ -271,7 +256,7 @@ impl MsSqlDialect {
             include_each: false,
             condition: None,
             exec_body: None,
-            statements: Some(trigger_statements_body),
+            statements,
             characteristics: None,
         })
     }

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -254,7 +254,7 @@ impl MsSqlDialect {
         } else {
             BeginEndStatements {
                 begin_token: AttachedToken::empty(),
-                statements: vec![parser.parse_statement()?],
+                statements: parser.parse_statements()?,
                 end_token: AttachedToken::empty(),
             }
         };

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -18,6 +18,7 @@
 use crate::ast::helpers::attached_token::AttachedToken;
 use crate::ast::{
     BeginEndStatements, ConditionalStatementBlock, ConditionalStatements, IfStatement, Statement,
+    TriggerObject,
 };
 use crate::dialect::Dialect;
 use crate::keywords::{self, Keyword};
@@ -125,6 +126,15 @@ impl Dialect for MsSqlDialect {
     fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
         if parser.peek_keyword(Keyword::IF) {
             Some(self.parse_if_stmt(parser))
+        } else if parser.parse_keywords(&[Keyword::CREATE, Keyword::TRIGGER]) {
+            Some(self.parse_create_trigger(parser, false))
+        } else if parser.parse_keywords(&[
+            Keyword::CREATE,
+            Keyword::OR,
+            Keyword::ALTER,
+            Keyword::TRIGGER,
+        ]) {
+            Some(self.parse_create_trigger(parser, true))
         } else {
             None
         }
@@ -213,6 +223,59 @@ impl MsSqlDialect {
             elseif_blocks: Vec::new(),
             end_token: None,
         }))
+    }
+
+    /// Parse `CREATE TRIGGER` for [MsSql]
+    ///
+    /// [MsSql]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql
+    fn parse_create_trigger(
+        &self,
+        parser: &mut Parser,
+        or_alter: bool,
+    ) -> Result<Statement, ParserError> {
+        let name = parser.parse_object_name(false)?;
+        parser.expect_keyword_is(Keyword::ON)?;
+        let table_name = parser.parse_object_name(false)?;
+        let period = parser.parse_trigger_period()?;
+        let events = parser.parse_comma_separated(Parser::parse_trigger_event)?;
+
+        parser.expect_keyword_is(Keyword::AS)?;
+
+        let trigger_statements_body = if parser.peek_keyword(Keyword::BEGIN) {
+            let begin_token = parser.expect_keyword(Keyword::BEGIN)?;
+            let statements = parser.parse_statement_list(&[Keyword::END])?;
+            let end_token = parser.expect_keyword(Keyword::END)?;
+
+            BeginEndStatements {
+                begin_token: AttachedToken(begin_token),
+                statements,
+                end_token: AttachedToken(end_token),
+            }
+        } else {
+            BeginEndStatements {
+                begin_token: AttachedToken::empty(),
+                statements: vec![parser.parse_statement()?],
+                end_token: AttachedToken::empty(),
+            }
+        };
+
+        Ok(Statement::CreateTrigger {
+            or_alter,
+            or_replace: false,
+            is_constraint: false,
+            name,
+            period,
+            events,
+            table_name,
+            referenced_table_name: None,
+            referencing: Vec::new(),
+            trigger_object: TriggerObject::Statement,
+            include_each: false,
+            condition: None,
+            exec_body: None,
+            statements: Some(trigger_statements_body),
+            characteristics: None,
+        })
     }
 
     /// Parse a sequence of statements, optionally separated by semicolon.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4614,9 +4614,9 @@ impl<'a> Parser<'a> {
         } else if self.parse_keyword(Keyword::FUNCTION) {
             self.parse_create_function(or_alter, or_replace, temporary)
         } else if self.parse_keyword(Keyword::TRIGGER) {
-            self.parse_create_trigger(or_replace, false)
+            self.parse_create_trigger(or_alter, or_replace, false)
         } else if self.parse_keywords(&[Keyword::CONSTRAINT, Keyword::TRIGGER]) {
-            self.parse_create_trigger(or_replace, true)
+            self.parse_create_trigger(or_alter, or_replace, true)
         } else if self.parse_keyword(Keyword::MACRO) {
             self.parse_create_macro(or_replace, temporary)
         } else if self.parse_keyword(Keyword::SECRET) {
@@ -5314,6 +5314,7 @@ impl<'a> Parser<'a> {
 
     pub fn parse_create_trigger(
         &mut self,
+        or_alter: bool,
         or_replace: bool,
         is_constraint: bool,
     ) -> Result<Statement, ParserError> {
@@ -5323,7 +5324,7 @@ impl<'a> Parser<'a> {
         }
 
         if dialect_of!(self is MsSqlDialect) {
-            return self.parse_mssql_create_trigger(or_replace, is_constraint);
+            return self.parse_mssql_create_trigger(or_alter, or_replace, is_constraint);
         }
 
         let name = self.parse_object_name(false)?;
@@ -5367,6 +5368,7 @@ impl<'a> Parser<'a> {
         let exec_body = self.parse_trigger_exec_body()?;
 
         Ok(Statement::CreateTrigger {
+            or_alter,
             or_replace,
             is_constraint,
             name,
@@ -5389,6 +5391,7 @@ impl<'a> Parser<'a> {
     /// [MsSql]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql
     pub fn parse_mssql_create_trigger(
         &mut self,
+        or_alter: bool,
         or_replace: bool,
         is_constraint: bool,
     ) -> Result<Statement, ParserError> {
@@ -5419,6 +5422,7 @@ impl<'a> Parser<'a> {
         };
 
         Ok(Statement::CreateTrigger {
+            or_alter,
             or_replace,
             is_constraint,
             name,

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -273,6 +273,16 @@ fn parse_create_function() {
         END\
     ";
     let _ = ms().verified_stmt(create_or_alter_function);
+
+    let create_function_with_return_expression = "\
+        CREATE FUNCTION some_scalar_udf(@foo INT, @bar VARCHAR(256)) \
+        RETURNS INT \
+        AS \
+        BEGIN \
+            RETURN CONVERT(INT, 1) + 2; \
+        END\
+    ";
+    let _ = ms().verified_stmt(create_function_with_return_expression);
 }
 
 #[test]
@@ -2197,6 +2207,94 @@ fn parse_mssql_merge_with_output() {
         WHEN NOT MATCHED BY SOURCE THEN DELETE \
         OUTPUT $action, deleted.ProductID INTO dsi.temp_products";
     ms_and_generic().verified_stmt(stmt);
+}
+
+#[test]
+fn parse_create_trigger() {
+    let create_trigger = "\
+        CREATE TRIGGER reminder1 \
+        ON Sales.Customer \
+        AFTER INSERT, UPDATE \
+        AS RAISERROR('Notify Customer Relations', 16, 10);\
+    ";
+    let create_stmt = ms().verified_stmt(create_trigger);
+    assert_eq!(
+        create_stmt,
+        Statement::CreateTrigger {
+            or_replace: false,
+            is_constraint: false,
+            name: ObjectName::from(vec![Ident::new("reminder1")]),
+            period: TriggerPeriod::After,
+            events: vec![TriggerEvent::Insert, TriggerEvent::Update(vec![]),],
+            table_name: ObjectName::from(vec![Ident::new("Sales"), Ident::new("Customer")]),
+            referenced_table_name: None,
+            referencing: vec![],
+            trigger_object: TriggerObject::Statement,
+            include_each: false,
+            condition: None,
+            exec_body: None,
+            statements: Some(BeginEndStatements {
+                begin_token: AttachedToken::empty(),
+                statements: vec![Statement::RaisError {
+                    message: Box::new(Expr::Value(
+                        (Value::SingleQuotedString("Notify Customer Relations".to_string()))
+                            .with_empty_span()
+                    )),
+                    severity: Box::new(Expr::Value(
+                        (Value::Number("16".parse().unwrap(), false)).with_empty_span()
+                    )),
+                    state: Box::new(Expr::Value(
+                        (Value::Number("10".parse().unwrap(), false)).with_empty_span()
+                    )),
+                    arguments: vec![],
+                    options: vec![],
+                }],
+                end_token: AttachedToken::empty(),
+            }),
+            characteristics: None,
+        }
+    );
+
+    let multi_statement_trigger = "\
+        CREATE TRIGGER some_trigger ON some_table FOR INSERT \
+        AS \
+        BEGIN \
+            DECLARE @var INT; \
+            RAISERROR('Trigger fired', 10, 1); \
+        END\
+    ";
+    let _ = ms().verified_stmt(multi_statement_trigger);
+
+    let create_trigger_with_return = "\
+        CREATE TRIGGER some_trigger ON some_table FOR INSERT \
+        AS \
+        BEGIN \
+            RETURN; \
+        END\
+    ";
+    let _ = ms().verified_stmt(create_trigger_with_return);
+
+    let create_trigger_with_return = "\
+        CREATE TRIGGER some_trigger ON some_table FOR INSERT \
+        AS \
+        BEGIN \
+            RETURN; \
+        END\
+    ";
+    let _ = ms().verified_stmt(create_trigger_with_return);
+
+    let create_trigger_with_conditional = "\
+        CREATE TRIGGER some_trigger ON some_table FOR INSERT \
+        AS \
+        BEGIN \
+            IF 1 = 2 \
+            BEGIN \
+                RAISERROR('Trigger fired', 10, 1); \
+            END; \
+            RETURN; \
+        END\
+    ";
+    let _ = ms().verified_stmt(create_trigger_with_conditional);
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2256,6 +2256,14 @@ fn parse_create_trigger() {
         }
     );
 
+    let multi_statement_as_trigger = "\
+        CREATE TRIGGER some_trigger ON some_table FOR INSERT \
+        AS \
+        DECLARE @var INT; \
+        RAISERROR('Trigger fired', 10, 1);\
+    ";
+    let _ = ms().verified_stmt(multi_statement_as_trigger);
+
     let multi_statement_trigger = "\
         CREATE TRIGGER some_trigger ON some_table FOR INSERT \
         AS \

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2234,8 +2234,7 @@ fn parse_create_trigger() {
             include_each: false,
             condition: None,
             exec_body: None,
-            statements: Some(BeginEndStatements {
-                begin_token: AttachedToken::empty(),
+            statements: Some(ConditionalStatements::Sequence {
                 statements: vec![Statement::RaisError {
                     message: Box::new(Expr::Value(
                         (Value::SingleQuotedString("Notify Customer Relations".to_string()))
@@ -2250,7 +2249,6 @@ fn parse_create_trigger() {
                     arguments: vec![],
                     options: vec![],
                 }],
-                end_token: AttachedToken::empty(),
             }),
             characteristics: None,
         }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2212,7 +2212,7 @@ fn parse_mssql_merge_with_output() {
 #[test]
 fn parse_create_trigger() {
     let create_trigger = "\
-        CREATE TRIGGER reminder1 \
+        CREATE OR ALTER TRIGGER reminder1 \
         ON Sales.Customer \
         AFTER INSERT, UPDATE \
         AS RAISERROR('Notify Customer Relations', 16, 10);\
@@ -2221,6 +2221,7 @@ fn parse_create_trigger() {
     assert_eq!(
         create_stmt,
         Statement::CreateTrigger {
+            or_alter: true,
             or_replace: false,
             is_constraint: false,
             name: ObjectName::from(vec![Ident::new("reminder1")]),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3779,6 +3779,7 @@ fn parse_create_trigger() {
     assert_eq!(
         create_stmt,
         Statement::CreateTrigger {
+            or_alter: false,
             or_replace: false,
             is_constraint: false,
             name: ObjectName::from(vec![Ident::new("emp_stamp")]),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3790,13 +3790,14 @@ fn parse_create_trigger() {
             trigger_object: TriggerObject::Row,
             include_each: true,
             condition: None,
-            exec_body: TriggerExecBody {
+            exec_body: Some(TriggerExecBody {
                 exec_type: TriggerExecBodyType::Function,
                 func_desc: FunctionDesc {
                     name: ObjectName::from(vec![Ident::new("emp_stamp")]),
                     args: None,
                 }
-            },
+            }),
+            statements: None,
             characteristics: None,
         }
     );

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5157,6 +5157,7 @@ fn test_escaped_string_literal() {
 fn parse_create_simple_before_insert_trigger() {
     let sql = "CREATE TRIGGER check_insert BEFORE INSERT ON accounts FOR EACH ROW EXECUTE FUNCTION check_account_insert";
     let expected = Statement::CreateTrigger {
+        or_alter: false,
         or_replace: false,
         is_constraint: false,
         name: ObjectName::from(vec![Ident::new("check_insert")]),
@@ -5186,6 +5187,7 @@ fn parse_create_simple_before_insert_trigger() {
 fn parse_create_after_update_trigger_with_condition() {
     let sql = "CREATE TRIGGER check_update AFTER UPDATE ON accounts FOR EACH ROW WHEN (NEW.balance > 10000) EXECUTE FUNCTION check_account_update";
     let expected = Statement::CreateTrigger {
+        or_alter: false,
         or_replace: false,
         is_constraint: false,
         name: ObjectName::from(vec![Ident::new("check_update")]),
@@ -5222,6 +5224,7 @@ fn parse_create_after_update_trigger_with_condition() {
 fn parse_create_instead_of_delete_trigger() {
     let sql = "CREATE TRIGGER check_delete INSTEAD OF DELETE ON accounts FOR EACH ROW EXECUTE FUNCTION check_account_deletes";
     let expected = Statement::CreateTrigger {
+        or_alter: false,
         or_replace: false,
         is_constraint: false,
         name: ObjectName::from(vec![Ident::new("check_delete")]),
@@ -5251,6 +5254,7 @@ fn parse_create_instead_of_delete_trigger() {
 fn parse_create_trigger_with_multiple_events_and_deferrable() {
     let sql = "CREATE CONSTRAINT TRIGGER check_multiple_events BEFORE INSERT OR UPDATE OR DELETE ON accounts DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION check_account_changes";
     let expected = Statement::CreateTrigger {
+        or_alter: false,
         or_replace: false,
         is_constraint: true,
         name: ObjectName::from(vec![Ident::new("check_multiple_events")]),
@@ -5288,6 +5292,7 @@ fn parse_create_trigger_with_multiple_events_and_deferrable() {
 fn parse_create_trigger_with_referencing() {
     let sql = "CREATE TRIGGER check_referencing BEFORE INSERT ON accounts REFERENCING NEW TABLE AS new_accounts OLD TABLE AS old_accounts FOR EACH ROW EXECUTE FUNCTION check_account_referencing";
     let expected = Statement::CreateTrigger {
+        or_alter: false,
         or_replace: false,
         is_constraint: false,
         name: ObjectName::from(vec![Ident::new("check_referencing")]),
@@ -5595,6 +5600,7 @@ fn parse_trigger_related_functions() {
     assert_eq!(
         create_trigger,
         Statement::CreateTrigger {
+            or_alter: false,
             or_replace: false,
             is_constraint: false,
             name: ObjectName::from(vec![Ident::new("emp_stamp")]),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5168,13 +5168,14 @@ fn parse_create_simple_before_insert_trigger() {
         trigger_object: TriggerObject::Row,
         include_each: true,
         condition: None,
-        exec_body: TriggerExecBody {
+        exec_body: Some(TriggerExecBody {
             exec_type: TriggerExecBodyType::Function,
             func_desc: FunctionDesc {
                 name: ObjectName::from(vec![Ident::new("check_account_insert")]),
                 args: None,
             },
-        },
+        }),
+        statements: None,
         characteristics: None,
     };
 
@@ -5203,13 +5204,14 @@ fn parse_create_after_update_trigger_with_condition() {
             op: BinaryOperator::Gt,
             right: Box::new(Expr::value(number("10000"))),
         }))),
-        exec_body: TriggerExecBody {
+        exec_body: Some(TriggerExecBody {
             exec_type: TriggerExecBodyType::Function,
             func_desc: FunctionDesc {
                 name: ObjectName::from(vec![Ident::new("check_account_update")]),
                 args: None,
             },
-        },
+        }),
+        statements: None,
         characteristics: None,
     };
 
@@ -5231,13 +5233,14 @@ fn parse_create_instead_of_delete_trigger() {
         trigger_object: TriggerObject::Row,
         include_each: true,
         condition: None,
-        exec_body: TriggerExecBody {
+        exec_body: Some(TriggerExecBody {
             exec_type: TriggerExecBodyType::Function,
             func_desc: FunctionDesc {
                 name: ObjectName::from(vec![Ident::new("check_account_deletes")]),
                 args: None,
             },
-        },
+        }),
+        statements: None,
         characteristics: None,
     };
 
@@ -5263,13 +5266,14 @@ fn parse_create_trigger_with_multiple_events_and_deferrable() {
         trigger_object: TriggerObject::Row,
         include_each: true,
         condition: None,
-        exec_body: TriggerExecBody {
+        exec_body: Some(TriggerExecBody {
             exec_type: TriggerExecBodyType::Function,
             func_desc: FunctionDesc {
                 name: ObjectName::from(vec![Ident::new("check_account_changes")]),
                 args: None,
             },
-        },
+        }),
+        statements: None,
         characteristics: Some(ConstraintCharacteristics {
             deferrable: Some(true),
             initially: Some(DeferrableInitial::Deferred),
@@ -5306,13 +5310,14 @@ fn parse_create_trigger_with_referencing() {
         trigger_object: TriggerObject::Row,
         include_each: true,
         condition: None,
-        exec_body: TriggerExecBody {
+        exec_body: Some(TriggerExecBody {
             exec_type: TriggerExecBodyType::Function,
             func_desc: FunctionDesc {
                 name: ObjectName::from(vec![Ident::new("check_account_referencing")]),
                 args: None,
             },
-        },
+        }),
+        statements: None,
         characteristics: None,
     };
 
@@ -5332,7 +5337,7 @@ fn parse_create_trigger_invalid_cases() {
         ),
         (
             "CREATE TRIGGER check_update TOMORROW UPDATE ON accounts EXECUTE FUNCTION check_account_update",
-            "Expected: one of BEFORE or AFTER or INSTEAD, found: TOMORROW"
+            "Expected: one of FOR or BEFORE or AFTER or INSTEAD, found: TOMORROW"
         ),
         (
             "CREATE TRIGGER check_update BEFORE SAVE ON accounts EXECUTE FUNCTION check_account_update",
@@ -5601,13 +5606,14 @@ fn parse_trigger_related_functions() {
             trigger_object: TriggerObject::Row,
             include_each: true,
             condition: None,
-            exec_body: TriggerExecBody {
+            exec_body: Some(TriggerExecBody {
                 exec_type: TriggerExecBodyType::Function,
                 func_desc: FunctionDesc {
                     name: ObjectName::from(vec![Ident::new("emp_stamp")]),
                     args: None,
                 }
-            },
+            }),
+            statements: None,
             characteristics: None
         }
     );


### PR DESCRIPTION
Adjacent to: https://github.com/apache/datafusion-sqlparser-rs/pull/1808 with similar considerations, and temporarily rebased on it (eg, this branch should probably wait for that branch to merge).

---

This PR introduces support for parsing `CREATE TRIGGER` for SQL Server.

The main concern is that for the existing dialects, there was an expectation of an `EXECUTE` keyword (PG: https://www.postgresql.org/docs/current/sql-createtrigger.html). However, SQL Server doesn't use this syntax and instead supports multi statement blocks (like a stored procedure).

The difficulty here in the codebase is what to do about CreateTrigger.exec_body & TriggerExecBody. In this iteration I made the property an `Option`, which seemed like the least impact on existing code. TriggerExecBody, etc can be left alone.

However in the future I think this could be improved with a more broad refactoring, such as a TriggerBody enum, which can consolidate TriggerExecBodyType's options & use `Vec<Statements>` for a `MultiStatement` variant and `FunctionDesc` for `Function` & `Procedure` variants. That'd basically remove the TriggerExecBody struct, too. Overall I think that'd be a cleaner approach for the CreateTrigger struct.

--- 

That's all speculative followup work, for now I just want to be able to parse most SQL Server triggers. Other SQL Server specific things like particular trigger options, DDL trigger stuff, etc can come later as needed.