### PR TITLE
Update `56.0.0` Changelog with latest commits

### DIFF
--- a/changelog/0.56.0.md
+++ b/changelog/0.56.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # sqlparser-rs 0.56.0 Changelog
 
-This release consists of 45 commits from 19 contributors. See credits at the end of this changelog for more information.
+This release consists of 48 commits from 19 contributors. See credits at the end of this changelog for more information.
 
 **Other:**
 
@@ -69,6 +69,8 @@ This release consists of 45 commits from 19 contributors. See credits at the end
 - Add `CREATE FUNCTION` support for SQL Server [#1808](https://github.com/apache/datafusion-sqlparser-rs/pull/1808) (aharpervc)
 - Add `OR ALTER` support for `CREATE VIEW` [#1818](https://github.com/apache/datafusion-sqlparser-rs/pull/1818) (aharpervc)
 - Add `DECLARE ... CURSOR FOR` support for SQL Server [#1821](https://github.com/apache/datafusion-sqlparser-rs/pull/1821) (aharpervc)
+- Handle missing login in changelog generate script [#1823](https://github.com/apache/datafusion-sqlparser-rs/pull/1823) (iffyio)
+- Snowflake: Add support for `CONNECT_BY_ROOT` [#1780](https://github.com/apache/datafusion-sqlparser-rs/pull/1780) (tomershaniii)
 
 ## Credits
 
@@ -76,14 +78,15 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
 
 ```
      8	Roman Borschel
-     5	Ifeanyi Ubah
+     6	Ifeanyi Ubah
+     5	Andrew Harper
      5	Michael Victor Zink
-     4	Andrew Harper
      4	Mohamed Abdeen
      3	Ophir LOJKINE
      2	Luca Cappelletti
      2	Yoav Cohen
      2	bar sela
+     2	tomershaniii
      1	Adam Johnson
      1	Aleksei Piianin
      1	Alexander Beedie
@@ -93,7 +96,6 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
      1	Jax Liu
      1	John Vandenberg
      1	LFC
-     1	tomershaniii
 ```
 
 Thank you also to everyone who contributed in other ways such as filing issues, reviewing PRs, and providing feedback on this release.


### PR DESCRIPTION
- part of https://github.com/apache/datafusion-sqlparser-rs/issues/1756
- closes https://github.com/validio-io/sqlparser-rs/pull/1

This PR updates the 56.0.0 changelog with two missing commits