### PR TITLE
Fix: parsing ident starting with underscore in certain dialects

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1295,7 +1295,7 @@ impl<'a> Tokenizer<'a> {
                         Some('_') => {
                             self.tokenizer_error(
                                 chars.location(),
-                                "Unexpected an underscore here".to_string(),
+                                "Unexpected underscore here".to_string(),
                             )
                         }
                         Some(ch)


### PR DESCRIPTION
The dialects that support underscore as a separator in numeric literals used to parse `._123` as a number, which I don't think is valid SQL. However, that means that something like `._abc` would be parsed as Number `._` and word `abc`, which is wrong.

This PR splits the tokenizer match branch for numbers and periods into two branches to make things easier, fixes the issue mentioned above, and adds tests.

CC: @mvzink