### PR TITLE
Add support for `PRINT` statement for SQL Server

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4054,6 +4054,12 @@ pub enum Statement {
         arguments: Vec<Expr>,
         options: Vec<RaisErrorOption>,
     },
+    /// ```sql
+    /// PRINT msg_str | @local_variable | string_expr
+    /// ```
+    ///
+    /// See: <https://learn.microsoft.com/en-us/sql/t-sql/statements/print-transact-sql>
+    Print(PrintStatement),
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
@@ -5745,7 +5751,7 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-
+            Statement::Print(s) => write!(f, "{s}"),
             Statement::List(command) => write!(f, "LIST {command}"),
             Statement::Remove(command) => write!(f, "REMOVE {command}"),
         }
@@ -9209,6 +9215,19 @@ pub enum CopyIntoSnowflakeKind {
     /// Unloads data from a table or query to external files
     /// See: <https://docs.snowflake.com/en/sql-reference/sql/copy-into-location>
     Location,
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct PrintStatement {
+    pub message: Box<Expr>,
+}
+
+impl fmt::Display for PrintStatement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "PRINT {}", self.message)
+    }
 }
 
 #[cfg(test)]

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -519,6 +519,7 @@ impl Spanned for Statement {
             Statement::UNLISTEN { .. } => Span::empty(),
             Statement::RenameTable { .. } => Span::empty(),
             Statement::RaisError { .. } => Span::empty(),
+            Statement::Print { .. } => Span::empty(),
             Statement::List(..) | Statement::Remove(..) => Span::empty(),
         }
     }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -686,6 +686,7 @@ define_keywords!(
     PRESERVE,
     PREWHERE,
     PRIMARY,
+    PRINT,
     PRIOR,
     PRIVILEGES,
     PROCEDURE,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -617,6 +617,7 @@ impl<'a> Parser<'a> {
                 }
                 // `COMMENT` is snowflake specific https://docs.snowflake.com/en/sql-reference/sql/comment
                 Keyword::COMMENT if self.dialect.supports_comment_on() => self.parse_comment(),
+                Keyword::PRINT => self.parse_print(),
                 _ => self.expected("an SQL statement", next_token),
             },
             Token::LParen => {
@@ -15056,6 +15057,13 @@ impl<'a> Parser<'a> {
         } else {
             Ok(None)
         }
+    }
+
+    /// Parse [Statement::Print]
+    fn parse_print(&mut self) -> Result<Statement, ParserError> {
+        Ok(Statement::Print(PrintStatement {
+            message: Box::new(self.parse_expr()?),
+        }))
     }
 
     /// Consume the parser and return its underlying token buffer

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2053,3 +2053,20 @@ fn parse_drop_trigger() {
         }
     );
 }
+
+#[test]
+fn parse_print() {
+    let print_string_literal = "PRINT 'Hello, world!'";
+    let print_stmt = ms().verified_stmt(print_string_literal);
+    assert_eq!(
+        print_stmt,
+        Statement::Print(PrintStatement {
+            message: Box::new(Expr::Value(
+                (Value::SingleQuotedString("Hello, world!".to_string())).with_empty_span()
+            )),
+        })
+    );
+
+    let _ = ms().verified_stmt("PRINT N'Hello, ⛄️!'");
+    let _ = ms().verified_stmt("PRINT @my_variable");
+}


### PR DESCRIPTION
Reference: https://learn.microsoft.com/en-us/sql/t-sql/language-elements/print-transact-sql?view=sql-server-ver16

Making `message` a `Box<Expr>` instead of an enum of (national) string literal, variable, or expression is _slightly_ lazy and also seems completely acceptable for the time being.