### PR TITLE
fix: allow arbitrary operators with ANY and ALL on Postgres

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3471,7 +3471,7 @@ impl<'a> Parser<'a> {
                     right
                 };
 
-                if !matches!(
+                if !dialect_of!(self is PostgreSqlDialect) && !matches!(
                     op,
                     BinaryOperator::Gt
                         | BinaryOperator::Lt


### PR DESCRIPTION
In sqlparser PR #963 a check was introduced which limits which operators can be used with `ANY` and `ALL` expressions.

Postgres can parse more (possibly _all_ binary operators, investigation pending) in this location. Postgres only seems to care that the operator yields a boolean - which is a semantic error, not a syntax (parse) error.

Example of semantic error in Postgres:

```
select 123 % ANY(array[246]);
ERROR:  op ANY/ALL (array) requires operator to yield boolean
LINE 1: select 123 % ANY(array[246]);
                   ^
```

FWIW, the Postgres `pg_trgm` extension provides support for the `%` where left and right args are `text` and it returns a `boolean` - which makes it useable with `ANY` and `ALL`.


The following code in `src/parser/mod.rs:2893-2908` is where the allowlist of operators is enforced:

```rust
if !matches!(
    op,
    BinaryOperator::Gt
        | BinaryOperator::Lt
        | BinaryOperator::GtEq
        | BinaryOperator::LtEq
        | BinaryOperator::Eq
        | BinaryOperator::NotEq
) {
    return parser_err!(
        format!(
        "Expected one of [=, >, <, =>, =<, !=] as comparison operator, found: {op}"
    ),
        tok.span.start
    );
};
```