### PR TITLE
Add `DECLARE ... CURSOR FOR` support for SQL Server

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2472,10 +2472,11 @@ impl fmt::Display for DeclareAssignment {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum DeclareType {
-    /// Cursor variable type. e.g. [Snowflake] [PostgreSQL]
+    /// Cursor variable type. e.g. [Snowflake] [PostgreSQL] [MsSql]
     ///
     /// [Snowflake]: https://docs.snowflake.com/en/developer-guide/snowflake-scripting/cursors#declaring-a-cursor
     /// [PostgreSQL]: https://www.postgresql.org/docs/current/plpgsql-cursors.html
+    /// [MsSql]: https://learn.microsoft.com/en-us/sql/t-sql/language-elements/declare-cursor-transact-sql
     Cursor,
 
     /// Result set variable type. [Snowflake]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1387,6 +1387,10 @@ fn parse_mssql_declare() {
         ],
         ast
     );
+
+    let declare_cursor_for_select =
+        "DECLARE vend_cursor CURSOR FOR SELECT * FROM Purchasing.Vendor";
+    let _ = ms().verified_stmt(declare_cursor_for_select);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for declaring cursors on queries for SQL Server ([docs](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/declare-cursor-transact-sql))

Eg, this now parses correctly, which is the "A" example from documentation:

```mssql
DECLARE vend_cursor CURSOR
    FOR SELECT * FROM Purchasing.Vendor
OPEN vend_cursor
FETCH NEXT FROM vend_cursor;
```

There was already basic support for SQL Server cursors. What was missing was detecting & parsing the `for_query` struct field, and not requiring the `@` prefix for cursor names.

A new verified statement test was also added accordingly.