### PR TITLE
Add support for `DENY` statements

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3903,6 +3903,7 @@ pub enum Statement {
         objects: Option<GrantObjects>,
         grantees: Vec<Grantee>,
         with_grant_option: bool,
+        as_grantor: Option<Ident>,
         granted_by: Option<Ident>,
     },
     /// ```sql
@@ -5584,6 +5585,7 @@ impl fmt::Display for Statement {
                 objects,
                 grantees,
                 with_grant_option,
+                as_grantor,
                 granted_by,
             } => {
                 write!(f, "GRANT {privileges} ")?;
@@ -5593,6 +5595,9 @@ impl fmt::Display for Statement {
                 write!(f, "TO {}", display_comma_separated(grantees))?;
                 if *with_grant_option {
                     write!(f, " WITH GRANT OPTION")?;
+                }
+                if let Some(grantor) = as_grantor {
+                    write!(f, " AS {grantor}")?;
                 }
                 if let Some(grantor) = granted_by {
                     write!(f, " GRANTED BY {grantor}")?;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -6385,6 +6385,9 @@ pub enum Action {
     },
     Delete,
     EvolveSchema,
+    Exec {
+        obj_type: Option<ActionExecuteObjectType>,
+    },
     Execute {
         obj_type: Option<ActionExecuteObjectType>,
     },
@@ -6451,6 +6454,12 @@ impl fmt::Display for Action {
             Action::DatabaseRole { role } => write!(f, "DATABASE ROLE {role}")?,
             Action::Delete => f.write_str("DELETE")?,
             Action::EvolveSchema => f.write_str("EVOLVE SCHEMA")?,
+            Action::Exec { obj_type } => {
+                f.write_str("EXEC")?;
+                if let Some(obj_type) = obj_type {
+                    write!(f, " {obj_type}")?
+                }
+            }
             Action::Execute { obj_type } => {
                 f.write_str("EXECUTE")?;
                 if let Some(obj_type) = obj_type {

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -491,6 +491,7 @@ impl Spanned for Statement {
             Statement::CreateStage { .. } => Span::empty(),
             Statement::Assert { .. } => Span::empty(),
             Statement::Grant { .. } => Span::empty(),
+            Statement::Deny { .. } => Span::empty(),
             Statement::Revoke { .. } => Span::empty(),
             Statement::Deallocate { .. } => Span::empty(),
             Statement::Execute { .. } => Span::empty(),

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -49,7 +49,7 @@ pub use self::postgresql::PostgreSqlDialect;
 pub use self::redshift::RedshiftSqlDialect;
 pub use self::snowflake::SnowflakeDialect;
 pub use self::sqlite::SQLiteDialect;
-use crate::ast::{ColumnOption, Expr, Statement};
+use crate::ast::{ColumnOption, Expr, GranteesType, Statement};
 pub use crate::keywords;
 use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
@@ -907,6 +907,11 @@ pub trait Dialect: Debug + Any {
     /// Returns reserved keywords that may prefix a select item expression
     /// e.g. `SELECT CONNECT_BY_ROOT name FROM Tbl2` (Snowflake)
     fn get_reserved_keywords_for_select_item_operator(&self) -> &[Keyword] {
+        &[]
+    }
+
+    /// Returns grantee types that should be treated as identifiers
+    fn get_reserved_grantees_types(&self) -> &[GranteesType] {
         &[]
     }
 

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -17,8 +17,8 @@
 
 use crate::ast::helpers::attached_token::AttachedToken;
 use crate::ast::{
-    BeginEndStatements, ConditionalStatementBlock, ConditionalStatements, IfStatement, Statement,
-    TriggerObject,
+    BeginEndStatements, ConditionalStatementBlock, ConditionalStatements, GranteesType,
+    IfStatement, Statement, TriggerObject,
 };
 use crate::dialect::Dialect;
 use crate::keywords::{self, Keyword};
@@ -121,6 +121,11 @@ impl Dialect for MsSqlDialect {
     /// See <https://learn.microsoft.com/en-us/sql/t-sql/queries/from-transact-sql>
     fn supports_object_name_double_dot_notation(&self) -> bool {
         true
+    }
+
+    /// See <https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/server-level-roles>
+    fn get_reserved_grantees_types(&self) -> &[GranteesType] {
+        &[GranteesType::Public]
     }
 
     fn is_column_alias(&self, kw: &Keyword, _parser: &mut Parser) -> bool {

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -52,6 +52,10 @@ impl Dialect for MsSqlDialect {
             || ch == '_'
     }
 
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('[')
+    }
+
     /// SQL Server has `CONVERT(type, value)` instead of `CONVERT(value, type)`
     /// <https://learn.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver16>
     fn convert_type_before_value(&self) -> bool {

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -278,6 +278,7 @@ define_keywords!(
     DELIMITER,
     DELTA,
     DENSE_RANK,
+    DENY,
     DEREF,
     DESC,
     DESCRIBE,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13393,15 +13393,26 @@ impl<'a> Parser<'a> {
         let with_grant_option =
             self.parse_keywords(&[Keyword::WITH, Keyword::GRANT, Keyword::OPTION]);
 
-        let granted_by = self
-            .parse_keywords(&[Keyword::GRANTED, Keyword::BY])
-            .then(|| self.parse_identifier().unwrap());
+        let as_grantor = if self.peek_keyword(Keyword::AS) {
+            self.parse_keywords(&[Keyword::AS])
+                .then(|| self.parse_identifier().unwrap())
+        } else {
+            None
+        };
+
+        let granted_by = if self.peek_keywords(&[Keyword::GRANTED, Keyword::BY]) {
+            self.parse_keywords(&[Keyword::GRANTED, Keyword::BY])
+                .then(|| self.parse_identifier().unwrap())
+        } else {
+            None
+        };
 
         Ok(Statement::Grant {
             privileges,
             objects,
             grantees,
             with_grant_option,
+            as_grantor,
             granted_by,
         })
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13393,16 +13393,14 @@ impl<'a> Parser<'a> {
         let with_grant_option =
             self.parse_keywords(&[Keyword::WITH, Keyword::GRANT, Keyword::OPTION]);
 
-        let as_grantor = if self.peek_keyword(Keyword::AS) {
-            self.parse_keywords(&[Keyword::AS])
-                .then(|| self.parse_identifier().unwrap())
+        let as_grantor = if self.parse_keywords(&[Keyword::AS]) {
+            Some(self.parse_identifier()?)
         } else {
             None
         };
 
-        let granted_by = if self.peek_keywords(&[Keyword::GRANTED, Keyword::BY]) {
-            self.parse_keywords(&[Keyword::GRANTED, Keyword::BY])
-                .then(|| self.parse_identifier().unwrap())
+        let granted_by = if self.parse_keywords(&[Keyword::GRANTED, Keyword::BY]) {
+            Some(self.parse_identifier()?)
         } else {
             None
         };
@@ -13842,9 +13840,11 @@ impl<'a> Parser<'a> {
         self.expect_keyword_is(Keyword::TO)?;
         let grantees = self.parse_grantees()?;
         let cascade = self.parse_cascade_option();
-        let granted_by = self
-            .parse_keywords(&[Keyword::AS])
-            .then(|| self.parse_identifier().unwrap());
+        let granted_by = if self.parse_keywords(&[Keyword::AS]) {
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
 
         Ok(Statement::Deny(DenyStatement {
             privileges,
@@ -13862,9 +13862,11 @@ impl<'a> Parser<'a> {
         self.expect_keyword_is(Keyword::FROM)?;
         let grantees = self.parse_grantees()?;
 
-        let granted_by = self
-            .parse_keywords(&[Keyword::GRANTED, Keyword::BY])
-            .then(|| self.parse_identifier().unwrap());
+        let granted_by = if self.parse_keywords(&[Keyword::GRANTED, Keyword::BY]) {
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
 
         let cascade = self.parse_cascade_option();
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13608,6 +13608,9 @@ impl<'a> Parser<'a> {
             Ok(Action::Create { obj_type })
         } else if self.parse_keyword(Keyword::DELETE) {
             Ok(Action::Delete)
+        } else if self.parse_keyword(Keyword::EXEC) {
+            let obj_type = self.maybe_parse_action_execute_obj_type();
+            Ok(Action::Exec { obj_type })
         } else if self.parse_keyword(Keyword::EXECUTE) {
             let obj_type = self.maybe_parse_action_execute_obj_type();
             Ok(Action::Execute { obj_type })

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13418,14 +13418,18 @@ impl<'a> Parser<'a> {
                 GranteesType::Share
             } else if self.parse_keyword(Keyword::GROUP) {
                 GranteesType::Group
-            } else if self.parse_keyword(Keyword::PUBLIC) {
-                GranteesType::Public
             } else if self.parse_keywords(&[Keyword::DATABASE, Keyword::ROLE]) {
                 GranteesType::DatabaseRole
             } else if self.parse_keywords(&[Keyword::APPLICATION, Keyword::ROLE]) {
                 GranteesType::ApplicationRole
             } else if self.parse_keyword(Keyword::APPLICATION) {
                 GranteesType::Application
+            } else if self.peek_keyword(Keyword::PUBLIC) {
+                if dialect_of!(self is MsSqlDialect) {
+                    grantee_type
+                } else {
+                    GranteesType::Public
+                }
             } else {
                 grantee_type // keep from previous iteraton, if not specified
             };

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -9332,6 +9332,7 @@ fn parse_grant() {
     verified_stmt("GRANT OWNERSHIP ON INTEGRATION int1 TO ROLE role1");
     verified_stmt("GRANT SELECT ON VIEW view1 TO ROLE role1");
     verified_stmt("GRANT EXEC ON my_sp TO runner");
+    verified_stmt("GRANT UPDATE ON my_table TO updater_role AS dbo");
 
     all_dialects_where(|d| d.identifier_quote_style("none") == Some('['))
         .verified_stmt("GRANT SELECT ON [my_table] TO [public]");

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -9331,6 +9331,7 @@ fn parse_grant() {
     verified_stmt("GRANT USAGE ON WAREHOUSE wh1 TO ROLE role1");
     verified_stmt("GRANT OWNERSHIP ON INTEGRATION int1 TO ROLE role1");
     verified_stmt("GRANT SELECT ON VIEW view1 TO ROLE role1");
+    verified_stmt("GRANT EXEC ON my_sp TO runner");
 
     all_dialects_where(|d| d.identifier_quote_style("none") == Some('['))
         .verified_stmt("GRANT SELECT ON [my_table] TO [public]");
@@ -9358,6 +9359,7 @@ fn parse_deny() {
 
     verified_stmt("DENY SELECT, INSERT, UPDATE, DELETE ON db1.sc1 TO role1, role2");
     verified_stmt("DENY ALL ON db1.sc1 TO role1");
+    verified_stmt("DENY EXEC ON my_sp TO runner");
 
     all_dialects_where(|d| d.identifier_quote_style("none") == Some('['))
         .verified_stmt("DENY SELECT ON [my_table] TO [public]");

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -9331,6 +9331,9 @@ fn parse_grant() {
     verified_stmt("GRANT USAGE ON WAREHOUSE wh1 TO ROLE role1");
     verified_stmt("GRANT OWNERSHIP ON INTEGRATION int1 TO ROLE role1");
     verified_stmt("GRANT SELECT ON VIEW view1 TO ROLE role1");
+
+    all_dialects_where(|d| d.identifier_quote_style("none") == Some('['))
+        .verified_stmt("GRANT SELECT ON [my_table] TO [public]");
 }
 
 #[test]
@@ -9355,6 +9358,9 @@ fn parse_deny() {
 
     verified_stmt("DENY SELECT, INSERT, UPDATE, DELETE ON db1.sc1 TO role1, role2");
     verified_stmt("DENY ALL ON db1.sc1 TO role1");
+
+    all_dialects_where(|d| d.identifier_quote_style("none") == Some('['))
+        .verified_stmt("DENY SELECT ON [my_table] TO [public]");
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2340,3 +2340,13 @@ fn parse_print() {
     let _ = ms().verified_stmt("PRINT N'Hello, ⛄️!'");
     let _ = ms().verified_stmt("PRINT @my_variable");
 }
+
+#[test]
+fn parse_mssql_grant() {
+    ms().verified_stmt("GRANT SELECT ON my_table TO public, db_admin");
+}
+
+#[test]
+fn parse_mssql_deny() {
+    ms().verified_stmt("DENY SELECT ON my_table TO public, db_admin");
+}

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3538,6 +3538,7 @@ fn parse_grant() {
         objects,
         grantees,
         with_grant_option,
+        as_grantor: _,
         granted_by,
     } = stmt
     {


### PR DESCRIPTION
This is another statement for SQL Server: https://learn.microsoft.com/en-us/sql/t-sql/statements/deny-transact-sql, but implemented in a common way. Similar to GRANT & REVOKE, so using a lot of those patterns with a similar test.

Supplementary improvements:

1. While I was working on that, I also noticed that `EXEC` was missing from the privileges list, so that's added now too (with a test example).
2. Additionally, SQL Server supports identifiers quoted `[like this]`. That dialect function hadn't been implemented yet, which caused a test failure on example that use that quoting style. So I've added that now too with a couple example cases for grant/deny.
3. ~~Finally,~~ "public" is a built in role on SQL Server, so doing something like `grant select on mytable to public` should parse public normally. However, the former logic was reading it as a keyword. This has been adjusted to be not special on SQL Server and tests cases have been added as well.
4. Actually finally, `GRANT ... AS role` parsing is now supported (formerly only worked for REVOKE/DENY) and a new test case example