### PR TITLE
Add `OR ALTER` support for `CREATE VIEW`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3037,6 +3037,10 @@ pub enum Statement {
     /// CREATE VIEW
     /// ```
     CreateView {
+        /// True if this is a `CREATE OR ALTER VIEW` statement
+        ///
+        /// [MsSql](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-view-transact-sql)
+        or_alter: bool,
         or_replace: bool,
         materialized: bool,
         /// View name
@@ -4590,6 +4594,7 @@ impl fmt::Display for Statement {
                 Ok(())
             }
             Statement::CreateView {
+                or_alter,
                 name,
                 or_replace,
                 columns,
@@ -4606,7 +4611,8 @@ impl fmt::Display for Statement {
             } => {
                 write!(
                     f,
-                    "CREATE {or_replace}",
+                    "CREATE {or_alter}{or_replace}",
+                    or_alter = if *or_alter { "OR ALTER " } else { "" },
                     or_replace = if *or_replace { "OR REPLACE " } else { "" },
                 )?;
                 if let Some(params) = params {

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -384,6 +384,7 @@ impl Spanned for Statement {
             ),
             Statement::Delete(delete) => delete.span(),
             Statement::CreateView {
+                or_alter: _,
                 or_replace: _,
                 materialized: _,
                 name,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4554,7 +4554,7 @@ impl<'a> Parser<'a> {
             self.parse_create_table(or_replace, temporary, global, transient)
         } else if self.parse_keyword(Keyword::MATERIALIZED) || self.parse_keyword(Keyword::VIEW) {
             self.prev_token();
-            self.parse_create_view(or_replace, temporary, create_view_params)
+            self.parse_create_view(or_alter, or_replace, temporary, create_view_params)
         } else if self.parse_keyword(Keyword::POLICY) {
             self.parse_create_policy()
         } else if self.parse_keyword(Keyword::EXTERNAL) {
@@ -5460,6 +5460,7 @@ impl<'a> Parser<'a> {
 
     pub fn parse_create_view(
         &mut self,
+        or_alter: bool,
         or_replace: bool,
         temporary: bool,
         create_view_params: Option<CreateViewParams>,
@@ -5524,6 +5525,7 @@ impl<'a> Parser<'a> {
             ]);
 
         Ok(Statement::CreateView {
+            or_alter,
             name,
             columns,
             query,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7840,6 +7840,7 @@ fn parse_create_view() {
     let sql = "CREATE VIEW myschema.myview AS SELECT foo FROM bar";
     match verified_stmt(sql) {
         Statement::CreateView {
+            or_alter,
             name,
             columns,
             query,
@@ -7854,6 +7855,7 @@ fn parse_create_view() {
             to,
             params,
         } => {
+            assert_eq!(or_alter, false);
             assert_eq!("myschema.myview", name.to_string());
             assert_eq!(Vec::<ViewColumnDef>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
@@ -7870,6 +7872,8 @@ fn parse_create_view() {
         }
         _ => unreachable!(),
     }
+
+    let _ = verified_stmt("CREATE OR ALTER VIEW v AS SELECT 1");
 }
 
 #[test]
@@ -7904,6 +7908,7 @@ fn parse_create_view_with_columns() {
     // match all_dialects().verified_stmt(sql) {
     match all_dialects_except(|d| d.is::<ClickHouseDialect>()).verified_stmt(sql) {
         Statement::CreateView {
+            or_alter,
             name,
             columns,
             or_replace,
@@ -7918,6 +7923,7 @@ fn parse_create_view_with_columns() {
             to,
             params,
         } => {
+            assert_eq!(or_alter, false);
             assert_eq!("v", name.to_string());
             assert_eq!(
                 columns,
@@ -7951,6 +7957,7 @@ fn parse_create_view_temporary() {
     let sql = "CREATE TEMPORARY VIEW myschema.myview AS SELECT foo FROM bar";
     match verified_stmt(sql) {
         Statement::CreateView {
+            or_alter,
             name,
             columns,
             query,
@@ -7965,6 +7972,7 @@ fn parse_create_view_temporary() {
             to,
             params,
         } => {
+            assert_eq!(or_alter, false);
             assert_eq!("myschema.myview", name.to_string());
             assert_eq!(Vec::<ViewColumnDef>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
@@ -7988,6 +7996,7 @@ fn parse_create_or_replace_view() {
     let sql = "CREATE OR REPLACE VIEW v AS SELECT 1";
     match verified_stmt(sql) {
         Statement::CreateView {
+            or_alter,
             name,
             columns,
             or_replace,
@@ -8002,6 +8011,7 @@ fn parse_create_or_replace_view() {
             to,
             params,
         } => {
+            assert_eq!(or_alter, false);
             assert_eq!("v", name.to_string());
             assert_eq!(columns, vec![]);
             assert_eq!(options, CreateTableOptions::None);
@@ -8029,6 +8039,7 @@ fn parse_create_or_replace_materialized_view() {
     let sql = "CREATE OR REPLACE MATERIALIZED VIEW v AS SELECT 1";
     match verified_stmt(sql) {
         Statement::CreateView {
+            or_alter,
             name,
             columns,
             or_replace,
@@ -8043,6 +8054,7 @@ fn parse_create_or_replace_materialized_view() {
             to,
             params,
         } => {
+            assert_eq!(or_alter, false);
             assert_eq!("v", name.to_string());
             assert_eq!(columns, vec![]);
             assert_eq!(options, CreateTableOptions::None);
@@ -8066,6 +8078,7 @@ fn parse_create_materialized_view() {
     let sql = "CREATE MATERIALIZED VIEW myschema.myview AS SELECT foo FROM bar";
     match verified_stmt(sql) {
         Statement::CreateView {
+            or_alter,
             name,
             or_replace,
             columns,
@@ -8080,6 +8093,7 @@ fn parse_create_materialized_view() {
             to,
             params,
         } => {
+            assert_eq!(or_alter, false);
             assert_eq!("myschema.myview", name.to_string());
             assert_eq!(Vec::<ViewColumnDef>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
@@ -8103,6 +8117,7 @@ fn parse_create_materialized_view_with_cluster_by() {
     let sql = "CREATE MATERIALIZED VIEW myschema.myview CLUSTER BY (foo) AS SELECT foo FROM bar";
     match verified_stmt(sql) {
         Statement::CreateView {
+            or_alter,
             name,
             or_replace,
             columns,
@@ -8117,6 +8132,7 @@ fn parse_create_materialized_view_with_cluster_by() {
             to,
             params,
         } => {
+            assert_eq!(or_alter, false);
             assert_eq!("myschema.myview", name.to_string());
             assert_eq!(Vec::<ViewColumnDef>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());


### PR DESCRIPTION
Reference: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-view-transact-sql

This PR adds an `or_alter` field to the CreateView struct, which is false by default but true for `CREATE OR ALTER`. This syntax is used by SQL Server, but implemented here generically. There is a `verified_stmt` test added to the existing "create view" test, to assert this field round trips as expected.