### PR TITLE
Add support for parsing with semicolons optional

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3826,7 +3826,7 @@ pub enum Statement {
         or_alter: bool,
         name: ObjectName,
         params: Option<Vec<ProcedureParam>>,
-        body: Vec<Statement>,
+        body: BeginEndStatements,
     },
     /// ```sql
     /// CREATE MACRO
@@ -4705,11 +4705,8 @@ impl fmt::Display for Statement {
                         write!(f, " ({})", display_comma_separated(p))?;
                     }
                 }
-                write!(
-                    f,
-                    " AS BEGIN {body} END",
-                    body = display_separated(body, "; ")
-                )
+
+                write!(f, " AS {body}")
             }
             Statement::CreateMacro {
                 or_replace,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3826,7 +3826,7 @@ pub enum Statement {
         or_alter: bool,
         name: ObjectName,
         params: Option<Vec<ProcedureParam>>,
-        body: BeginEndStatements,
+        body: ConditionalStatements,
     },
     /// ```sql
     /// CREATE MACRO

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -958,8 +958,14 @@ pub trait Dialect: Debug + Any {
     /// Returns true if the specified keyword should be parsed as a table factor alias.
     /// When explicit is true, the keyword is preceded by an `AS` word. Parser is provided
     /// to enable looking ahead if needed.
+    ///
+    /// When the dialect supports statements without semicolon delimiter, actual keywords aren't parsed as aliases.
     fn is_table_factor_alias(&self, explicit: bool, kw: &Keyword, _parser: &mut Parser) -> bool {
-        explicit || !keywords::RESERVED_FOR_TABLE_ALIAS.contains(kw)
+        if self.supports_statements_without_semicolon_delimiter() {
+            kw == &Keyword::NoKeyword
+        } else {
+            explicit || !keywords::RESERVED_FOR_TABLE_ALIAS.contains(kw)
+        }
     }
 
     /// Returns true if this dialect supports querying historical table data

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1021,6 +1021,11 @@ pub trait Dialect: Debug + Any {
     fn supports_set_names(&self) -> bool {
         false
     }
+
+    /// Returns true if the dialect supports parsing statements without a semicolon delimiter.
+    fn supports_statements_without_semicolon_delimiter(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -63,7 +63,7 @@ impl Dialect for MsSqlDialect {
     }
 
     fn supports_connect_by(&self) -> bool {
-        true
+        false
     }
 
     fn supports_eq_alias_assignment(&self) -> bool {
@@ -116,6 +116,10 @@ impl Dialect for MsSqlDialect {
 
     /// See <https://learn.microsoft.com/en-us/sql/t-sql/queries/from-transact-sql>
     fn supports_object_name_double_dot_notation(&self) -> bool {
+        true
+    }
+
+    fn supports_statements_without_semicolon_delimiter(&self) -> bool {
         true
     }
 
@@ -271,6 +275,9 @@ impl MsSqlDialect {
     ) -> Result<Vec<Statement>, ParserError> {
         let mut stmts = Vec::new();
         loop {
+            while let Token::SemiColon = parser.peek_token_ref().token {
+                parser.advance_token();
+            }
             if let Token::EOF = parser.peek_token_ref().token {
                 break;
             }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1062,6 +1062,7 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::ANTI,
     Keyword::SEMI,
     Keyword::RETURNING,
+    Keyword::RETURN,
     Keyword::ASOF,
     Keyword::MATCH_CONDITION,
     // for MSSQL-specific OUTER APPLY (seems reserved in most dialects)
@@ -1115,6 +1116,7 @@ pub const RESERVED_FOR_COLUMN_ALIAS: &[Keyword] = &[
     Keyword::CLUSTER,
     Keyword::DISTRIBUTE,
     Keyword::RETURNING,
+    Keyword::RETURN,
     // Reserved only as a column alias in the `SELECT` clause
     Keyword::FROM,
     Keyword::INTO,
@@ -1129,6 +1131,7 @@ pub const RESERVED_FOR_TABLE_FACTOR: &[Keyword] = &[
     Keyword::LIMIT,
     Keyword::HAVING,
     Keyword::WHERE,
+    Keyword::RETURN,
 ];
 
 /// Global list of reserved keywords that cannot be parsed as identifiers
@@ -1139,4 +1142,5 @@ pub const RESERVED_FOR_IDENTIFIER: &[Keyword] = &[
     Keyword::INTERVAL,
     Keyword::STRUCT,
     Keyword::TRIM,
+    Keyword::RETURN,
 ];

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1088,6 +1088,11 @@ pub const RESERVED_FOR_TABLE_ALIAS: &[Keyword] = &[
     Keyword::TABLESAMPLE,
     Keyword::FROM,
     Keyword::OPEN,
+    Keyword::INSERT,
+    Keyword::UPDATE,
+    Keyword::DELETE,
+    Keyword::EXEC,
+    Keyword::EXECUTE,
 ];
 
 /// Can't be used as a column alias, so that `SELECT <expr> alias`

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15506,27 +15506,13 @@ impl<'a> Parser<'a> {
         let params = self.parse_optional_procedure_parameters()?;
         self.expect_keyword_is(Keyword::AS)?;
 
-        let begin_token: AttachedToken = self
-            .expect_keyword(Keyword::BEGIN)
-            .map(AttachedToken)
-            .unwrap_or_else(|_| AttachedToken::empty());
-        let statements = self.parse_statement_list(&[Keyword::END])?;
-        let end_token = match &begin_token.0.token {
-            Token::Word(w) if w.keyword == Keyword::BEGIN => {
-                AttachedToken(self.expect_keyword(Keyword::END)?)
-            }
-            _ => AttachedToken::empty(),
-        };
+        let body = self.parse_conditional_statements(&[Keyword::END])?;
 
         Ok(Statement::CreateProcedure {
             name,
             or_alter,
             params,
-            body: BeginEndStatements {
-                begin_token,
-                statements,
-                end_token,
-            },
+            body,
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4520,6 +4520,18 @@ impl<'a> Parser<'a> {
             return Ok(vec![]);
         }
 
+        if end_token == Token::SemiColon
+            && self
+                .dialect
+                .supports_statements_without_semicolon_delimiter()
+        {
+            if let Token::Word(ref kw) = self.peek_token().token {
+                if kw.keyword != Keyword::NoKeyword {
+                    return Ok(vec![]);
+                }
+            }
+        }
+
         if self.options.trailing_commas && self.peek_tokens() == [Token::Comma, end_token] {
             let _ = self.consume_token(&Token::Comma);
             return Ok(vec![]);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -186,6 +186,37 @@ impl TestedDialects {
         statements
     }
 
+    /// The same as [`statements_parse_to`] but it will strip semicolons from the SQL text.
+    pub fn statements_without_semicolons_parse_to(
+        &self,
+        sql: &str,
+        canonical: &str,
+    ) -> Vec<Statement> {
+        let sql_without_semicolons = sql
+            .replace("; ", " ")
+            .replace(" ;", " ")
+            .replace(";\n", "\n")
+            .replace("\n;", "\n")
+            .replace(";", " ");
+        let statements = self
+            .parse_sql_statements(&sql_without_semicolons)
+            .expect(&sql_without_semicolons);
+        if !canonical.is_empty() && sql != canonical {
+            assert_eq!(self.parse_sql_statements(canonical).unwrap(), statements);
+        } else {
+            assert_eq!(
+                sql,
+                statements
+                    .iter()
+                    // note: account for format_statement_list manually inserted semicolons
+                    .map(|s| s.to_string().trim_end_matches(";").to_string())
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            );
+        }
+        statements
+    }
+
     /// Ensures that `sql` parses as an [`Expr`], and that
     /// re-serializing the parse result produces canonical
     pub fn expr_parses_to(&self, sql: &str, canonical: &str) -> Expr {
@@ -311,6 +342,43 @@ where
     F: Fn(&dyn Dialect) -> bool,
 {
     all_dialects_where(|d| !except(d))
+}
+
+/// Returns all dialects that don't support statements without semicolon delimiters.
+/// (i.e. dialects that require semicolon delimiters.)
+pub fn all_dialects_requiring_semicolon_statement_delimiter() -> TestedDialects {
+    let tested_dialects =
+        all_dialects_except(|d| d.supports_statements_without_semicolon_delimiter());
+    assert_ne!(tested_dialects.dialects.len(), 0);
+    tested_dialects
+}
+
+/// Returns all dialects that do support statements without semicolon delimiters.
+/// (i.e. dialects not requiring semicolon delimiters.)
+pub fn all_dialects_not_requiring_semicolon_statement_delimiter() -> TestedDialects {
+    let tested_dialects =
+        all_dialects_where(|d| d.supports_statements_without_semicolon_delimiter());
+    assert_ne!(tested_dialects.dialects.len(), 0);
+    tested_dialects
+}
+
+/// Asserts an error for `parse_sql_statements`:
+/// - "end of statement" for dialects that require semicolon delimiters
+/// - "an SQL statement" for dialects that don't require semicolon delimiters.
+pub fn assert_err_parse_statements(sql: &str, found: &str) {
+    assert_eq!(
+        ParserError::ParserError(format!("Expected: end of statement, found: {}", found)),
+        all_dialects_requiring_semicolon_statement_delimiter()
+            .parse_sql_statements(sql)
+            .unwrap_err()
+    );
+
+    assert_eq!(
+        ParserError::ParserError(format!("Expected: an SQL statement, found: {}", found)),
+        all_dialects_not_requiring_semicolon_statement_delimiter()
+            .parse_sql_statements(sql)
+            .unwrap_err()
+    );
 }
 
 pub fn assert_eq_vec<T: ToString>(expected: &[&str], actual: &[T]) {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -667,6 +667,23 @@ fn parse_select_with_table_alias() {
 }
 
 #[test]
+fn parse_consecutive_queries() {
+    let select_then_exec = "SELECT * FROM deleted; EXECUTE my_sp 'some', 'params'";
+    let _ = all_dialects()
+        .parse_sql_statements(select_then_exec)
+        .unwrap();
+    let _ = all_dialects_not_requiring_semicolon_statement_delimiter()
+        .statements_without_semicolons_parse_to(select_then_exec, "");
+
+    let select_then_update = "SELECT 1 FROM x; UPDATE y SET z = 1";
+    let _ = all_dialects()
+        .parse_sql_statements(select_then_update)
+        .unwrap();
+    let _ = all_dialects_not_requiring_semicolon_statement_delimiter()
+        .statements_without_semicolons_parse_to(select_then_update, "");
+}
+
+#[test]
 fn parse_analyze() {
     verified_stmt("ANALYZE TABLE test_table");
     verified_stmt("ANALYZE test_table");

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -100,48 +100,52 @@ fn parse_mssql_delimited_identifiers() {
 
 #[test]
 fn parse_create_procedure() {
-    let sql = "CREATE OR ALTER PROCEDURE test (@foo INT, @bar VARCHAR(256)) AS BEGIN SELECT 1 END";
+    let sql = "CREATE OR ALTER PROCEDURE test (@foo INT, @bar VARCHAR(256)) AS BEGIN SELECT 1; END";
 
     assert_eq!(
         ms().verified_stmt(sql),
         Statement::CreateProcedure {
             or_alter: true,
-            body: vec![Statement::Query(Box::new(Query {
-                with: None,
-                limit_clause: None,
-                fetch: None,
-                locks: vec![],
-                for_clause: None,
-                order_by: None,
-                settings: None,
-                format_clause: None,
-                pipe_operators: vec![],
-                body: Box::new(SetExpr::Select(Box::new(Select {
-                    select_token: AttachedToken::empty(),
-                    distinct: None,
-                    top: None,
-                    top_before_distinct: false,
-                    projection: vec![SelectItem::UnnamedExpr(Expr::Value(
-                        (number("1")).with_empty_span()
-                    ))],
-                    into: None,
-                    from: vec![],
-                    lateral_views: vec![],
-                    prewhere: None,
-                    selection: None,
-                    group_by: GroupByExpr::Expressions(vec![], vec![]),
-                    cluster_by: vec![],
-                    distribute_by: vec![],
-                    sort_by: vec![],
-                    having: None,
-                    named_window: vec![],
-                    window_before_qualify: false,
-                    qualify: None,
-                    value_table_mode: None,
-                    connect_by: None,
-                    flavor: SelectFlavor::Standard,
-                })))
-            }))],
+            body: BeginEndStatements {
+                begin_token: AttachedToken::empty(),
+                statements: vec![Statement::Query(Box::new(Query {
+                    with: None,
+                    limit_clause: None,
+                    fetch: None,
+                    locks: vec![],
+                    for_clause: None,
+                    order_by: None,
+                    settings: None,
+                    format_clause: None,
+                    pipe_operators: vec![],
+                    body: Box::new(SetExpr::Select(Box::new(Select {
+                        select_token: AttachedToken::empty(),
+                        distinct: None,
+                        top: None,
+                        top_before_distinct: false,
+                        projection: vec![SelectItem::UnnamedExpr(Expr::Value(
+                            (number("1")).with_empty_span()
+                        ))],
+                        into: None,
+                        from: vec![],
+                        lateral_views: vec![],
+                        prewhere: None,
+                        selection: None,
+                        group_by: GroupByExpr::Expressions(vec![], vec![]),
+                        cluster_by: vec![],
+                        distribute_by: vec![],
+                        sort_by: vec![],
+                        having: None,
+                        named_window: vec![],
+                        window_before_qualify: false,
+                        qualify: None,
+                        value_table_mode: None,
+                        connect_by: None,
+                        flavor: SelectFlavor::Standard,
+                    })))
+                }))],
+                end_token: AttachedToken::empty(),
+            },
             params: Some(vec![
                 ProcedureParam {
                     name: Ident {
@@ -174,19 +178,20 @@ fn parse_create_procedure() {
 
 #[test]
 fn parse_mssql_create_procedure() {
-    let _ = ms_and_generic().verified_stmt("CREATE OR ALTER PROCEDURE foo AS BEGIN SELECT 1 END");
-    let _ = ms_and_generic().verified_stmt("CREATE PROCEDURE foo AS BEGIN SELECT 1 END");
+    let _ = ms_and_generic().verified_stmt("CREATE OR ALTER PROCEDURE foo AS SELECT 1;");
+    let _ = ms_and_generic().verified_stmt("CREATE OR ALTER PROCEDURE foo AS BEGIN SELECT 1; END");
+    let _ = ms_and_generic().verified_stmt("CREATE PROCEDURE foo AS BEGIN SELECT 1; END");
     let _ = ms().verified_stmt(
-        "CREATE PROCEDURE foo AS BEGIN SELECT [myColumn] FROM [myschema].[mytable] END",
+        "CREATE PROCEDURE foo AS BEGIN SELECT [myColumn] FROM [myschema].[mytable]; END",
     );
     let _ = ms_and_generic().verified_stmt(
-        "CREATE PROCEDURE foo (@CustomerName NVARCHAR(50)) AS BEGIN SELECT * FROM DEV END",
+        "CREATE PROCEDURE foo (@CustomerName NVARCHAR(50)) AS BEGIN SELECT * FROM DEV; END",
     );
-    let _ = ms().verified_stmt("CREATE PROCEDURE [foo] AS BEGIN UPDATE bar SET col = 'test' END");
+    let _ = ms().verified_stmt("CREATE PROCEDURE [foo] AS BEGIN UPDATE bar SET col = 'test'; END");
     // Test a statement with END in it
-    let _ = ms().verified_stmt("CREATE PROCEDURE [foo] AS BEGIN SELECT [foo], CASE WHEN [foo] IS NULL THEN 'empty' ELSE 'notempty' END AS [foo] END");
+    let _ = ms().verified_stmt("CREATE PROCEDURE [foo] AS BEGIN SELECT [foo], CASE WHEN [foo] IS NULL THEN 'empty' ELSE 'notempty' END AS [foo]; END");
     // Multiple statements
-    let _ = ms().verified_stmt("CREATE PROCEDURE [foo] AS BEGIN UPDATE bar SET col = 'test'; SELECT [foo] FROM BAR WHERE [FOO] > 10 END");
+    let _ = ms().verified_stmt("CREATE PROCEDURE [foo] AS BEGIN UPDATE bar SET col = 'test'; SELECT [foo] FROM BAR WHERE [FOO] > 10; END");
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -32,7 +32,10 @@ use sqlparser::ast::DeclareAssignment::MsSqlAssignment;
 use sqlparser::ast::Value::SingleQuotedString;
 use sqlparser::ast::*;
 use sqlparser::dialect::{GenericDialect, MsSqlDialect};
-use sqlparser::parser::{Parser, ParserError};
+use sqlparser::parser::{Parser, ParserError, ParserOptions};
+
+#[cfg(test)]
+use pretty_assertions::assert_eq;
 
 #[test]
 fn parse_mssql_identifiers() {
@@ -192,6 +195,10 @@ fn parse_mssql_create_procedure() {
     let _ = ms().verified_stmt("CREATE PROCEDURE [foo] AS BEGIN SELECT [foo], CASE WHEN [foo] IS NULL THEN 'empty' ELSE 'notempty' END AS [foo]; END");
     // Multiple statements
     let _ = ms().verified_stmt("CREATE PROCEDURE [foo] AS BEGIN UPDATE bar SET col = 'test'; SELECT [foo] FROM BAR WHERE [FOO] > 10; END");
+    // early return
+    let _ = ms().verified_stmt(
+        "CREATE PROCEDURE [foo] AS BEGIN IF 1 = 0 RETURN;; DECLARE @x INT; RETURN @x; END",
+    );
 }
 
 #[test]
@@ -242,6 +249,7 @@ fn parse_create_function() {
             remote_connection: None,
         }),
     );
+    let _ = ms().statements_without_semicolons_parse_to(return_expression_function, "");
 
     let multi_statement_function = "\
         CREATE FUNCTION some_scalar_udf(@foo INT, @bar VARCHAR(256)) \
@@ -253,6 +261,7 @@ fn parse_create_function() {
         END\
     ";
     let _ = ms().verified_stmt(multi_statement_function);
+    let _ = ms().statements_without_semicolons_parse_to(multi_statement_function, "");
 
     let create_function_with_conditional = "\
         CREATE FUNCTION some_scalar_udf() \
@@ -267,6 +276,7 @@ fn parse_create_function() {
         END\
     ";
     let _ = ms().verified_stmt(create_function_with_conditional);
+    let _ = ms().statements_without_semicolons_parse_to(create_function_with_conditional, "");
 
     let create_or_alter_function = "\
         CREATE OR ALTER FUNCTION some_scalar_udf(@foo INT, @bar VARCHAR(256)) \
@@ -278,6 +288,7 @@ fn parse_create_function() {
         END\
     ";
     let _ = ms().verified_stmt(create_or_alter_function);
+    let _ = ms().statements_without_semicolons_parse_to(create_or_alter_function, "");
 
     let create_function_with_return_expression = "\
         CREATE FUNCTION some_scalar_udf(@foo INT, @bar VARCHAR(256)) \
@@ -288,6 +299,7 @@ fn parse_create_function() {
         END\
     ";
     let _ = ms().verified_stmt(create_function_with_return_expression);
+    let _ = ms().statements_without_semicolons_parse_to(create_function_with_return_expression, "");
 }
 
 #[test]
@@ -1434,6 +1446,7 @@ fn test_mssql_cursor() {
         DEALLOCATE Employee_Cursor\
     ";
     let _ = ms().statements_parse_to(full_cursor_usage, "");
+    let _ = ms().statements_without_semicolons_parse_to(full_cursor_usage, "");
 }
 
 #[test]
@@ -2048,7 +2061,7 @@ fn parse_mssql_if_else() {
 
     // Multiple statements
     let stmts = ms()
-        .parse_sql_statements("DECLARE @A INT; IF 1=1 BEGIN SET @A = 1 END ELSE SET @A = 2")
+        .parse_sql_statements("DECLARE @A INT; IF 1=1 BEGIN SET @A = 1; END ELSE SET @A = 2;")
         .unwrap();
     match &stmts[..] {
         [Statement::Declare { .. }, Statement::If(stmt)] => {
@@ -2063,11 +2076,11 @@ fn parse_mssql_if_else() {
 
 #[test]
 fn test_mssql_if_else_span() {
-    let sql = "IF 1 = 1 SELECT '1' ELSE SELECT '2'";
+    let sql = "IF 1 = 1 SELECT '1'; ELSE SELECT '2';";
     let mut parser = Parser::new(&MsSqlDialect {}).try_with_sql(sql).unwrap();
     assert_eq!(
         parser.parse_statement().unwrap().span(),
-        Span::new(Location::new(1, 1), Location::new(1, sql.len() as u64 + 1))
+        Span::new(Location::new(1, 1), Location::new(1, sql.len() as u64))
     );
 }
 
@@ -2090,7 +2103,7 @@ fn test_mssql_if_else_multiline_span() {
 #[test]
 fn test_mssql_if_statements_span() {
     // Simple statements
-    let mut sql = "IF 1 = 1 SELECT '1' ELSE SELECT '2'";
+    let mut sql = "IF 1 = 1 SELECT '1'; ELSE SELECT '2'";
     let mut parser = Parser::new(&MsSqlDialect {}).try_with_sql(sql).unwrap();
     match parser.parse_statement().unwrap() {
         Statement::If(IfStatement {
@@ -2104,14 +2117,15 @@ fn test_mssql_if_statements_span() {
             );
             assert_eq!(
                 else_block.span(),
-                Span::new(Location::new(1, 21), Location::new(1, 36))
+                Span::new(Location::new(1, 22), Location::new(1, 37))
             );
         }
         stmt => panic!("Unexpected statement: {:?}", stmt),
     }
+    let _ = ms().statements_without_semicolons_parse_to(sql, "");
 
     // Blocks
-    sql = "IF 1 = 1 BEGIN SET @A = 1; END ELSE BEGIN SET @A = 2 END";
+    sql = "IF 1 = 1 BEGIN SET @A = 1; END ELSE BEGIN SET @A = 2; END";
     parser = Parser::new(&MsSqlDialect {}).try_with_sql(sql).unwrap();
     match parser.parse_statement().unwrap() {
         Statement::If(IfStatement {
@@ -2125,11 +2139,12 @@ fn test_mssql_if_statements_span() {
             );
             assert_eq!(
                 else_block.span(),
-                Span::new(Location::new(1, 32), Location::new(1, 57))
+                Span::new(Location::new(1, 32), Location::new(1, 58))
             );
         }
         stmt => panic!("Unexpected statement: {:?}", stmt),
     }
+    let _ = ms().statements_without_semicolons_parse_to(sql, "");
 }
 
 #[test]
@@ -2276,6 +2291,7 @@ fn parse_create_trigger() {
         END\
     ";
     let _ = ms().verified_stmt(multi_statement_trigger);
+    let _ = ms().statements_without_semicolons_parse_to(multi_statement_trigger, "");
 
     let create_trigger_with_return = "\
         CREATE TRIGGER some_trigger ON some_table FOR INSERT \
@@ -2285,15 +2301,7 @@ fn parse_create_trigger() {
         END\
     ";
     let _ = ms().verified_stmt(create_trigger_with_return);
-
-    let create_trigger_with_return = "\
-        CREATE TRIGGER some_trigger ON some_table FOR INSERT \
-        AS \
-        BEGIN \
-            RETURN; \
-        END\
-    ";
-    let _ = ms().verified_stmt(create_trigger_with_return);
+    let _ = ms().statements_without_semicolons_parse_to(create_trigger_with_return, "");
 
     let create_trigger_with_conditional = "\
         CREATE TRIGGER some_trigger ON some_table FOR INSERT \
@@ -2307,6 +2315,7 @@ fn parse_create_trigger() {
         END\
     ";
     let _ = ms().verified_stmt(create_trigger_with_conditional);
+    let _ = ms().statements_without_semicolons_parse_to(create_trigger_with_conditional, "");
 }
 
 #[test]
@@ -2339,4 +2348,316 @@ fn parse_print() {
 
     let _ = ms().verified_stmt("PRINT N'Hello, ⛄️!'");
     let _ = ms().verified_stmt("PRINT @my_variable");
+}
+
+#[test]
+fn test_supports_statements_without_semicolon_delimiter() {
+    use sqlparser::ast::Ident;
+
+    use sqlparser::tokenizer::Location;
+
+    fn parse_n_statements(n: usize, sql: &str) -> Vec<Statement> {
+        let dialect = MsSqlDialect {};
+        let parser = Parser::new(&dialect).with_options(
+            ParserOptions::default().with_require_semicolon_statement_delimiter(false),
+        );
+        let stmts = parser
+            .try_with_sql(sql)
+            .unwrap()
+            .parse_statements()
+            .unwrap();
+        assert_eq!(stmts.len(), n);
+        stmts
+    }
+
+    let multiple_statements = "SELECT 1 SELECT 2";
+    assert_eq!(
+        parse_n_statements(2, multiple_statements),
+        vec![
+            Statement::Query(Box::new(Query {
+                with: None,
+                limit_clause: None,
+                fetch: None,
+                locks: vec![],
+                for_clause: None,
+                order_by: None,
+                settings: None,
+                format_clause: None,
+                pipe_operators: vec![],
+                body: Box::new(SetExpr::Select(Box::new(Select {
+                    select_token: AttachedToken::empty(),
+                    distinct: None,
+                    top: None,
+                    top_before_distinct: false,
+                    projection: vec![SelectItem::UnnamedExpr(Expr::Value(
+                        (Value::Number("1".parse().unwrap(), false)).with_empty_span()
+                    ))],
+                    into: None,
+                    from: vec![],
+                    lateral_views: vec![],
+                    prewhere: None,
+                    selection: None,
+                    group_by: GroupByExpr::Expressions(vec![], vec![]),
+                    cluster_by: vec![],
+                    distribute_by: vec![],
+                    sort_by: vec![],
+                    having: None,
+                    named_window: vec![],
+                    window_before_qualify: false,
+                    qualify: None,
+                    value_table_mode: None,
+                    connect_by: None,
+                    flavor: SelectFlavor::Standard,
+                }))),
+            })),
+            Statement::Query(Box::new(Query {
+                with: None,
+                limit_clause: None,
+                fetch: None,
+                locks: vec![],
+                for_clause: None,
+                order_by: None,
+                settings: None,
+                format_clause: None,
+                pipe_operators: vec![],
+                body: Box::new(SetExpr::Select(Box::new(Select {
+                    select_token: AttachedToken::empty(),
+                    distinct: None,
+                    top: None,
+                    top_before_distinct: false,
+                    projection: vec![SelectItem::UnnamedExpr(Expr::Value(
+                        (Value::Number("2".parse().unwrap(), false)).with_empty_span()
+                    ))],
+                    into: None,
+                    from: vec![],
+                    lateral_views: vec![],
+                    prewhere: None,
+                    selection: None,
+                    group_by: GroupByExpr::Expressions(vec![], vec![]),
+                    cluster_by: vec![],
+                    distribute_by: vec![],
+                    sort_by: vec![],
+                    having: None,
+                    named_window: vec![],
+                    window_before_qualify: false,
+                    qualify: None,
+                    value_table_mode: None,
+                    connect_by: None,
+                    flavor: SelectFlavor::Standard
+                }))),
+            })),
+        ]
+    );
+
+    let udf = "CREATE OR ALTER FUNCTION utc_now()
+        RETURNS SMALLDATETIME \
+        AS \
+        BEGIN \
+            RETURN GETUTCDATE()
+        END \
+    ";
+    assert_eq!(
+        parse_n_statements(1, udf)[0],
+        Statement::CreateFunction(CreateFunction {
+            or_alter: true,
+            or_replace: false,
+            temporary: false,
+            if_not_exists: false,
+            name: ObjectName::from(vec![sqlparser::ast::Ident::with_span(
+                Span::new(Location::new(1, 26), Location::new(1, 33)),
+                "utc_now"
+            )]),
+            args: Some(vec![]),
+            return_type: Some(sqlparser::ast::DataType::Custom(
+                ObjectName(vec![sqlparser::ast::ObjectNamePart::Identifier(Ident {
+                    value: "SMALLDATETIME".to_string(),
+                    quote_style: None,
+                    span: Span {
+                        start: Location::new(2, 17),
+                        end: Location::new(2, 30)
+                    },
+                })]),
+                vec![]
+            )),
+            function_body: Some(CreateFunctionBody::AsBeginEnd(BeginEndStatements {
+                begin_token: AttachedToken(TokenWithSpan {
+                    token: Token::Word(Word {
+                        value: "BEGIN".to_string(),
+                        quote_style: None,
+                        keyword: Keyword::BEGIN
+                    }),
+                    span: Span::new(Location::new(2, 47), Location::new(2, 57)),
+                }),
+                statements: vec![Statement::Return(ReturnStatement {
+                    value: Some(ReturnStatementValue::Expr(Expr::Function(Function {
+                        name: ObjectName::from(vec![Ident::new("GETUTCDATE")]),
+                        uses_odbc_syntax: false,
+                        parameters: FunctionArguments::None,
+                        args: FunctionArguments::List(FunctionArgumentList {
+                            duplicate_treatment: None,
+                            args: vec![],
+                            clauses: vec![],
+                        }),
+                        filter: None,
+                        null_treatment: None,
+                        over: None,
+                        within_group: vec![],
+                    }))),
+                })],
+                end_token: AttachedToken(TokenWithSpan {
+                    token: Token::Word(Word {
+                        value: "END".to_string(),
+                        quote_style: None,
+                        keyword: Keyword::END
+                    }),
+                    span: Span::new(Location::new(3, 9), Location::new(3, 12)),
+                })
+            })),
+            behavior: None,
+            called_on_null: None,
+            parallel: None,
+            using: None,
+            language: None,
+            determinism_specifier: None,
+            options: None,
+            remote_connection: None
+        })
+    );
+
+    let sp = "CREATE OR ALTER PROCEDURE example_sp \
+        AS \
+            IF USER_NAME() = 'X' \
+                RETURN \
+            IF 1 = 2 \
+                RETURN (SELECT 1) \
+            \
+            RETURN CONVERT(INT, 123) \
+    ";
+    assert_eq!(
+        parse_n_statements(1, sp)[0],
+        Statement::CreateProcedure {
+            or_alter: true,
+            name: ObjectName::from(vec![Ident::new("example_sp")]),
+            params: Some(vec![]),
+            body: ConditionalStatements::Sequence {
+                statements: vec![
+                    Statement::If(IfStatement {
+                        if_block: ConditionalStatementBlock {
+                            start_token: AttachedToken::empty(),
+                            condition: Some(Expr::BinaryOp {
+                                left: Box::new(Expr::Function(Function {
+                                    name: ObjectName::from(vec![Ident::new("USER_NAME")]),
+                                    uses_odbc_syntax: false,
+                                    parameters: FunctionArguments::None,
+                                    args: FunctionArguments::List(FunctionArgumentList {
+                                        duplicate_treatment: None,
+                                        args: vec![],
+                                        clauses: vec![],
+                                    }),
+                                    filter: None,
+                                    null_treatment: None,
+                                    over: None,
+                                    within_group: vec![],
+                                })),
+                                op: BinaryOperator::Eq,
+                                right: Box::new(Expr::Value(ValueWithSpan {
+                                    value: Value::SingleQuotedString("X".to_string()),
+                                    span: Span::new(Location::new(1, 58), Location::new(1, 61)),
+                                })),
+                            }),
+                            then_token: None,
+                            conditional_statements: ConditionalStatements::Sequence {
+                                statements: vec![Statement::Return(ReturnStatement {
+                                    value: None
+                                })],
+                            },
+                        },
+                        elseif_blocks: vec![],
+                        else_block: None,
+                        end_token: None,
+                    }),
+                    Statement::If(IfStatement {
+                        if_block: ConditionalStatementBlock {
+                            start_token: AttachedToken::empty(),
+                            condition: Some(Expr::BinaryOp {
+                                left: Box::new(Expr::Value(number("1").with_span(Span::new(
+                                    Location::new(1, 73),
+                                    Location::new(1, 74)
+                                )))),
+                                op: BinaryOperator::Eq,
+                                right: Box::new(Expr::Value(number("2").with_span(Span::new(
+                                    Location::new(1, 76),
+                                    Location::new(1, 77)
+                                )))),
+                            }),
+                            then_token: None,
+                            conditional_statements: ConditionalStatements::Sequence {
+                                statements: vec![Statement::Return(ReturnStatement {
+                                    value: Some(ReturnStatementValue::Expr(Expr::Subquery(
+                                        Box::new(Query {
+                                            with: None,
+                                            body: Box::new(SetExpr::Select(Box::new(Select {
+                                                select_token: AttachedToken::empty(),
+                                                distinct: None,
+                                                top: None,
+                                                top_before_distinct: false,
+                                                projection: vec![SelectItem::UnnamedExpr(
+                                                    Expr::Value(number("1").with_span(Span::new(
+                                                        Location::new(1, 93),
+                                                        Location::new(1, 94)
+                                                    )))
+                                                ),],
+                                                into: None,
+                                                from: vec![],
+                                                lateral_views: vec![],
+                                                prewhere: None,
+                                                selection: None,
+                                                group_by: GroupByExpr::Expressions(vec![], vec![],),
+                                                cluster_by: vec![],
+                                                distribute_by: vec![],
+                                                sort_by: vec![],
+                                                having: None,
+                                                named_window: vec![],
+                                                qualify: None,
+                                                window_before_qualify: false,
+                                                value_table_mode: None,
+                                                connect_by: None,
+                                                flavor: SelectFlavor::Standard,
+                                            }),)),
+                                            order_by: None,
+                                            limit_clause: None,
+                                            fetch: None,
+                                            locks: vec![],
+                                            for_clause: None,
+                                            settings: None,
+                                            format_clause: None,
+                                            pipe_operators: vec![],
+                                        }),
+                                    ))),
+                                })],
+                            },
+                        },
+                        elseif_blocks: vec![],
+                        else_block: None,
+                        end_token: None,
+                    }),
+                    Statement::Return(ReturnStatement {
+                        value: Some(ReturnStatementValue::Expr(Expr::Convert {
+                            is_try: false,
+                            expr: Box::new(Expr::Value(
+                                number("123").with_span(Span::new(
+                                    Location::new(1, 89),
+                                    Location::new(1, 92)
+                                ))
+                            )),
+                            data_type: Some(DataType::Int(None)),
+                            charset: None,
+                            target_before_value: true,
+                            styles: vec![],
+                        })),
+                    }),
+                ],
+            },
+        }
+    );
 }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2660,4 +2660,105 @@ fn test_supports_statements_without_semicolon_delimiter() {
             },
         }
     );
+
+    let exec_then_update = "\
+        EXEC my_sp \
+        UPDATE my_table SET col = 1 \
+    ";
+    assert_eq!(
+        parse_n_statements(2, exec_then_update),
+        vec![
+            Statement::Execute {
+                name: Some(ObjectName::from(vec![Ident::new("my_sp")])),
+                parameters: vec![],
+                has_parentheses: false,
+                immediate: false,
+                into: vec![],
+                using: vec![],
+            },
+            Statement::Update {
+                table: TableWithJoins {
+                    relation: TableFactor::Table {
+                        name: ObjectName::from(vec![Ident::new("my_table")]),
+                        alias: None,
+                        with_hints: vec![],
+                        args: None,
+                        version: None,
+                        with_ordinality: false,
+                        partitions: vec![],
+                        json_path: None,
+                        sample: None,
+                        index_hints: vec![]
+                    },
+                    joins: vec![],
+                },
+                assignments: vec![Assignment {
+                    value: Expr::Value(
+                        number("1")
+                            .with_span(Span::new(Location::new(3, 16), Location::new(3, 17)))
+                    ),
+                    target: AssignmentTarget::ColumnName(ObjectName::from(vec![Ident::new("col")])),
+                },],
+                selection: None,
+                returning: None,
+                from: None,
+                or: None
+            },
+        ]
+    );
+
+    let exec_params_then_update = "\
+        EXEC my_sp 1, 2 \
+        UPDATE my_table SET col = 1 \
+    ";
+    assert_eq!(
+        parse_n_statements(2, exec_params_then_update),
+        vec![
+            Statement::Execute {
+                name: Some(ObjectName::from(vec![Ident::with_span(
+                    Span::new(Location::new(1, 6), Location::new(1, 11)),
+                    "my_sp"
+                )])),
+                parameters: vec![],
+                has_parentheses: false,
+                immediate: false,
+                into: vec![],
+                using: vec![],
+            },
+            Statement::Update {
+                table: TableWithJoins {
+                    relation: TableFactor::Table {
+                        name: ObjectName::from(vec![Ident::with_span(
+                            Span::new(Location::new(1, 24), Location::new(1, 32)),
+                            "my_table"
+                        )]),
+                        alias: None,
+                        with_hints: vec![],
+                        args: None,
+                        version: None,
+                        with_ordinality: false,
+                        partitions: vec![],
+                        json_path: None,
+                        sample: None,
+                        index_hints: vec![]
+                    },
+                    joins: vec![],
+                },
+                assignments: vec![Assignment {
+                    value: Expr::Value(
+                        number("1")
+                            .with_span(Span::new(Location::new(3, 16), Location::new(3, 17)))
+                    ),
+                    target: AssignmentTarget::ColumnName(ObjectName::from(vec![Ident::with_span(
+                        Span::new(Location::new(1, 37), Location::new(1, 40)),
+                        "col"
+                    )])),
+                },],
+                selection: None,
+                returning: None,
+                from: None,
+                or: None
+            },
+        ]
+    );
 }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -106,7 +106,7 @@ fn parse_create_procedure() {
         ms().verified_stmt(sql),
         Statement::CreateProcedure {
             or_alter: true,
-            body: BeginEndStatements {
+            body: ConditionalStatements::BeginEnd(BeginEndStatements {
                 begin_token: AttachedToken::empty(),
                 statements: vec![Statement::Query(Box::new(Query {
                     with: None,
@@ -145,7 +145,7 @@ fn parse_create_procedure() {
                     })))
                 }))],
                 end_token: AttachedToken::empty(),
-            },
+            }),
             params: Some(vec![
                 ProcedureParam {
                     name: Ident {

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -1367,6 +1367,7 @@ fn parse_escaped_quote_identifiers_with_no_escape() {
             ParserOptions {
                 trailing_commas: false,
                 unescape: false,
+                require_semicolon_statement_delimiter: true,
             }
         )
         .verified_stmt(sql),


### PR DESCRIPTION
This PR introduces support for parsing SQL without requiring semicolon statement delimiters. The implementation is as follows:

1. new ParserOption `require_semicolon_statement_delimiter` that defaults to a new Dialect function `supports_statements_without_semicolon_delimiter`
2. semicolon statement delimiters remain required by default for all dialects except SQL Server, where they're optional

To make this work, the following supplementary changes were required:

1. `RETURN` statement parsing was tightened up. I think I suggested in the prior PR for that function that it might need attention in the future (turns out the future is now). The reason this needed work is that without a semicolon to terminate the statement, it's hard to know if the thing following RETURN is part of RETURN or it's own thing. That ambiguity is addressed by having parse_return only allow a strict list of "returnable expr's" instead of any expr. This could have been it's own stand-alone PR but seems reasonable to review together instead of having a deeper stack of branches.
2. There are many tests that assert a parse statement error in the form of `Expected: end of statement, found: asdf`. When semicolons are optional, the parse error becomes `Expected: an SQL statement, found: asdf`. Since this is otherwise an acceptable error for that kind of test, a new helper was introduced `assert_err_parse_statements` that splits the dialects based on semicolon optional/required and asserts the appropriate error. The helper also has a pleasant side effect of reducing the volume of extremely similar error assertions.
3. Additionally for testing, a `statements_without_semicolons_parse_to` helper was added. It's the same as `statements_parse_to` but it will strip semicolons from the SQL text. This makes it easier to add supplementary assertions for both SQL variants.
4. Finally, I added a `test_supports_statements_without_semicolon_delimiter` test case to the SQL Server tests, to assert the proper AST for several examples not using semicolons. This is a belt and suspenders test to validate that parsing still produces the expected tree even without semicolons.

I understand this is a big change, and possibly controversial. However like `GO` batch delimiters in https://github.com/apache/datafusion-sqlparser-rs/pull/1809, this enhancement takes a BIG step towards having this library be able to successfully parse real-world SQL files.

---

Fixes https://github.com/apache/datafusion-sqlparser-rs/issues/1800