### PR TITLE
Added support for `CREATE DOMAIN`

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2156,6 +2156,50 @@ impl fmt::Display for ClusteredBy {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+/// ```sql
+/// CREATE DOMAIN name [ AS ] data_type
+///         [ COLLATE collation ]
+///         [ DEFAULT expression ]
+///         [ domain_constraint [ ... ] ]
+///
+///     where domain_constraint is:
+///
+///     [ CONSTRAINT constraint_name ]
+///     { NOT NULL | NULL | CHECK (expression) }
+/// ```
+/// See [PostgreSQL](https://www.postgresql.org/docs/current/sql-createdomain.html)
+pub struct CreateDomain {
+    /// The name of the domain to be created.
+    name: ObjectName,
+    /// The data type of the domain.
+    data_type: DataType,
+    /// The collation of the domain.
+    collation: Option<Ident>,
+    /// The default value of the domain.
+    default: Option<Expr>,
+    /// The constraints of the domain.
+    constraints: Vec<TableConstraint>,
+}
+
+impl fmt::Display for CreateDomain {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CREATE DOMAIN {name} AS {data_type}")?;
+        if let Some(collation) = collation {
+            write!(f, " COLLATE {collation}")?;
+        }
+        if let Some(default) = default {
+            write!(f, " DEFAULT {default}")?;
+        }
+        if !constraints.is_empty() {
+            write!(f, " {}", display_separated(constraints, " "))?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct CreateFunction {
     /// True if this is a `CREATE OR ALTER FUNCTION` statement
     ///

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2170,28 +2170,33 @@ impl fmt::Display for ClusteredBy {
 /// See [PostgreSQL](https://www.postgresql.org/docs/current/sql-createdomain.html)
 pub struct CreateDomain {
     /// The name of the domain to be created.
-    name: ObjectName,
+    pub name: ObjectName,
     /// The data type of the domain.
-    data_type: DataType,
+    pub data_type: DataType,
     /// The collation of the domain.
-    collation: Option<Ident>,
+    pub collation: Option<Ident>,
     /// The default value of the domain.
-    default: Option<Expr>,
+    pub default: Option<Expr>,
     /// The constraints of the domain.
-    constraints: Vec<TableConstraint>,
+    pub constraints: Vec<TableConstraint>,
 }
 
 impl fmt::Display for CreateDomain {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "CREATE DOMAIN {name} AS {data_type}")?;
-        if let Some(collation) = collation {
+        write!(
+            f,
+            "CREATE DOMAIN {name} AS {data_type}",
+            name = self.name,
+            data_type = self.data_type
+        )?;
+        if let Some(collation) = &self.collation {
             write!(f, " COLLATE {collation}")?;
         }
-        if let Some(default) = default {
+        if let Some(default) = &self.default {
             write!(f, " DEFAULT {default}")?;
         }
-        if !constraints.is_empty() {
-            write!(f, " {}", display_separated(constraints, " "))?;
+        if !self.constraints.is_empty() {
+            write!(f, " {}", display_separated(&self.constraints, " "))?;
         }
         Ok(())
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3979,13 +3979,7 @@ pub enum Statement {
     ///     { NOT NULL | NULL | CHECK (expression) }
     /// ```
     /// See [PostgreSQL](https://www.postgresql.org/docs/current/sql-createdomain.html)
-    CreateDomain {
-        name: ObjectName,
-        data_type: DataType,
-        collation: Option<Ident>,
-        default: Option<Expr>,
-        constraints: Vec<TableConstraint>,
-    },
+    CreateDomain(CreateDomain),
     /// ```sql
     /// CREATE TYPE <name>
     /// ```
@@ -4532,25 +4526,7 @@ impl fmt::Display for Statement {
                 Ok(())
             }
             Statement::CreateFunction(create_function) => create_function.fmt(f),
-            Statement::CreateDomain {
-                name,
-                data_type,
-                collation,
-                default,
-                constraints,
-            } => {
-                write!(f, "CREATE DOMAIN {name} AS {data_type}")?;
-                if let Some(collation) = collation {
-                    write!(f, " COLLATE {collation}")?;
-                }
-                if let Some(default) = default {
-                    write!(f, " DEFAULT {default}")?;
-                }
-                if !constraints.is_empty() {
-                    write!(f, " {}", display_separated(constraints, " "))?;
-                }
-                Ok(())
-            }
+            Statement::CreateDomain(create_domain) => create_domain.fmt(f),
             Statement::CreateTrigger {
                 or_replace,
                 is_constraint,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -55,12 +55,12 @@ pub use self::ddl::{
     AlterTableAlgorithm, AlterTableLock, AlterTableOperation, AlterType, AlterTypeAddValue,
     AlterTypeAddValuePosition, AlterTypeOperation, AlterTypeRename, AlterTypeRenameValue,
     ClusteredBy, ColumnDef, ColumnOption, ColumnOptionDef, ColumnPolicy, ColumnPolicyProperty,
-    ConstraintCharacteristics, CreateConnector, CreateFunction, Deduplicate, DeferrableInitial,
-    DropBehavior, GeneratedAs, GeneratedExpressionMode, IdentityParameters, IdentityProperty,
-    IdentityPropertyFormatKind, IdentityPropertyKind, IdentityPropertyOrder, IndexOption,
-    IndexType, KeyOrIndexDisplay, NullsDistinctOption, Owner, Partition, ProcedureParam,
-    ReferentialAction, TableConstraint, TagsColumnOption, UserDefinedTypeCompositeAttributeDef,
-    UserDefinedTypeRepresentation, ViewColumnDef,
+    ConstraintCharacteristics, CreateConnector, CreateDomain, CreateFunction, Deduplicate,
+    DeferrableInitial, DropBehavior, GeneratedAs, GeneratedExpressionMode, IdentityParameters,
+    IdentityProperty, IdentityPropertyFormatKind, IdentityPropertyKind, IdentityPropertyOrder,
+    IndexOption, IndexType, KeyOrIndexDisplay, NullsDistinctOption, Owner, Partition,
+    ProcedureParam, ReferentialAction, TableConstraint, TagsColumnOption,
+    UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation, ViewColumnDef,
 };
 pub use self::dml::{CreateIndex, CreateTable, Delete, IndexColumn, Insert};
 pub use self::operator::{BinaryOperator, UnaryOperator};

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3967,18 +3967,7 @@ pub enum Statement {
         sequence_options: Vec<SequenceOptions>,
         owned_by: Option<ObjectName>,
     },
-    /// ```sql
-    /// CREATE DOMAIN name [ AS ] data_type
-    ///         [ COLLATE collation ]
-    ///         [ DEFAULT expression ]
-    ///         [ domain_constraint [ ... ] ]
-    ///
-    ///     where domain_constraint is:
-    ///
-    ///     [ CONSTRAINT constraint_name ]
-    ///     { NOT NULL | NULL | CHECK (expression) }
-    /// ```
-    /// See [PostgreSQL](https://www.postgresql.org/docs/current/sql-createdomain.html)
+    /// A `CREATE DOMAIN` statement.
     CreateDomain(CreateDomain),
     /// ```sql
     /// CREATE TYPE <name>

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -479,6 +479,7 @@ impl Spanned for Statement {
             Statement::CreateSchema { .. } => Span::empty(),
             Statement::CreateDatabase { .. } => Span::empty(),
             Statement::CreateFunction { .. } => Span::empty(),
+            Statement::CreateDomain { .. } => Span::empty(),
             Statement::CreateTrigger { .. } => Span::empty(),
             Statement::DropTrigger { .. } => Span::empty(),
             Statement::CreateProcedure { .. } => Span::empty(),

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -286,6 +286,7 @@ define_keywords!(
     DISTRIBUTE,
     DIV,
     DO,
+    DOMAIN,
     DOUBLE,
     DOW,
     DOY,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5896,20 +5896,8 @@ impl<'a> Parser<'a> {
         Ok(owner)
     }
 
-    /// ```sql
-    ///     CREATE DOMAIN name [ AS ] data_type
-    ///             [ COLLATE collation ]
-    ///             [ DEFAULT expression ]
-    ///             [ domain_constraint [ ... ] ]
-    ///     
-    ///         where domain_constraint is:
-    ///     
-    ///         [ CONSTRAINT constraint_name ]
-    ///         { NOT NULL | NULL | CHECK (expression) }
-    /// ```
-    ///
-    /// [PostgreSQL Documentation](https://www.postgresql.org/docs/current/sql-createdomain.html)
-    pub fn parse_create_domain(&mut self) -> Result<Statement, ParserError> {
+    /// Parses a [Statement::CreateDomain] statement.
+    fn parse_create_domain(&mut self) -> Result<Statement, ParserError> {
         let name = self.parse_object_name(false)?;
         self.expect_keyword_is(Keyword::AS)?;
         let data_type = self.parse_data_type()?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5928,13 +5928,13 @@ impl<'a> Parser<'a> {
             constraints.push(constraint);
         }
 
-        Ok(Statement::CreateDomain {
+        Ok(Statement::CreateDomain(CreateDomain {
             name,
             data_type,
             collation,
             default,
             constraints,
-        })
+        }))
     }
 
     /// ```sql

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5081,6 +5081,111 @@ fn test_escaped_string_literal() {
 }
 
 #[test]
+fn parse_create_domain() {
+    let sql1 = "CREATE DOMAIN my_domain AS INTEGER CHECK (VALUE > 0)";
+    let expected = Statement::CreateDomain {
+        name: ObjectName::from(vec![Ident::new("my_domain")]),
+        data_type: DataType::Integer(None),
+        collation: None,
+        default: None,
+        constraints: vec![TableConstraint::Check {
+            name: None,
+            expr: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
+                op: BinaryOperator::Gt,
+                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+            }),
+        }],
+    };
+
+    assert_eq!(pg().verified_stmt(sql1), expected);
+}
+
+#[test]
+fn parse_create_domain_with_collation() {
+    let sql2 = "CREATE DOMAIN my_domain AS INTEGER COLLATE \"en_US\" CHECK (VALUE > 0)";
+    let expected = Statement::CreateDomain {
+        name: ObjectName::from(vec![Ident::new("my_domain")]),
+        data_type: DataType::Integer(None),
+        collation: Some(Ident::with_quote('"', "en_US")),
+        default: None,
+        constraints: vec![TableConstraint::Check {
+            name: None,
+            expr: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
+                op: BinaryOperator::Gt,
+                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+            }),
+        }],
+    };
+
+    assert_eq!(pg().verified_stmt(sql2), expected);
+}
+
+#[test]
+fn parse_create_domain_with_default() {
+    let sql3 = "CREATE DOMAIN my_domain AS INTEGER DEFAULT 1 CHECK (VALUE > 0)";
+    let expected = Statement::CreateDomain {
+        name: ObjectName::from(vec![Ident::new("my_domain")]),
+        data_type: DataType::Integer(None),
+        collation: None,
+        default: Some(Expr::Value(Value::Number("1".to_string(), false).into())),
+        constraints: vec![TableConstraint::Check {
+            name: None,
+            expr: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
+                op: BinaryOperator::Gt,
+                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+            }),
+        }],
+    };
+
+    assert_eq!(pg().verified_stmt(sql3), expected);
+}
+
+#[test]
+fn parse_create_domain_with_default_and_collation() {
+    let sql4 = "CREATE DOMAIN my_domain AS INTEGER COLLATE \"en_US\" DEFAULT 1 CHECK (VALUE > 0)";
+    let expected = Statement::CreateDomain {
+        name: ObjectName::from(vec![Ident::new("my_domain")]),
+        data_type: DataType::Integer(None),
+        collation: Some(Ident::with_quote('"', "en_US")),
+        default: Some(Expr::Value(Value::Number("1".to_string(), false).into())),
+        constraints: vec![TableConstraint::Check {
+            name: None,
+            expr: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
+                op: BinaryOperator::Gt,
+                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+            }),
+        }],
+    };
+
+    assert_eq!(pg().verified_stmt(sql4), expected);
+}
+
+#[test]
+fn parse_create_domain_with_named_constraint() {
+    let sql5 = "CREATE DOMAIN my_domain AS INTEGER CONSTRAINT my_constraint CHECK (VALUE > 0)";
+    let expected = Statement::CreateDomain {
+        name: ObjectName::from(vec![Ident::new("my_domain")]),
+        data_type: DataType::Integer(None),
+        collation: None,
+        default: None,
+        constraints: vec![TableConstraint::Check {
+            name: Some(Ident::new("my_constraint")),
+            expr: Box::new(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
+                op: BinaryOperator::Gt,
+                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+            }),
+        }],
+    };
+
+    assert_eq!(pg().verified_stmt(sql5), expected);
+}
+
+#[test]
 fn parse_create_simple_before_insert_trigger() {
     let sql = "CREATE TRIGGER check_insert BEFORE INSERT ON accounts FOR EACH ROW EXECUTE FUNCTION check_account_insert";
     let expected = Statement::CreateTrigger {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5083,7 +5083,7 @@ fn test_escaped_string_literal() {
 #[test]
 fn parse_create_domain() {
     let sql1 = "CREATE DOMAIN my_domain AS INTEGER CHECK (VALUE > 0)";
-    let expected = Statement::CreateDomain {
+    let expected = Statement::CreateDomain(CreateDomain {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
         data_type: DataType::Integer(None),
         collation: None,
@@ -5096,7 +5096,7 @@ fn parse_create_domain() {
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql1), expected);
 }
@@ -5104,7 +5104,7 @@ fn parse_create_domain() {
 #[test]
 fn parse_create_domain_with_collation() {
     let sql2 = "CREATE DOMAIN my_domain AS INTEGER COLLATE \"en_US\" CHECK (VALUE > 0)";
-    let expected = Statement::CreateDomain {
+    let expected = Statement::CreateDomain(CreateDomain {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
         data_type: DataType::Integer(None),
         collation: Some(Ident::with_quote('"', "en_US")),
@@ -5117,7 +5117,7 @@ fn parse_create_domain_with_collation() {
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql2), expected);
 }
@@ -5125,7 +5125,7 @@ fn parse_create_domain_with_collation() {
 #[test]
 fn parse_create_domain_with_default() {
     let sql3 = "CREATE DOMAIN my_domain AS INTEGER DEFAULT 1 CHECK (VALUE > 0)";
-    let expected = Statement::CreateDomain {
+    let expected = Statement::CreateDomain(CreateDomain {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
         data_type: DataType::Integer(None),
         collation: None,
@@ -5138,7 +5138,7 @@ fn parse_create_domain_with_default() {
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql3), expected);
 }
@@ -5146,7 +5146,7 @@ fn parse_create_domain_with_default() {
 #[test]
 fn parse_create_domain_with_default_and_collation() {
     let sql4 = "CREATE DOMAIN my_domain AS INTEGER COLLATE \"en_US\" DEFAULT 1 CHECK (VALUE > 0)";
-    let expected = Statement::CreateDomain {
+    let expected = Statement::CreateDomain(CreateDomain {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
         data_type: DataType::Integer(None),
         collation: Some(Ident::with_quote('"', "en_US")),
@@ -5159,7 +5159,7 @@ fn parse_create_domain_with_default_and_collation() {
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql4), expected);
 }
@@ -5167,7 +5167,7 @@ fn parse_create_domain_with_default_and_collation() {
 #[test]
 fn parse_create_domain_with_named_constraint() {
     let sql5 = "CREATE DOMAIN my_domain AS INTEGER CONSTRAINT my_constraint CHECK (VALUE > 0)";
-    let expected = Statement::CreateDomain {
+    let expected = Statement::CreateDomain(CreateDomain {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
         data_type: DataType::Integer(None),
         collation: None,
@@ -5180,7 +5180,7 @@ fn parse_create_domain_with_named_constraint() {
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql5), expected);
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5099,10 +5099,7 @@ fn parse_create_domain() {
     });
 
     assert_eq!(pg().verified_stmt(sql1), expected);
-}
 
-#[test]
-fn parse_create_domain_with_collation() {
     let sql2 = "CREATE DOMAIN my_domain AS INTEGER COLLATE \"en_US\" CHECK (VALUE > 0)";
     let expected = Statement::CreateDomain(CreateDomain {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
@@ -5120,10 +5117,7 @@ fn parse_create_domain_with_collation() {
     });
 
     assert_eq!(pg().verified_stmt(sql2), expected);
-}
 
-#[test]
-fn parse_create_domain_with_default() {
     let sql3 = "CREATE DOMAIN my_domain AS INTEGER DEFAULT 1 CHECK (VALUE > 0)";
     let expected = Statement::CreateDomain(CreateDomain {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
@@ -5141,10 +5135,7 @@ fn parse_create_domain_with_default() {
     });
 
     assert_eq!(pg().verified_stmt(sql3), expected);
-}
 
-#[test]
-fn parse_create_domain_with_default_and_collation() {
     let sql4 = "CREATE DOMAIN my_domain AS INTEGER COLLATE \"en_US\" DEFAULT 1 CHECK (VALUE > 0)";
     let expected = Statement::CreateDomain(CreateDomain {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
@@ -5162,10 +5153,7 @@ fn parse_create_domain_with_default_and_collation() {
     });
 
     assert_eq!(pg().verified_stmt(sql4), expected);
-}
 
-#[test]
-fn parse_create_domain_with_named_constraint() {
     let sql5 = "CREATE DOMAIN my_domain AS INTEGER CONSTRAINT my_constraint CHECK (VALUE > 0)";
     let expected = Statement::CreateDomain(CreateDomain {
         name: ObjectName::from(vec![Ident::new("my_domain")]),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5093,7 +5093,7 @@ fn parse_create_domain() {
             expr: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
                 op: BinaryOperator::Gt,
-                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+                right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
     };
@@ -5114,7 +5114,7 @@ fn parse_create_domain_with_collation() {
             expr: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
                 op: BinaryOperator::Gt,
-                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+                right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
     };
@@ -5129,13 +5129,13 @@ fn parse_create_domain_with_default() {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
         data_type: DataType::Integer(None),
         collation: None,
-        default: Some(Expr::Value(Value::Number("1".to_string(), false).into())),
+        default: Some(Expr::Value(test_utils::number("1").into())),
         constraints: vec![TableConstraint::Check {
             name: None,
             expr: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
                 op: BinaryOperator::Gt,
-                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+                right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
     };
@@ -5150,13 +5150,13 @@ fn parse_create_domain_with_default_and_collation() {
         name: ObjectName::from(vec![Ident::new("my_domain")]),
         data_type: DataType::Integer(None),
         collation: Some(Ident::with_quote('"', "en_US")),
-        default: Some(Expr::Value(Value::Number("1".to_string(), false).into())),
+        default: Some(Expr::Value(test_utils::number("1").into())),
         constraints: vec![TableConstraint::Check {
             name: None,
             expr: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
                 op: BinaryOperator::Gt,
-                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+                right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
     };
@@ -5177,7 +5177,7 @@ fn parse_create_domain_with_named_constraint() {
             expr: Box::new(Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::new("VALUE"))),
                 op: BinaryOperator::Gt,
-                right: Box::new(Expr::Value(Value::Number("0".to_string(), false).into())),
+                right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
         }],
     };


### PR DESCRIPTION
This pull request adds support for the [`CREATE DOMAIN`](https://www.postgresql.org/docs/current/sql-createdomain.html) syntax and the tests to validate whether the implementation is correct. It closes issue #1829.

IMPORTANT: this pull request may collide with #1828, as I had to add the keyword `DOMAIN` in both of them.

Best,
Luca