### PR TITLE
Added support for `DROP DOMAIN`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3325,11 +3325,7 @@ pub enum Statement {
     ///
     /// DROP DOMAIN [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
     ///
-    DropDomain {
-        if_exists: bool,
-        name: ObjectName,
-        drop_behavior: Option<DropBehavior>,
-    },
+    DropDomain(DropDomain),
     /// ```sql
     /// DROP PROCEDURE
     /// ```
@@ -5104,11 +5100,11 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
-            Statement::DropDomain {
+            Statement::DropDomain(DropDomain {
                 if_exists,
                 name,
                 drop_behavior,
-            } => {
+            }) => {
                 write!(
                     f,
                     "DROP DOMAIN{} {name}",
@@ -6852,6 +6848,19 @@ impl fmt::Display for CloseCursor {
             CloseCursor::Specific { name } => write!(f, "{name}"),
         }
     }
+}
+
+/// A Drop Domain statement
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct DropDomain {
+    /// Whether to drop the domain if it exists
+    pub if_exists: bool,
+    /// The name of the domain to drop
+    pub name: ObjectName,
+    /// The behavior to apply when dropping the domain
+    pub drop_behavior: Option<DropBehavior>,
 }
 
 /// A function call

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3319,6 +3319,18 @@ pub enum Statement {
         drop_behavior: Option<DropBehavior>,
     },
     /// ```sql
+    /// DROP DOMAIN
+    /// ```
+    /// See [PostgreSQL](https://www.postgresql.org/docs/current/sql-dropdomain.html)
+    ///
+    /// DROP DOMAIN [ IF EXISTS ] name [, ...] [ CASCADE | RESTRICT ]
+    ///
+    DropDomain {
+        if_exists: bool,
+        name: ObjectName,
+        drop_behavior: Option<DropBehavior>,
+    },
+    /// ```sql
     /// DROP PROCEDURE
     /// ```
     DropProcedure {
@@ -5086,6 +5098,21 @@ impl fmt::Display for Statement {
                     "DROP FUNCTION{} {}",
                     if *if_exists { " IF EXISTS" } else { "" },
                     display_comma_separated(func_desc),
+                )?;
+                if let Some(op) = drop_behavior {
+                    write!(f, " {op}")?;
+                }
+                Ok(())
+            }
+            Statement::DropDomain {
+                if_exists,
+                name,
+                drop_behavior,
+            } => {
+                write!(
+                    f,
+                    "DROP DOMAIN{} {name}",
+                    if *if_exists { " IF EXISTS" } else { "" },
                 )?;
                 if let Some(op) = drop_behavior {
                     write!(f, " {op}")?;

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -454,6 +454,7 @@ impl Spanned for Statement {
             Statement::DetachDuckDBDatabase { .. } => Span::empty(),
             Statement::Drop { .. } => Span::empty(),
             Statement::DropFunction { .. } => Span::empty(),
+            Statement::DropDomain { .. } => Span::empty(),
             Statement::DropProcedure { .. } => Span::empty(),
             Statement::DropSecret { .. } => Span::empty(),
             Statement::Declare { .. } => Span::empty(),

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -286,6 +286,7 @@ define_keywords!(
     DISTRIBUTE,
     DIV,
     DO,
+    DOMAIN,
     DOUBLE,
     DOW,
     DOY,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6155,11 +6155,11 @@ impl<'a> Parser<'a> {
         let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
         let name = self.parse_object_name(false)?;
         let drop_behavior = self.parse_optional_drop_behavior();
-        Ok(Statement::DropDomain {
+        Ok(Statement::DropDomain(DropDomain {
             if_exists,
             name,
             drop_behavior,
-        })
+        }))
     }
 
     /// ```sql

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6051,6 +6051,8 @@ impl<'a> Parser<'a> {
             return self.parse_drop_policy();
         } else if self.parse_keyword(Keyword::CONNECTOR) {
             return self.parse_drop_connector();
+        } else if self.parse_keyword(Keyword::DOMAIN) {
+            return self.parse_drop_domain();
         } else if self.parse_keyword(Keyword::PROCEDURE) {
             return self.parse_drop_procedure();
         } else if self.parse_keyword(Keyword::SECRET) {
@@ -6144,6 +6146,20 @@ impl<'a> Parser<'a> {
         let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
         let name = self.parse_identifier()?;
         Ok(Statement::DropConnector { if_exists, name })
+    }
+
+    /// ```sql
+    /// DROP DOMAIN [ IF EXISTS ] name [ CASCADE | RESTRICT ]
+    /// ```
+    fn parse_drop_domain(&mut self) -> Result<Statement, ParserError> {
+        let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
+        let name = self.parse_object_name(false)?;
+        let drop_behavior = self.parse_optional_drop_behavior();
+        Ok(Statement::DropDomain {
+            if_exists,
+            name,
+            drop_behavior,
+        })
     }
 
     /// ```sql

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4240,6 +4240,66 @@ fn parse_drop_function() {
 }
 
 #[test]
+fn parse_drop_domain() {
+    let sql = "DROP DOMAIN IF EXISTS jpeg_domain";
+    assert_eq!(
+        pg().verified_stmt(sql),
+        Statement::DropDomain {
+            if_exists: true,
+            name: ObjectName::from(vec![Ident {
+                value: "jpeg_domain".to_string(),
+                quote_style: None,
+                span: Span::empty(),
+            }]),
+            drop_behavior: None
+        }
+    );
+
+    let sql = "DROP DOMAIN jpeg_domain";
+    assert_eq!(
+        pg().verified_stmt(sql),
+        Statement::DropDomain {
+            if_exists: false,
+            name: ObjectName::from(vec![Ident {
+                value: "jpeg_domain".to_string(),
+                quote_style: None,
+                span: Span::empty(),
+            }]),
+            drop_behavior: None
+        }
+    );
+
+    let sql = "DROP DOMAIN IF EXISTS jpeg_domain CASCADE";
+    assert_eq!(
+        pg().verified_stmt(sql),
+        Statement::DropDomain {
+            if_exists: true,
+            name: ObjectName::from(vec![Ident {
+                value: "jpeg_domain".to_string(),
+                quote_style: None,
+                span: Span::empty(),
+            }]),
+            drop_behavior: Some(DropBehavior::Cascade)
+        }
+    );
+
+    let sql = "DROP DOMAIN IF EXISTS jpeg_domain RESTRICT";
+
+    assert_eq!(
+        pg().verified_stmt(sql),
+        Statement::DropDomain {
+            if_exists: true,
+            name: ObjectName::from(vec![Ident {
+                value: "jpeg_domain".to_string(),
+                quote_style: None,
+                span: Span::empty(),
+            }]),
+            drop_behavior: Some(DropBehavior::Restrict)
+        }
+    );
+}
+
+#[test]
 fn parse_drop_procedure() {
     let sql = "DROP PROCEDURE IF EXISTS test_proc";
     assert_eq!(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -4244,7 +4244,7 @@ fn parse_drop_domain() {
     let sql = "DROP DOMAIN IF EXISTS jpeg_domain";
     assert_eq!(
         pg().verified_stmt(sql),
-        Statement::DropDomain {
+        Statement::DropDomain(DropDomain {
             if_exists: true,
             name: ObjectName::from(vec![Ident {
                 value: "jpeg_domain".to_string(),
@@ -4252,13 +4252,13 @@ fn parse_drop_domain() {
                 span: Span::empty(),
             }]),
             drop_behavior: None
-        }
+        })
     );
 
     let sql = "DROP DOMAIN jpeg_domain";
     assert_eq!(
         pg().verified_stmt(sql),
-        Statement::DropDomain {
+        Statement::DropDomain(DropDomain {
             if_exists: false,
             name: ObjectName::from(vec![Ident {
                 value: "jpeg_domain".to_string(),
@@ -4266,13 +4266,13 @@ fn parse_drop_domain() {
                 span: Span::empty(),
             }]),
             drop_behavior: None
-        }
+        })
     );
 
     let sql = "DROP DOMAIN IF EXISTS jpeg_domain CASCADE";
     assert_eq!(
         pg().verified_stmt(sql),
-        Statement::DropDomain {
+        Statement::DropDomain(DropDomain {
             if_exists: true,
             name: ObjectName::from(vec![Ident {
                 value: "jpeg_domain".to_string(),
@@ -4280,14 +4280,14 @@ fn parse_drop_domain() {
                 span: Span::empty(),
             }]),
             drop_behavior: Some(DropBehavior::Cascade)
-        }
+        })
     );
 
     let sql = "DROP DOMAIN IF EXISTS jpeg_domain RESTRICT";
 
     assert_eq!(
         pg().verified_stmt(sql),
-        Statement::DropDomain {
+        Statement::DropDomain(DropDomain {
             if_exists: true,
             name: ObjectName::from(vec![Ident {
                 value: "jpeg_domain".to_string(),
@@ -4295,7 +4295,7 @@ fn parse_drop_domain() {
                 span: Span::empty(),
             }]),
             drop_behavior: Some(DropBehavior::Restrict)
-        }
+        })
     );
 }
 


### PR DESCRIPTION
This pull request:
* Adds support for [`DROP DOMAIN`](https://www.postgresql.org/docs/current/sql-dropdomain.html) syntax resolving issue #1827 
* Adds tests for `DROP DOMAIN`

Best,
Luca