### PR TITLE
Handle optional datatypes properly in `CREATE FUNCTION` statements

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5210,12 +5210,9 @@ impl<'a> Parser<'a> {
         // To check whether the first token is a name or a type, we need to
         // peek the next token, which if it is another type keyword, then the
         // first token is a name and not a type in itself.
-        let potential_tokens = [Token::Eq, Token::RParen, Token::Comma];
-        if !self.peek_keyword(Keyword::DEFAULT)
-            && !potential_tokens.contains(&self.peek_token().token)
-        {
+        if let Some(next_data_type) = self.maybe_parse(|parser| parser.parse_data_type())? {
             name = Some(Ident::new(next_token.to_string()));
-            data_type = self.parse_data_type()?;
+            data_type = next_data_type;
         }
 
         let default_expr = if self.parse_keyword(Keyword::DEFAULT) || self.consume_token(&Token::Eq)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5201,11 +5201,6 @@ impl<'a> Parser<'a> {
         let mut name = None;
         let mut data_type = self.parse_data_type()?;
 
-        // It may appear that the first token can be converted into a known
-        // type, but this could also be a collision as some types are only
-        // present in some dialects and therefore some type reserved keywords
-        // may be freely used as argument names in other dialects.
-
         // To check whether the first token is a name or a type, we need to
         // peek the next token, which if it is another type keyword, then the
         // first token is a name and not a type in itself.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5199,7 +5199,6 @@ impl<'a> Parser<'a> {
 
         // parse: [ argname ] argtype
         let mut name = None;
-        let next_token = self.peek_token();
         let mut data_type = self.parse_data_type()?;
 
         // It may appear that the first token can be converted into a known
@@ -5210,8 +5209,16 @@ impl<'a> Parser<'a> {
         // To check whether the first token is a name or a type, we need to
         // peek the next token, which if it is another type keyword, then the
         // first token is a name and not a type in itself.
+        let data_type_idx = self.get_current_index();
         if let Some(next_data_type) = self.maybe_parse(|parser| parser.parse_data_type())? {
-            name = Some(Ident::new(next_token.to_string()));
+            let token = self.token_at(data_type_idx);
+
+            // We ensure that the token is a `Word` token, and not other special tokens.
+            if !matches!(token.token, Token::Word(_)) {
+                return self.expected("a name or type", token.clone());
+            }
+
+            name = Some(Ident::new(token.to_string()));
             data_type = next_data_type;
         }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4304,12 +4304,9 @@ $$"#;
             remote_connection: None,
         })
     );
-}
 
-#[test]
-fn parser_create_function_with_invalid_args() {
-    let sql = "CREATE FUNCTION add(function(struct<a,b> int64), b INTEGER) RETURNS INTEGER LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS 'select $1 + $2;'";
-    assert!(pg().parse_sql_statements(sql).is_err(),);
+    let incorrect_sql = "CREATE FUNCTION add(function(struct<a,b> int64), b INTEGER) RETURNS INTEGER LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS 'select $1 + $2;'";
+    assert!(pg().parse_sql_statements(incorrect_sql).is_err(),);
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4099,6 +4099,174 @@ fn parse_update_in_with_subquery() {
 }
 
 #[test]
+fn parser_create_function_with_args() {
+    let sql1 = r#"CREATE OR REPLACE FUNCTION check_strings_different(str1 VARCHAR, str2 VARCHAR) RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+BEGIN
+    IF str1 <> str2 THEN
+        RETURN TRUE;
+    ELSE
+        RETURN FALSE;
+    END IF;
+END;
+$$"#;
+
+    assert_eq!(
+        pg_and_generic().verified_stmt(sql1),
+        Statement::CreateFunction(CreateFunction {
+            or_alter: false,
+            or_replace: true,
+            temporary: false,
+            name: ObjectName::from(vec![Ident::new("check_strings_different")]),
+            args: Some(vec![
+                OperateFunctionArg::with_name(
+                    "str1",
+                    DataType::Varchar(None),
+                ),
+                OperateFunctionArg::with_name(
+                    "str2",
+                    DataType::Varchar(None),
+                ),
+            ]),
+            return_type: Some(DataType::Boolean),
+            language: Some("plpgsql".into()),
+            behavior: None,
+            called_on_null: None,
+            parallel: None,
+            function_body: Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+                (Value::DollarQuotedString(DollarQuotedString {value: "\nBEGIN\n    IF str1 <> str2 THEN\n        RETURN TRUE;\n    ELSE\n        RETURN FALSE;\n    END IF;\nEND;\n".to_owned(), tag: None})).with_empty_span()
+            ))),
+            if_not_exists: false,
+            using: None,
+            determinism_specifier: None,
+            options: None,
+            remote_connection: None,
+        })
+    );
+
+    let sql2 = r#"CREATE OR REPLACE FUNCTION check_not_zero(int1 INT) RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+BEGIN
+    IF int1 <> 0 THEN
+        RETURN TRUE;
+    ELSE
+        RETURN FALSE;
+    END IF;
+END;
+$$"#;
+    assert_eq!(
+        pg_and_generic().verified_stmt(sql2),
+        Statement::CreateFunction(CreateFunction {
+            or_alter: false,
+            or_replace: true,
+            temporary: false,
+            name: ObjectName::from(vec![Ident::new("check_not_zero")]),
+            args: Some(vec![
+                OperateFunctionArg::with_name(
+                    "int1",
+                    DataType::Int(None)
+                )
+            ]),
+            return_type: Some(DataType::Boolean),
+            language: Some("plpgsql".into()),
+            behavior: None,
+            called_on_null: None,
+            parallel: None,
+            function_body: Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+                (Value::DollarQuotedString(DollarQuotedString {value: "\nBEGIN\n    IF int1 <> 0 THEN\n        RETURN TRUE;\n    ELSE\n        RETURN FALSE;\n    END IF;\nEND;\n".to_owned(), tag: None})).with_empty_span()
+            ))),
+            if_not_exists: false,
+            using: None,
+            determinism_specifier: None,
+            options: None,
+            remote_connection: None,
+        })
+    );
+
+    let sql3 = r#"CREATE OR REPLACE FUNCTION check_values_different(a INT, b INT) RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+BEGIN
+    IF a <> b THEN
+        RETURN TRUE;
+    ELSE
+        RETURN FALSE;
+    END IF;
+END;
+$$"#;
+    assert_eq!(
+        pg_and_generic().verified_stmt(sql3),
+        Statement::CreateFunction(CreateFunction {
+            or_alter: false,
+            or_replace: true,
+            temporary: false,
+            name: ObjectName::from(vec![Ident::new("check_values_different")]),
+            args: Some(vec![
+                OperateFunctionArg::with_name(
+                    "a",
+                    DataType::Int(None)
+                ),
+                OperateFunctionArg::with_name(
+                    "b",
+                    DataType::Int(None)
+                ),
+            ]),
+            return_type: Some(DataType::Boolean),
+            language: Some("plpgsql".into()),
+            behavior: None,
+            called_on_null: None,
+            parallel: None,
+            function_body: Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+                (Value::DollarQuotedString(DollarQuotedString {value: "\nBEGIN\n    IF a <> b THEN\n        RETURN TRUE;\n    ELSE\n        RETURN FALSE;\n    END IF;\nEND;\n".to_owned(), tag: None})).with_empty_span()
+            ))),
+            if_not_exists: false,
+            using: None,
+            determinism_specifier: None,
+            options: None,
+            remote_connection: None,
+        })
+    );
+
+    let sql4 = r#"CREATE OR REPLACE FUNCTION check_values_different(int1 INT, int2 INT) RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+BEGIN
+    IF int1 <> int2 THEN
+        RETURN TRUE;
+    ELSE
+        RETURN FALSE;
+    END IF;
+END;
+$$"#;
+    assert_eq!(
+        pg_and_generic().verified_stmt(sql4),
+        Statement::CreateFunction(CreateFunction {
+            or_alter: false,
+            or_replace: true,
+            temporary: false,
+            name: ObjectName::from(vec![Ident::new("check_values_different")]),
+            args: Some(vec![
+                OperateFunctionArg::with_name(
+                    "int1",
+                    DataType::Int(None)
+                ),
+                OperateFunctionArg::with_name(
+                    "int2",
+                    DataType::Int(None)
+                ),
+            ]),
+            return_type: Some(DataType::Boolean),
+            language: Some("plpgsql".into()),
+            behavior: None,
+            called_on_null: None,
+            parallel: None,
+            function_body: Some(CreateFunctionBody::AsBeforeOptions(Expr::Value(
+                (Value::DollarQuotedString(DollarQuotedString {value: "\nBEGIN\n    IF int1 <> int2 THEN\n        RETURN TRUE;\n    ELSE\n        RETURN FALSE;\n    END IF;\nEND;\n".to_owned(), tag: None})).with_empty_span()
+            ))),
+            if_not_exists: false,
+            using: None,
+            determinism_specifier: None,
+            options: None,
+            remote_connection: None,
+        })
+    );
+}
+
+#[test]
 fn parse_create_function() {
     let sql = "CREATE FUNCTION add(INTEGER, INTEGER) RETURNS INTEGER LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS 'select $1 + $2;'";
     assert_eq!(


### PR DESCRIPTION
This pull request resolves the bug described in issue #1825, which was caused by an incorrect implementation of the named argument parsing. It also adds a few tests to verify that the new implementation is correct.

The previous implementation made the incorrect assumption that arguments name cannot have the same name as types, but the set of types that are parsed as types in `sqlparser` is a superset of the types that are present in each dialect. Therefore, it is correct syntax to use as argument name for instance `int2` for PostgreSQL, while this same argument name would be interpreted as a type elsewhere.

I have changed the parsing to determine via a look-ahead whether the name is a type or not.

Best,
Luca