### PR TITLE
Fix big performance issue in string serialization

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -462,16 +462,20 @@ impl fmt::Display for EscapeQuotedString<'_> {
             match ch {
                 char if char == quote => {
                     if previous_char == '\\' {
+                        // the quote is already escaped with a backslash, skip
                         peekable_chars.next();
                         continue;
                     }
                     peekable_chars.next();
                     match peekable_chars.peek() {
                         Some((_, c)) if *c == quote => {
+                            // the quote is already escaped with another quote, skip
                             peekable_chars.next();
                         }
                         _ => {
-                            // not calling .next(), so the quote at idx will be printed twice
+                            // The quote is not escaped.
+                            // Not calling .next(), so the quote at idx will be printed twice:
+                            // in this call to write_str() and in the next one.
                             f.write_str(&self.string[start_idx..=idx])?;
                             start_idx = idx;
                         }

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -474,7 +474,7 @@ impl fmt::Display for EscapeQuotedString<'_> {
                         }
                         _ => {
                             // The quote is not escaped.
-                            // Not calling .next(), so the quote at idx will be printed twice:
+                            // Including idx in the range, so the quote at idx will be printed twice:
                             // in this call to write_str() and in the next one.
                             f.write_str(&self.string[start_idx..=idx])?;
                             start_idx = idx;


### PR DESCRIPTION
The old code was handling string escaping character by character. For every literal string in the AST, it would push it to the underlying writer **character by character**, resulting in thousands of write calls for long strings.

The new code calls the write function only once, with the entire string, in most cases.

Only when the string is stored unescaped do we really need to call write multiple times; and even then, we don't need to call it more than the total number of characters to escape plus one.

Here are benchmark results for serializing the following sql statement: `"SELECT 'xxx...(x 10000)' as long_string"` to a string in memory:

```
sqlparser-rs parsing benchmark/format_long_string
                        time:   [10.544 µs 10.645 µs 10.743 µs]
                        change: [-84.871% -84.195% -83.553%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
```

![image](https://github.com/user-attachments/assets/fb896406-899d-433b-a814-2179837d68ad)
