### PR TITLE
fix new rust 1.87 cargo clippy warnings

### DIFF
--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -977,7 +977,8 @@ mod visit_mut_tests {
             .parse_statement()
             .unwrap();
 
-        s.visit(visitor);
+        let flow = s.visit(visitor);
+        assert_eq!(flow, ControlFlow::Continue(()));
         s
     }
 

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -741,7 +741,7 @@ mod tests {
         }
     }
 
-    fn do_visit<V: Visitor>(sql: &str, visitor: &mut V) -> Statement {
+    fn do_visit<V: Visitor<Break = ()>>(sql: &str, visitor: &mut V) -> Statement {
         let dialect = GenericDialect {};
         let tokens = Tokenizer::new(&dialect, sql).tokenize().unwrap();
         let s = Parser::new(&dialect)
@@ -749,7 +749,8 @@ mod tests {
             .parse_statement()
             .unwrap();
 
-        s.visit(visitor);
+        let flow = s.visit(visitor);
+        assert_eq!(flow, ControlFlow::Continue(()));
         s
     }
 
@@ -938,7 +939,8 @@ mod tests {
             .unwrap();
 
         let mut visitor = QuickVisitor {};
-        s.visit(&mut visitor);
+        let flow = s.visit(&mut visitor);
+        assert_eq!(flow, ControlFlow::Continue(()));
     }
 }
 
@@ -969,7 +971,7 @@ mod visit_mut_tests {
         }
     }
 
-    fn do_visit_mut<V: VisitorMut>(sql: &str, visitor: &mut V) -> Statement {
+    fn do_visit_mut<V: VisitorMut<Break = ()>>(sql: &str, visitor: &mut V) -> Statement {
         let dialect = GenericDialect {};
         let tokens = Tokenizer::new(&dialect, sql).tokenize().unwrap();
         let mut s = Parser::new(&dialect)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::upper_case_acronyms)]
-// The AST represents rich AST nodes,
-// and favors expressiveness and ease of use over speed and memory usage.
+// Permit large enum variants to keep a unified, expressive AST.
+// Splitting complex nodes (expressions, statements, types) into separate types
+// would bloat the API and hide intent. Extra memory is a worthwhile tradeoff.
 #![allow(clippy::large_enum_variant)]
 
 // Allow proc-macros to find this crate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::upper_case_acronyms)]
+// The AST represents rich AST nodes,
+// and favors expressiveness and ease of use over speed and memory usage.
+#![allow(clippy::large_enum_variant)]
 
 // Allow proc-macros to find this crate
 extern crate self as sqlparser;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2558,8 +2558,7 @@ impl<'a> Parser<'a> {
         self.expect_token(&Token::LParen)?;
         let mut trim_where = None;
         if let Token::Word(word) = self.peek_token().token {
-            if [Keyword::BOTH, Keyword::LEADING, Keyword::TRAILING].contains(&word.keyword)
-            {
+            if [Keyword::BOTH, Keyword::LEADING, Keyword::TRAILING].contains(&word.keyword) {
                 trim_where = Some(self.parse_trim_where()?);
             }
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2558,9 +2558,7 @@ impl<'a> Parser<'a> {
         self.expect_token(&Token::LParen)?;
         let mut trim_where = None;
         if let Token::Word(word) = self.peek_token().token {
-            if [Keyword::BOTH, Keyword::LEADING, Keyword::TRAILING]
-                .iter()
-                .any(|d| word.keyword == *d)
+            if [Keyword::BOTH, Keyword::LEADING, Keyword::TRAILING].contains(&word.keyword)
             {
                 trim_where = Some(self.parse_trim_where()?);
             }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -14346,7 +14346,7 @@ fn test_visit_order() {
     let sql = "SELECT CASE a WHEN 1 THEN 2 WHEN 3 THEN 4 ELSE 5 END";
     let stmt = verified_stmt(sql);
     let mut visited = vec![];
-    sqlparser::ast::visit_expressions(&stmt, |expr| {
+    let _ = sqlparser::ast::visit_expressions(&stmt, |expr| {
         visited.push(expr.to_string());
         core::ops::ControlFlow::<()>::Continue(())
     });


### PR DESCRIPTION
all PRs are currently red because of the new rust release