### PR TITLE
Postgresql: Add `REPLICA IDENTITY` operation for `ALTER TABLE`

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -39,6 +39,8 @@ use crate::ast::{
 use crate::keywords::Keyword;
 use crate::tokenizer::Token;
 
+/// ALTER TABLE operation REPLICA IDENTITY values
+/// See [Postgres ALTER TABLE docs](https://www.postgresql.org/docs/current/sql-altertable.html)
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
@@ -232,6 +234,7 @@ pub enum AlterTableOperation {
     /// REPLICA IDENTITY { DEFAULT | USING INDEX index_name | FULL | NOTHING }
     ///
     /// Note: this is a PostgreSQL-specific operation.
+    /// Please refer to [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-altertable.html)
     ReplicaIdentity {
         identity: ReplicaIdentity,
     },

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -65,7 +65,7 @@ pub use self::ddl::{
     DeferrableInitial, DropBehavior, GeneratedAs, GeneratedExpressionMode, IdentityParameters,
     IdentityProperty, IdentityPropertyFormatKind, IdentityPropertyKind, IdentityPropertyOrder,
     IndexOption, IndexType, KeyOrIndexDisplay, NullsDistinctOption, Owner, Partition,
-    ProcedureParam, ReferentialAction, TableConstraint, TagsColumnOption,
+    ProcedureParam, ReferentialAction, ReplicaIdentity, TableConstraint, TagsColumnOption,
     UserDefinedTypeCompositeAttributeDef, UserDefinedTypeRepresentation, ViewColumnDef,
 };
 pub use self::dml::{CreateIndex, CreateTable, Delete, IndexColumn, Insert};

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1174,6 +1174,7 @@ impl Spanned for AlterTableOperation {
             AlterTableOperation::Algorithm { .. } => Span::empty(),
             AlterTableOperation::AutoIncrement { value, .. } => value.span(),
             AlterTableOperation::Lock { .. } => Span::empty(),
+            AlterTableOperation::ReplicaIdentity { .. } => Span::empty(),
         }
     }
 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5959,3 +5959,30 @@ fn parse_varbit_datatype() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn parse_alter_table_replica_identity() {
+    match pg_and_generic().verified_stmt("ALTER TABLE foo REPLICA IDENTITY FULL") {
+        Statement::AlterTable { operations, .. } => {
+            assert_eq!(
+                operations,
+                vec![AlterTableOperation::ReplicaIdentity {
+                    identity: ReplicaIdentity::Full
+                }]
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    match pg_and_generic().verified_stmt("ALTER TABLE foo REPLICA IDENTITY USING INDEX foo_idx") {
+        Statement::AlterTable { operations, .. } => {
+            assert_eq!(
+                operations,
+                vec![AlterTableOperation::ReplicaIdentity {
+                    identity: ReplicaIdentity::Index("foo_idx".into())
+                }]
+            );
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
Add support for the psql-specific ALTER TABLE operation REPLICA IDENTITY

Docs: https://www.postgresql.org/docs/current/sql-altertable.html