### PR TITLE
Fix `STRAIGHT_JOIN` constraint when table alias is absent

### DIFF
--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -27,7 +27,12 @@ use crate::{
 
 use super::keywords;
 
-const RESERVED_FOR_TABLE_ALIAS_MYSQL: &[Keyword] = &[Keyword::USE, Keyword::IGNORE, Keyword::FORCE];
+const RESERVED_FOR_TABLE_ALIAS_MYSQL: &[Keyword] = &[
+    Keyword::USE,
+    Keyword::IGNORE,
+    Keyword::FORCE,
+    Keyword::STRAIGHT_JOIN,
+];
 
 /// A [`Dialect`] for [MySQL](https://www.mysql.com/)
 #[derive(Debug)]

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3715,10 +3715,7 @@ fn parse_straight_join() {
     mysql().verified_stmt(
         "SELECT a.*, b.* FROM table_a AS a STRAIGHT_JOIN table_b AS b ON a.b_id = b.id",
     );
-}
-
-#[test]
-fn parse_straight_join_without_alias() {
+    // Without table alias
     mysql()
         .verified_stmt("SELECT a.*, b.* FROM table_a STRAIGHT_JOIN table_b AS b ON a.b_id = b.id");
 }

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3716,3 +3716,9 @@ fn parse_straight_join() {
         "SELECT a.*, b.* FROM table_a AS a STRAIGHT_JOIN table_b AS b ON a.b_id = b.id",
     );
 }
+
+#[test]
+fn parse_straight_join_without_alias() {
+    mysql()
+        .verified_stmt("SELECT a.*, b.* FROM table_a STRAIGHT_JOIN table_b AS b ON a.b_id = b.id");
+}


### PR DESCRIPTION
In https://github.com/apache/datafusion-sqlparser-rs/pull/1802 was added support for MySQL STRAIGHT_JOIN, but it was not added as a RESERVED_FOR_TABLE_ALIAS. Because of this, it fails to parse queries where we are not using an alias.