### PR TITLE
Add support for table valued functions for SQL Server

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -51,12 +51,12 @@ pub enum DataType {
     /// [MsSQL]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16#c-create-a-multi-statement-table-valued-function
     Table(Option<Vec<ColumnDef>>),
     /// Table type with a name, e.g. CREATE FUNCTION RETURNS @result TABLE(...).
-    NamedTable(
+    NamedTable {
         /// Table name.
-        ObjectName,
+        name: ObjectName,
         /// Table columns.
-        Vec<ColumnDef>,
-    ),
+        columns: Vec<ColumnDef>,
+    },
     /// Fixed-length character type, e.g. CHARACTER(10).
     Character(Option<CharacterLength>),
     /// Fixed-length char type, e.g. CHAR(10).
@@ -732,8 +732,8 @@ impl fmt::Display for DataType {
                     write!(f, "TABLE")
                 }
             },
-            DataType::NamedTable(name, fields) => {
-                write!(f, "{} TABLE ({})", name, display_comma_separated(fields))
+            DataType::NamedTable { name, columns } => {
+                write!(f, "{} TABLE ({})", name, display_comma_separated(columns))
             }
             DataType::GeometricType(kind) => write!(f, "{}", kind),
         }

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -49,7 +49,7 @@ pub enum DataType {
     ///
     /// [PostgreSQL]: https://www.postgresql.org/docs/15/sql-createfunction.html
     /// [MsSQL]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16#c-create-a-multi-statement-table-valued-function
-    Table(Vec<ColumnDef>),
+    Table(Option<Vec<ColumnDef>>),
     /// Table type with a name, e.g. CREATE FUNCTION RETURNS @result TABLE(...).
     NamedTable(
         /// Table name.
@@ -724,12 +724,14 @@ impl fmt::Display for DataType {
             DataType::Unspecified => Ok(()),
             DataType::Trigger => write!(f, "TRIGGER"),
             DataType::AnyType => write!(f, "ANY TYPE"),
-            DataType::Table(fields) => {
-                if fields.is_empty() {
-                    return write!(f, "TABLE");
+            DataType::Table(fields) => match fields {
+                Some(fields) => {
+                    write!(f, "TABLE({})", display_comma_separated(fields))
                 }
-                write!(f, "TABLE({})", display_comma_separated(fields))
-            }
+                None => {
+                    write!(f, "TABLE")
+                }
+            },
             DataType::NamedTable(name, fields) => {
                 write!(f, "{} TABLE ({})", name, display_comma_separated(fields))
             }

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -51,6 +51,8 @@ pub enum DataType {
     /// [MsSQL]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16#c-create-a-multi-statement-table-valued-function
     Table(Option<Vec<ColumnDef>>),
     /// Table type with a name, e.g. CREATE FUNCTION RETURNS @result TABLE(...).
+    ///
+    /// [MsSQl]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16#table
     NamedTable {
         /// Table name.
         name: ObjectName,

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -48,6 +48,7 @@ pub enum DataType {
     /// Table type in [PostgreSQL], e.g. CREATE FUNCTION RETURNS TABLE(...).
     ///
     /// [PostgreSQL]: https://www.postgresql.org/docs/15/sql-createfunction.html
+    /// [MsSQL]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16#c-create-a-multi-statement-table-valued-function
     Table(Vec<ColumnDef>),
     /// Fixed-length character type, e.g. CHARACTER(10).
     Character(Option<CharacterLength>),
@@ -716,7 +717,12 @@ impl fmt::Display for DataType {
             DataType::Unspecified => Ok(()),
             DataType::Trigger => write!(f, "TRIGGER"),
             DataType::AnyType => write!(f, "ANY TYPE"),
-            DataType::Table(fields) => write!(f, "TABLE({})", display_comma_separated(fields)),
+            DataType::Table(fields) => {
+                if fields.is_empty() {
+                    return write!(f, "TABLE");
+                }
+                write!(f, "TABLE({})", display_comma_separated(fields))
+            }
             DataType::GeometricType(kind) => write!(f, "{}", kind),
         }
     }

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -50,6 +50,13 @@ pub enum DataType {
     /// [PostgreSQL]: https://www.postgresql.org/docs/15/sql-createfunction.html
     /// [MsSQL]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16#c-create-a-multi-statement-table-valued-function
     Table(Vec<ColumnDef>),
+    /// Table type with a name, e.g. CREATE FUNCTION RETURNS @result TABLE(...).
+    NamedTable(
+        /// Table name.
+        ObjectName,
+        /// Table columns.
+        Vec<ColumnDef>,
+    ),
     /// Fixed-length character type, e.g. CHARACTER(10).
     Character(Option<CharacterLength>),
     /// Fixed-length char type, e.g. CHAR(10).
@@ -722,6 +729,9 @@ impl fmt::Display for DataType {
                     return write!(f, "TABLE");
                 }
                 write!(f, "TABLE({})", display_comma_separated(fields))
+            }
+            DataType::NamedTable(name, fields) => {
+                write!(f, "{} TABLE ({})", name, display_comma_separated(fields))
             }
             DataType::GeometricType(kind) => write!(f, "{}", kind),
         }

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2346,7 +2346,7 @@ impl fmt::Display for CreateFunction {
         if let Some(CreateFunctionBody::Return(function_body)) = &self.function_body {
             write!(f, " RETURN {function_body}")?;
         }
-        if let Some(CreateFunctionBody::AsReturnSubquery(function_body)) = &self.function_body {
+        if let Some(CreateFunctionBody::AsReturnExpr(function_body)) = &self.function_body {
             write!(f, " AS RETURN {function_body}")?;
         }
         if let Some(CreateFunctionBody::AsReturnSelect(function_body)) = &self.function_body {

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2346,6 +2346,9 @@ impl fmt::Display for CreateFunction {
         if let Some(CreateFunctionBody::Return(function_body)) = &self.function_body {
             write!(f, " RETURN {function_body}")?;
         }
+        if let Some(CreateFunctionBody::AsReturn(function_body)) = &self.function_body {
+            write!(f, " AS RETURN {function_body}")?;
+        }
         if let Some(using) = &self.using {
             write!(f, " {using}")?;
         }

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -2346,7 +2346,10 @@ impl fmt::Display for CreateFunction {
         if let Some(CreateFunctionBody::Return(function_body)) = &self.function_body {
             write!(f, " RETURN {function_body}")?;
         }
-        if let Some(CreateFunctionBody::AsReturn(function_body)) = &self.function_body {
+        if let Some(CreateFunctionBody::AsReturnSubquery(function_body)) = &self.function_body {
+            write!(f, " AS RETURN {function_body}")?;
+        }
+        if let Some(CreateFunctionBody::AsReturnSelect(function_body)) = &self.function_body {
             write!(f, " AS RETURN {function_body}")?;
         }
         if let Some(using) = &self.using {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8799,6 +8799,8 @@ pub enum CreateFunctionBody {
     /// RETURNS TABLE
     /// AS RETURN SELECT a + b AS sum;
     /// ```
+    ///
+    /// [MsSql]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16#select_stmt
     AsReturnSelect(Select),
 }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8778,6 +8778,18 @@ pub enum CreateFunctionBody {
     ///
     /// [PostgreSQL]: https://www.postgresql.org/docs/current/sql-createfunction.html
     Return(Expr),
+
+    /// Function body expression using the 'AS RETURN' keywords
+    ///
+    /// Example:
+    /// ```sql
+    /// CREATE FUNCTION myfunc(a INT, b INT)
+    /// RETURNS TABLE
+    /// AS RETURN (SELECT a + b AS sum);
+    /// ```
+    ///
+    /// [MsSql]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql
+    AsReturn(Expr),
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8789,7 +8789,7 @@ pub enum CreateFunctionBody {
     /// ```
     ///
     /// [MsSql]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql
-    AsReturnSubquery(Expr),
+    AsReturnExpr(Expr),
 
     /// Function body expression using the 'AS RETURN' keywords, with an un-parenthesized SELECT query
     ///

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8789,7 +8789,17 @@ pub enum CreateFunctionBody {
     /// ```
     ///
     /// [MsSql]: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql
-    AsReturn(Expr),
+    AsReturnSubquery(Expr),
+
+    /// Function body expression using the 'AS RETURN' keywords, with an un-parenthesized SELECT query
+    ///
+    /// Example:
+    /// ```sql
+    /// CREATE FUNCTION myfunc(a INT, b INT)
+    /// RETURNS TABLE
+    /// AS RETURN SELECT a + b AS sum;
+    /// ```
+    AsReturnSelect(Select),
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9851,11 +9851,13 @@ impl<'a> Parser<'a> {
                     Ok(DataType::AnyType)
                 }
                 Keyword::TABLE => {
-                    if self.peek_token() != Token::LParen {
-                        Ok(DataType::Table(None))
-                    } else {
+                    // an LParen after the TABLE keyword indicates that table columns are being defined
+                    // whereas no LParen indicates an anonymous table expression will be returned
+                    if self.peek_token() == Token::LParen {
                         let columns = self.parse_returns_table_columns()?;
                         Ok(DataType::Table(Some(columns)))
+                    } else {
+                        Ok(DataType::Table(None))
                     }
                 }
                 Keyword::SIGNED => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5264,14 +5264,7 @@ impl<'a> Parser<'a> {
             }))
         } else if self.parse_keyword(Keyword::RETURN) {
             if self.peek_token() == Token::LParen {
-                let expr = self.parse_expr()?;
-                if !matches!(expr, Expr::Subquery(_)) {
-                    parser_err!(
-                        "Expected a subquery after RETURN",
-                        self.peek_token().span.start
-                    )?
-                }
-                Some(CreateFunctionBody::AsReturnSubquery(expr))
+                Some(CreateFunctionBody::AsReturnExpr(self.parse_expr()?))
             } else if self.peek_keyword(Keyword::SELECT) {
                 let select = self.parse_select()?;
                 Some(CreateFunctionBody::AsReturnSelect(select))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5233,9 +5233,7 @@ impl<'a> Parser<'a> {
             Some(self.parse_data_type()?)
         };
 
-        if self.peek_keyword(Keyword::AS) {
-            self.expect_keyword_is(Keyword::AS)?;
-        }
+        let _ = self.parse_keyword(Keyword::AS);
 
         let function_body = if self.peek_keyword(Keyword::BEGIN) {
             let begin_token = self.expect_keyword(Keyword::BEGIN)?;
@@ -5247,9 +5245,7 @@ impl<'a> Parser<'a> {
                 statements,
                 end_token: AttachedToken(end_token),
             }))
-        } else if self.peek_keyword(Keyword::RETURN) {
-            self.expect_keyword(Keyword::RETURN)?;
-
+        } else if self.parse_keyword(Keyword::RETURN) {
             if self.peek_token() == Token::LParen {
                 let expr = self.parse_expr()?;
                 if !matches!(expr, Expr::Subquery(_)) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5208,12 +5208,8 @@ impl<'a> Parser<'a> {
         let return_table = self.maybe_parse(|p| {
             let return_table_name = p.parse_identifier()?;
 
-            if !p.peek_keyword(Keyword::TABLE) {
-                parser_err!(
-                    "Expected TABLE keyword after return type",
-                    p.peek_token().span.start
-                )?
-            }
+            p.expect_keyword_is(Keyword::TABLE)?;
+            p.prev_token();
 
             let table_column_defs = match p.parse_data_type()? {
                 DataType::Table(maybe_table_column_defs) => match maybe_table_column_defs {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5230,7 +5230,9 @@ impl<'a> Parser<'a> {
             Some(self.parse_data_type()?)
         };
 
-        self.expect_keyword_is(Keyword::AS)?;
+        if self.peek_keyword(Keyword::AS) {
+            self.expect_keyword_is(Keyword::AS)?;
+        }
 
         let function_body = if self.peek_keyword(Keyword::BEGIN) {
             let begin_token = self.expect_keyword(Keyword::BEGIN)?;
@@ -9819,7 +9821,7 @@ impl<'a> Parser<'a> {
                     Ok(DataType::AnyType)
                 }
                 Keyword::TABLE => {
-                    if self.peek_keyword(Keyword::AS) {
+                    if self.peek_token() != Token::LParen {
                         Ok(DataType::Table(Vec::<ColumnDef>::new()))
                     } else {
                         let columns = self.parse_returns_table_columns()?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9867,13 +9867,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_returns_table_column(&mut self) -> Result<ColumnDef, ParserError> {
-        let name = self.parse_identifier()?;
-        let data_type = self.parse_data_type()?;
-        Ok(ColumnDef {
-            name,
-            data_type,
-            options: Vec::new(), // No constraints expected here
-        })
+        self.parse_column_def()
     }
 
     fn parse_returns_table_columns(&mut self) -> Result<Vec<ColumnDef>, ParserError> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5212,24 +5212,11 @@ impl<'a> Parser<'a> {
             p.prev_token();
 
             let table_column_defs = match p.parse_data_type()? {
-                DataType::Table(maybe_table_column_defs) => match maybe_table_column_defs {
-                    Some(table_column_defs) => {
-                        if table_column_defs.is_empty() {
-                            parser_err!(
-                                "Expected table column definitions after TABLE keyword",
-                                p.peek_token().span.start
-                            )?
-                        }
-
-                        table_column_defs
-                    }
-                    None => parser_err!(
-                        "Expected table column definitions after TABLE keyword",
-                        p.peek_token().span.start
-                    )?,
-                },
+                DataType::Table(Some(table_column_defs)) if !table_column_defs.is_empty() => {
+                    table_column_defs
+                }
                 _ => parser_err!(
-                    "Expected table data type after TABLE keyword",
+                    "Expected table column definitions after TABLE keyword",
                     p.peek_token().span.start
                 )?,
             };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5221,9 +5221,19 @@ impl<'a> Parser<'a> {
                     p.peek_token().span.start
                 )?
             };
+
+            if table_column_defs.is_none()
+                || table_column_defs.clone().is_some_and(|tcd| tcd.is_empty())
+            {
+                parser_err!(
+                    "Expected table column definitions after TABLE keyword",
+                    p.peek_token().span.start
+                )?
+            }
+
             Ok(DataType::NamedTable(
                 ObjectName(vec![ObjectNamePart::Identifier(return_table_name)]),
-                table_column_defs.clone(),
+                table_column_defs.clone().unwrap(),
             ))
         })?;
 
@@ -9835,10 +9845,10 @@ impl<'a> Parser<'a> {
                 }
                 Keyword::TABLE => {
                     if self.peek_token() != Token::LParen {
-                        Ok(DataType::Table(Vec::<ColumnDef>::new()))
+                        Ok(DataType::Table(None))
                     } else {
                         let columns = self.parse_returns_table_columns()?;
-                        Ok(DataType::Table(columns))
+                        Ok(DataType::Table(Some(columns)))
                     }
                 }
                 Keyword::SIGNED => {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5216,7 +5216,10 @@ impl<'a> Parser<'a> {
                     )?,
                 }
             } else {
-                parser_err!("Expected TABLE keyword after return type", p.peek_token().span.start)?
+                parser_err!(
+                    "Expected TABLE keyword after return type",
+                    p.peek_token().span.start
+                )?
             };
             Ok(DataType::NamedTable(
                 ObjectName(vec![ObjectNamePart::Identifier(return_table_name)]),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5238,10 +5238,10 @@ impl<'a> Parser<'a> {
                 )?,
             };
 
-            Ok(DataType::NamedTable(
-                ObjectName(vec![ObjectNamePart::Identifier(return_table_name)]),
-                table_column_defs,
-            ))
+            Ok(DataType::NamedTable {
+                name: ObjectName(vec![ObjectNamePart::Identifier(return_table_name)]),
+                columns: table_column_defs,
+            })
         })?;
 
         let return_type = if return_table.is_some() {

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -254,6 +254,12 @@ fn parse_create_function() {
     ";
     let _ = ms().verified_stmt(multi_statement_function);
 
+    let multi_statement_function_without_as = multi_statement_function.replace(" AS", "");
+    let _ = ms().one_statement_parses_to(
+        &multi_statement_function_without_as,
+        multi_statement_function,
+    );
+
     let create_function_with_conditional = "\
         CREATE FUNCTION some_scalar_udf() \
         RETURNS INT \
@@ -297,6 +303,13 @@ fn parse_create_function() {
     ";
     let _ = ms().verified_stmt(create_inline_table_value_function);
 
+    let create_inline_table_value_function_without_as =
+        create_inline_table_value_function.replace(" AS", "");
+    let _ = ms().one_statement_parses_to(
+        &create_inline_table_value_function_without_as,
+        create_inline_table_value_function,
+    );
+
     let create_multi_statement_table_value_function = "\
         CREATE FUNCTION some_multi_statement_tvf(@foo INT, @bar VARCHAR(256)) \
         RETURNS @t TABLE (col_1 INT) \
@@ -307,6 +320,13 @@ fn parse_create_function() {
         END\
     ";
     let _ = ms().verified_stmt(create_multi_statement_table_value_function);
+
+    let create_multi_statement_table_value_function_without_as =
+        create_multi_statement_table_value_function.replace(" AS", "");
+    let _ = ms().one_statement_parses_to(
+        &create_multi_statement_table_value_function_without_as,
+        create_multi_statement_table_value_function,
+    );
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -327,6 +327,17 @@ fn parse_create_function() {
         &create_multi_statement_table_value_function_without_as,
         create_multi_statement_table_value_function,
     );
+
+    let create_multi_statement_table_value_function_with_constraints = "\
+        CREATE FUNCTION some_multi_statement_tvf(@foo INT, @bar VARCHAR(256)) \
+        RETURNS @t TABLE (col_1 INT NOT NULL) \
+        AS \
+        BEGIN \
+            INSERT INTO @t SELECT 1; \
+            RETURN @t; \
+        END\
+    ";
+    let _ = ms().verified_stmt(create_multi_statement_table_value_function_with_constraints);
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -296,6 +296,17 @@ fn parse_create_function() {
         RETURN (SELECT 1 AS col_1)\
     ";
     let _ = ms().verified_stmt(create_inline_table_value_function);
+
+    let create_multi_statement_table_value_function = "\
+        CREATE FUNCTION some_multi_statement_tvf(@foo INT, @bar VARCHAR(256)) \
+        RETURNS @t TABLE (col_1 INT) \
+        AS \
+        BEGIN \
+            INSERT INTO @t SELECT 1; \
+            RETURN; \
+        END\
+    ";
+    let _ = ms().verified_stmt(create_multi_statement_table_value_function);
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -303,6 +303,14 @@ fn parse_create_function() {
     ";
     let _ = ms().verified_stmt(create_inline_table_value_function);
 
+    let create_inline_table_value_function_without_parentheses = "\
+        CREATE FUNCTION some_inline_tvf(@foo INT, @bar VARCHAR(256)) \
+        RETURNS TABLE \
+        AS \
+        RETURN SELECT 1 AS col_1\
+    ";
+    let _ = ms().verified_stmt(create_inline_table_value_function_without_parentheses);
+
     let create_inline_table_value_function_without_as =
         create_inline_table_value_function.replace(" AS", "");
     let _ = ms().one_statement_parses_to(

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -288,6 +288,14 @@ fn parse_create_function() {
         END\
     ";
     let _ = ms().verified_stmt(create_function_with_return_expression);
+
+    let create_inline_table_value_function = "\
+        CREATE FUNCTION some_inline_tvf(@foo INT, @bar VARCHAR(256)) \
+        RETURNS TABLE \
+        AS \
+        RETURN (SELECT 1 AS col_1)\
+    ";
+    let _ = ms().verified_stmt(create_inline_table_value_function);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for table valued functions for SQL Server, both inline & multi statement functions. For reference, that's the B & C documentation here: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16#b-create-an-inline-table-valued-function

Inline TVF's are defined with `AS RETURN`, so we have a new `CreateFunctionBody::AsReturn` variant accordingly. Functions using "AS RETURN" don't have BEGIN/END, so that part of the parsing logic is now conditional. Additionally, the data type parser now supports "RETURNS TABLE" without a table definition.

Multi statement TVF's use named table expressions, so a new `NamedTable` data type variant was added. I didn't see a great way to integrate this into the existing data type parser (especially without rewinding), so creating this data type happens inside the parse create function logic first by parsing the identifier, then parsing the table definition, then using those elements to produce a NamedTable.

I also added a new test example for each of these scenarios.