### PR TITLE
Improve support for cursors for SQL Server

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2226,7 +2226,33 @@ impl fmt::Display for IfStatement {
     }
 }
 
-/// A block within a [Statement::Case] or [Statement::If]-like statement
+/// A `WHILE` statement.
+///
+/// Example:
+/// ```sql
+/// WHILE @@FETCH_STATUS = 0
+/// BEGIN
+///    FETCH NEXT FROM c1 INTO @var1, @var2;
+/// END
+/// ```
+///
+/// [MsSql](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/while-transact-sql)
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct WhileStatement {
+    pub while_block: ConditionalStatementBlock,
+}
+
+impl fmt::Display for WhileStatement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let WhileStatement { while_block } = self;
+        write!(f, "{while_block}")?;
+        Ok(())
+    }
+}
+
+/// A block within a [Statement::Case] or [Statement::If] or [Statement::While]-like statement
 ///
 /// Example 1:
 /// ```sql
@@ -2241,6 +2267,14 @@ impl fmt::Display for IfStatement {
 /// Example 3:
 /// ```sql
 /// ELSE SELECT 1; SELECT 2;
+/// ```
+///
+/// Example 4:
+/// ```sql
+/// WHILE @@FETCH_STATUS = 0
+/// BEGIN
+///    FETCH NEXT FROM c1 INTO @var1, @var2;
+/// END
 /// ```
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -2981,6 +3015,8 @@ pub enum Statement {
     Case(CaseStatement),
     /// An `IF` statement.
     If(IfStatement),
+    /// A `WHILE` statement.
+    While(WhileStatement),
     /// A `RAISE` statement.
     Raise(RaiseStatement),
     /// ```sql
@@ -4343,6 +4379,9 @@ impl fmt::Display for Statement {
                 write!(f, "{stmt}")
             }
             Statement::If(stmt) => {
+                write!(f, "{stmt}")
+            }
+            Statement::While(stmt) => {
                 write!(f, "{stmt}")
             }
             Statement::Raise(stmt) => {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3071,10 +3071,7 @@ pub enum Statement {
     /// OPEN cursor_name
     /// ```
     /// Opens a cursor.
-    Open {
-        /// Cursor name
-        cursor_name: Ident,
-    },
+    Open(OpenStatement),
     /// ```sql
     /// CLOSE
     /// ```
@@ -4535,11 +4532,7 @@ impl fmt::Display for Statement {
                 Ok(())
             }
             Statement::Delete(delete) => write!(f, "{delete}"),
-            Statement::Open { cursor_name } => {
-                write!(f, "OPEN {cursor_name}")?;
-
-                Ok(())
-            }
+            Statement::Open(open) => write!(f, "{open}"),
             Statement::Close { cursor } => {
                 write!(f, "CLOSE {cursor}")?;
 
@@ -9388,6 +9381,21 @@ impl fmt::Display for ReturnStatement {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum ReturnStatementValue {
     Expr(Expr),
+}
+
+/// Represents an `OPEN` statement.
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct OpenStatement {
+    /// Cursor name
+    pub cursor_name: Ident,
+}
+
+impl fmt::Display for OpenStatement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "OPEN {}", self.cursor_name)
+    }
 }
 
 #[cfg(test)]

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -31,13 +31,13 @@ use super::{
     FunctionArguments, GroupByExpr, HavingBound, IfStatement, IlikeSelectItem, Insert, Interpolate,
     InterpolateExpr, Join, JoinConstraint, JoinOperator, JsonPath, JsonPathElem, LateralView,
     LimitClause, MatchRecognizePattern, Measure, NamedWindowDefinition, ObjectName, ObjectNamePart,
-    Offset, OnConflict, OnConflictAction, OnInsert, OrderBy, OrderByExpr, OrderByKind, Partition,
-    PivotValueSource, ProjectionSelect, Query, RaiseStatement, RaiseStatementValue,
-    ReferentialAction, RenameSelectItem, ReplaceSelectElement, ReplaceSelectItem, Select,
-    SelectInto, SelectItem, SetExpr, SqlOption, Statement, Subscript, SymbolDefinition, TableAlias,
-    TableAliasColumnDef, TableConstraint, TableFactor, TableObject, TableOptionsClustered,
-    TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef, WhileStatement,
-    WildcardAdditionalOptions, With, WithFill,
+    Offset, OnConflict, OnConflictAction, OnInsert, OpenStatement, OrderBy, OrderByExpr,
+    OrderByKind, Partition, PivotValueSource, ProjectionSelect, Query, RaiseStatement,
+    RaiseStatementValue, ReferentialAction, RenameSelectItem, ReplaceSelectElement,
+    ReplaceSelectItem, Select, SelectInto, SelectItem, SetExpr, SqlOption, Statement, Subscript,
+    SymbolDefinition, TableAlias, TableAliasColumnDef, TableConstraint, TableFactor, TableObject,
+    TableOptionsClustered, TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef,
+    WhileStatement, WildcardAdditionalOptions, With, WithFill,
 };
 
 /// Given an iterator of spans, return the [Span::union] of all spans.
@@ -365,7 +365,7 @@ impl Spanned for Statement {
                 from_query: _,
                 partition: _,
             } => Span::empty(),
-            Statement::Open { cursor_name } => cursor_name.span,
+            Statement::Open(open) => open.span(),
             Statement::Close { cursor } => match cursor {
                 CloseCursor::All => Span::empty(),
                 CloseCursor::Specific { name } => name.span,
@@ -2302,6 +2302,13 @@ impl Spanned for BeginEndStatements {
                 .chain(statements.iter().map(|i| i.span()))
                 .chain(core::iter::once(end_token.0.span)),
         )
+    }
+}
+
+impl Spanned for OpenStatement {
+    fn span(&self) -> Span {
+        let OpenStatement { cursor_name } = self;
+        cursor_name.span
     }
 }
 

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -364,6 +364,7 @@ impl Spanned for Statement {
                 from_query: _,
                 partition: _,
             } => Span::empty(),
+            Statement::Open { cursor_name } => cursor_name.span,
             Statement::Close { cursor } => match cursor {
                 CloseCursor::All => Span::empty(),
                 CloseCursor::Specific { name } => name.span,

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -36,7 +36,7 @@ use super::{
     ReferentialAction, RenameSelectItem, ReplaceSelectElement, ReplaceSelectItem, Select,
     SelectInto, SelectItem, SetExpr, SqlOption, Statement, Subscript, SymbolDefinition, TableAlias,
     TableAliasColumnDef, TableConstraint, TableFactor, TableObject, TableOptionsClustered,
-    TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef,
+    TableWithJoins, UpdateTableFromKind, Use, Value, Values, ViewColumnDef, WhileStatement,
     WildcardAdditionalOptions, With, WithFill,
 };
 
@@ -338,6 +338,7 @@ impl Spanned for Statement {
             } => source.span(),
             Statement::Case(stmt) => stmt.span(),
             Statement::If(stmt) => stmt.span(),
+            Statement::While(stmt) => stmt.span(),
             Statement::Raise(stmt) => stmt.span(),
             Statement::Call(function) => function.span(),
             Statement::Copy {
@@ -772,6 +773,14 @@ impl Spanned for IfStatement {
                 .chain(else_block.as_ref().map(|b| b.span()))
                 .chain(end_token.as_ref().map(|AttachedToken(t)| t.span)),
         )
+    }
+}
+
+impl Spanned for WhileStatement {
+    fn span(&self) -> Span {
+        let WhileStatement { while_block } = self;
+
+        while_block.span()
     }
 }
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1065,7 +1065,6 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::SAMPLE,
     Keyword::TABLESAMPLE,
     Keyword::FROM,
-    // Reserved for SQL Server cursors
     Keyword::OPEN,
 ];
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1065,6 +1065,8 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::SAMPLE,
     Keyword::TABLESAMPLE,
     Keyword::FROM,
+    // Reserved for SQL Server cursors
+    Keyword::OPEN,
 ];
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -981,6 +981,7 @@ define_keywords!(
     WHEN,
     WHENEVER,
     WHERE,
+    WHILE,
     WIDTH_BUCKET,
     WINDOW,
     WITH,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8784,9 +8784,9 @@ impl<'a> Parser<'a> {
     /// Parse [Statement::Open]
     fn parse_open(&mut self) -> Result<Statement, ParserError> {
         self.expect_keyword(Keyword::OPEN)?;
-        Ok(Statement::Open {
+        Ok(Statement::Open(OpenStatement {
             cursor_name: self.parse_identifier()?,
-        })
+        }))
     }
 
     pub fn parse_close(&mut self) -> Result<Statement, ParserError> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4482,14 +4482,16 @@ impl<'a> Parser<'a> {
     ) -> Result<Vec<Statement>, ParserError> {
         let mut values = vec![];
         loop {
-            if let Token::Word(w) = &self.peek_nth_token_ref(0).token {
-                if w.quote_style.is_none() && terminal_keywords.contains(&w.keyword) {
-                    break;
+            match &self.peek_nth_token_ref(0).token {
+                Token::EOF => break,
+                Token::Word(w) => {
+                    if w.quote_style.is_none() && terminal_keywords.contains(&w.keyword) {
+                        break;
+                    }
                 }
+                _ => {}
             }
-            if let Token::EOF = self.peek_nth_token_ref(0).token {
-                break;
-            }
+
             values.push(self.parse_statement()?);
             self.expect_token(&Token::SemiColon)?;
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6646,10 +6646,12 @@ impl<'a> Parser<'a> {
             }
         };
 
-        let from_or_in_token = if self.peek_keyword(Keyword::FROM) {
-            self.expect_keyword(Keyword::FROM)?
+        let position = if self.peek_keyword(Keyword::FROM) {
+            self.expect_keyword(Keyword::FROM)?;
+            FetchPosition::From
         } else if self.peek_keyword(Keyword::IN) {
-            self.expect_keyword(Keyword::IN)?
+            self.expect_keyword(Keyword::IN)?;
+            FetchPosition::In
         } else {
             return parser_err!("Expected FROM or IN", self.peek_token().span.start);
         };
@@ -6665,7 +6667,7 @@ impl<'a> Parser<'a> {
         Ok(Statement::Fetch {
             name,
             direction,
-            from_or_in: AttachedToken(from_or_in_token),
+            position,
             into,
         })
     }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -169,14 +169,8 @@ impl TestedDialects {
     }
 
     /// The same as [`one_statement_parses_to`] but it works for a multiple statements
-    pub fn statements_parse_to(
-        &self,
-        sql: &str,
-        statement_count: usize,
-        canonical: &str,
-    ) -> Vec<Statement> {
+    pub fn statements_parse_to(&self, sql: &str, canonical: &str) -> Vec<Statement> {
         let statements = self.parse_sql_statements(sql).expect(sql);
-        assert_eq!(statements.len(), statement_count);
         if !canonical.is_empty() && sql != canonical {
             assert_eq!(self.parse_sql_statements(canonical).unwrap(), statements);
         } else {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -151,6 +151,8 @@ impl TestedDialects {
     ///
     /// 2. re-serializing the result of parsing `sql` produces the same
     ///    `canonical` sql string
+    ///
+    ///  For multiple statements, use [`statements_parse_to`].
     pub fn one_statement_parses_to(&self, sql: &str, canonical: &str) -> Statement {
         let mut statements = self.parse_sql_statements(sql).expect(sql);
         assert_eq!(statements.len(), 1);
@@ -164,6 +166,30 @@ impl TestedDialects {
             assert_eq!(canonical, only_statement.to_string())
         }
         only_statement
+    }
+
+    /// The same as [`one_statement_parses_to`] but it works for a multiple statements
+    pub fn statements_parse_to(
+        &self,
+        sql: &str,
+        statement_count: usize,
+        canonical: &str,
+    ) -> Vec<Statement> {
+        let statements = self.parse_sql_statements(sql).expect(sql);
+        assert_eq!(statements.len(), statement_count);
+        if !canonical.is_empty() && sql != canonical {
+            assert_eq!(self.parse_sql_statements(canonical).unwrap(), statements);
+        } else {
+            assert_eq!(
+                sql,
+                statements
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            );
+        }
+        statements
     }
 
     /// Ensures that `sql` parses as an [`Expr`], and that

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15103,3 +15103,15 @@ fn parse_return() {
 
     let _ = all_dialects().verified_stmt("RETURN 1");
 }
+
+#[test]
+fn test_open() {
+    let open_cursor = "OPEN Employee_Cursor";
+    let stmt = all_dialects().verified_stmt(open_cursor);
+    assert_eq!(
+        stmt,
+        Statement::Open(OpenStatement {
+            cursor_name: Ident::new("Employee_Cursor"),
+        })
+    );
+}

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1414,7 +1414,7 @@ fn test_mssql_cursor() {
         CLOSE Employee_Cursor; \
         DEALLOCATE Employee_Cursor\
     ";
-    let _ = ms().statements_parse_to(full_cursor_usage, 6, "");
+    let _ = ms().statements_parse_to(full_cursor_usage, "");
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -23,7 +23,8 @@
 mod test_utils;
 
 use helpers::attached_token::AttachedToken;
-use sqlparser::tokenizer::{Location, Span};
+use sqlparser::keywords::Keyword;
+use sqlparser::tokenizer::{Location, Span, Token, TokenWithSpan, Word};
 use test_utils::*;
 
 use sqlparser::ast::DataType::{Int, Text, Varbinary};
@@ -1419,7 +1420,40 @@ fn test_mssql_cursor() {
 #[test]
 fn test_mssql_while_statement() {
     let while_single_statement = "WHILE 1 = 0 PRINT 'Hello World';";
-    let _ = ms().verified_stmt(while_single_statement);
+    let stmt = ms().verified_stmt(while_single_statement);
+    assert_eq!(
+        stmt,
+        Statement::While(sqlparser::ast::WhileStatement {
+            while_block: ConditionalStatementBlock {
+                start_token: AttachedToken(TokenWithSpan {
+                    token: Token::Word(Word {
+                        value: "WHILE".to_string(),
+                        quote_style: None,
+                        keyword: Keyword::WHILE
+                    }),
+                    span: Span::empty()
+                }),
+                condition: Some(Expr::BinaryOp {
+                    left: Box::new(Expr::Value(
+                        (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                    )),
+                    op: BinaryOperator::Eq,
+                    right: Box::new(Expr::Value(
+                        (Value::Number("0".parse().unwrap(), false)).with_empty_span()
+                    )),
+                }),
+                then_token: None,
+                conditional_statements: ConditionalStatements::Sequence {
+                    statements: vec![Statement::Print(PrintStatement {
+                        message: Box::new(Expr::Value(
+                            (Value::SingleQuotedString("Hello World".to_string()))
+                                .with_empty_span()
+                        )),
+                    }),],
+                }
+            }
+        })
+    );
 
     let while_begin_end = "\
         WHILE @@FETCH_STATUS = 0 \

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -223,7 +223,7 @@ fn parse_create_function() {
                     value: Some(ReturnStatementValue::Expr(Expr::Value(
                         (number("1")).with_empty_span()
                     ))),
-                }),],
+                })],
                 end_token: AttachedToken::empty(),
             })),
             behavior: None,
@@ -1449,7 +1449,7 @@ fn test_mssql_while_statement() {
                             (Value::SingleQuotedString("Hello World".to_string()))
                                 .with_empty_span()
                         )),
-                    }),],
+                    })],
                 }
             }
         })

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1394,6 +1394,24 @@ fn parse_mssql_declare() {
 }
 
 #[test]
+fn test_mssql_cursor() {
+    let full_cursor_usage = "\
+        DECLARE Employee_Cursor CURSOR FOR \
+        SELECT LastName, FirstName \
+        FROM AdventureWorks2022.HumanResources.vEmployee \
+        WHERE LastName LIKE 'B%'; \
+        \
+        OPEN Employee_Cursor; \
+        \
+        FETCH NEXT FROM Employee_Cursor; \
+        \
+        CLOSE Employee_Cursor; \
+        DEALLOCATE Employee_Cursor\
+    ";
+    let _ = ms().statements_parse_to(full_cursor_usage, 5, "");
+}
+
+#[test]
 fn test_parse_raiserror() {
     let sql = r#"RAISERROR('This is a test', 16, 1)"#;
     let s = ms().verified_stmt(sql);

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1405,10 +1405,38 @@ fn test_mssql_cursor() {
         \
         FETCH NEXT FROM Employee_Cursor; \
         \
+        WHILE @@FETCH_STATUS = 0 \
+        BEGIN \
+            FETCH NEXT FROM Employee_Cursor; \
+        END; \
+        \
         CLOSE Employee_Cursor; \
         DEALLOCATE Employee_Cursor\
     ";
-    let _ = ms().statements_parse_to(full_cursor_usage, 5, "");
+    let _ = ms().statements_parse_to(full_cursor_usage, 6, "");
+}
+
+#[test]
+fn test_mssql_while_statement() {
+    let while_single_statement = "WHILE 1 = 0 PRINT 'Hello World';";
+    let _ = ms().verified_stmt(while_single_statement);
+
+    let while_begin_end = "\
+        WHILE @@FETCH_STATUS = 0 \
+        BEGIN \
+            FETCH NEXT FROM Employee_Cursor; \
+        END\
+    ";
+    let _ = ms().verified_stmt(while_begin_end);
+
+    let while_begin_end_multiple_statements = "\
+        WHILE @@FETCH_STATUS = 0 \
+        BEGIN \
+            FETCH NEXT FROM Employee_Cursor; \
+            PRINT 'Hello World'; \
+        END\
+    ";
+    let _ = ms().verified_stmt(while_begin_end_multiple_statements);
 }
 
 #[test]


### PR DESCRIPTION
This PR is a followup to https://github.com/apache/datafusion-sqlparser-rs/pull/1821 to address several difficulties I had parsing real world SQL files.

There are 3 related enhancements here:

1. Introduce support for parsing `OPEN` statements, eg: `OPEN my_cursor`
2. Expand existing `FETCH` statement parsing support the `FROM` keyword. Eg, `FETCH NEXT FROM my_cursor`. The logic formerly only supported "FETCH NEXT IN" syntax
3. Introduce support for parsing `WHILE` statements, which is commonly used in conjunction with cursors. Eg `WHILE @@fetch_status = 0...`. This is a conditional statement block, much like IF & CASE, so that code has been structured similarly and placed adjacent to those statements.

(4th thing -- a test helper introduced in this PR was brought over here, because it simplifies validating a test case. If the other PR merges first that commit can be dropped out of this branch).

The effect of these changes is that this cursor example from the [SQL Server FETCH documentation page](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/fetch-transact-sql?view=sql-server-ver16#a-using-fetch-in-a-simple-cursor) now successfully parses:

```mssql
DECLARE Employee_Cursor CURSOR FOR
SELECT LastName, FirstName
FROM AdventureWorks2022.HumanResources.vEmployee
WHERE LastName LIKE 'B%';

OPEN Employee_Cursor;
FETCH NEXT FROM Employee_Cursor;

WHILE @@FETCH_STATUS = 0
BEGIN
    FETCH NEXT FROM Employee_Cursor;
END;

CLOSE Employee_Cursor;
DEALLOCATE Employee_Cursor
```