### PR TITLE
Handle missing login in changelog generate script

### DIFF
--- a/dev/release/generate-changelog.py
+++ b/dev/release/generate-changelog.py
@@ -28,7 +28,8 @@ def print_pulls(repo_name, title, pulls):
         print()
         for (pull, commit) in pulls:
             url = "https://github.com/{}/pull/{}".format(repo_name, pull.number)
-            print("- {} [#{}]({}) ({})".format(pull.title, pull.number, url, commit.author.login))
+            author = f"({commit.author.login})" if commit.author else ''
+            print("- {} [#{}]({}) {}".format(pull.title, pull.number, url, author))
         print()
 
 


### PR DESCRIPTION
Noticed during #1822 that the script initially failed due to [this
commit](https://github.com/apache/datafusion-sqlparser-rs/commit/10cf7c164ee0bae8a71e1d8f0af5851b96465692) no longer having the associated GitHub user.

Updates the script to skip the username referencing in such cases.