### PR TITLE
Add support for `TABLESAMPLE` pipe operator

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2707,7 +2707,7 @@ impl fmt::Display for PipeOperator {
             PipeOperator::Limit { expr, offset } => {
                 write!(f, "LIMIT {}", expr)?;
                 if let Some(offset) = offset {
-                    write!(f, "OFFSET {}", offset)?;
+                    write!(f, " OFFSET {}", offset)?;
                 }
                 Ok(())
             }
@@ -2719,12 +2719,12 @@ impl fmt::Display for PipeOperator {
                 if !full_table_exprs.is_empty() {
                     write!(
                         f,
-                        "{}",
+                        " {}",
                         display_comma_separated(full_table_exprs.as_slice())
                     )?;
                 }
                 if !group_by_expr.is_empty() {
-                    write!(f, "GROUP BY {}", display_comma_separated(group_by_expr))?;
+                    write!(f, " GROUP BY {}", display_comma_separated(group_by_expr))?;
                 }
                 Ok(())
             }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -104,7 +104,7 @@ impl fmt::Display for Query {
             format.fmt(f)?;
         }
         for pipe_operator in &self.pipe_operators {
-            f.write_str(" |>")?;
+            f.write_str(" |> ")?;
             pipe_operator.fmt(f)?;
         }
         Ok(())
@@ -2690,24 +2690,24 @@ impl fmt::Display for PipeOperator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             PipeOperator::Select { exprs } => {
-                write!(f, " SELECT {}", display_comma_separated(exprs.as_slice()))
+                write!(f, "SELECT {}", display_comma_separated(exprs.as_slice()))
             }
             PipeOperator::Extend { exprs } => {
-                write!(f, " EXTEND {}", display_comma_separated(exprs.as_slice()))
+                write!(f, "EXTEND {}", display_comma_separated(exprs.as_slice()))
             }
             PipeOperator::Set { assignments } => {
-                write!(f, " SET {}", display_comma_separated(assignments.as_slice()))
+                write!(f, "SET {}", display_comma_separated(assignments.as_slice()))
             }
             PipeOperator::Drop { columns } => {
-                write!(f, " DROP {}", display_comma_separated(columns.as_slice()))
+                write!(f, "DROP {}", display_comma_separated(columns.as_slice()))
             }
             PipeOperator::As { alias } => {
-                write!(f, " AS {}", alias)
+                write!(f, "AS {}", alias)
             }
             PipeOperator::Limit { expr, offset } => {
-                write!(f, " LIMIT {}", expr)?;
+                write!(f, "LIMIT {}", expr)?;
                 if let Some(offset) = offset {
-                    write!(f, " OFFSET {}", offset)?;
+                    write!(f, "OFFSET {}", offset)?;
                 }
                 Ok(())
             }
@@ -2715,25 +2715,25 @@ impl fmt::Display for PipeOperator {
                 full_table_exprs,
                 group_by_expr,
             } => {
-                write!(f, " AGGREGATE")?;
+                write!(f, "AGGREGATE")?;
                 if !full_table_exprs.is_empty() {
                     write!(
                         f,
-                        " {}",
+                        "{}",
                         display_comma_separated(full_table_exprs.as_slice())
                     )?;
                 }
                 if !group_by_expr.is_empty() {
-                    write!(f, " GROUP BY {}", display_comma_separated(group_by_expr))?;
+                    write!(f, "GROUP BY {}", display_comma_separated(group_by_expr))?;
                 }
                 Ok(())
             }
 
             PipeOperator::Where { expr } => {
-                write!(f, " WHERE {}", expr)
+                write!(f, "WHERE {}", expr)
             }
             PipeOperator::OrderBy { exprs } => {
-                write!(f, " ORDER BY {}", display_comma_separated(exprs.as_slice()))
+                write!(f, "ORDER BY {}", display_comma_separated(exprs.as_slice()))
             }
 
             PipeOperator::TableSample { sample } => {

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2680,6 +2680,10 @@ pub enum PipeOperator {
         full_table_exprs: Vec<ExprWithAliasAndOrderBy>,
         group_by_expr: Vec<ExprWithAliasAndOrderBy>,
     },
+    /// Selects a random sample of rows from the input table.
+    /// Syntax: `|> TABLESAMPLE <method> (<size> {ROWS | PERCENT})`
+    /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#tablesample_pipe_operator>
+    TableSample { sample: Box <TableSample> },
 }
 
 impl fmt::Display for PipeOperator {
@@ -2730,6 +2734,10 @@ impl fmt::Display for PipeOperator {
             }
             PipeOperator::OrderBy { exprs } => {
                 write!(f, "ORDER BY {}", display_comma_separated(exprs.as_slice()))
+            }
+
+            PipeOperator::TableSample { sample } => {
+                write!(f, " {}", sample)
             }
         }
     }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2683,7 +2683,7 @@ pub enum PipeOperator {
     /// Selects a random sample of rows from the input table.
     /// Syntax: `|> TABLESAMPLE SYSTEM (10 PERCENT)
     /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#tablesample_pipe_operator>
-    TableSample { sample: Box <TableSample> },
+    TableSample { sample: Box<TableSample> },
 }
 
 impl fmt::Display for PipeOperator {

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -104,7 +104,7 @@ impl fmt::Display for Query {
             format.fmt(f)?;
         }
         for pipe_operator in &self.pipe_operators {
-            f.write_str(" |> ")?;
+            f.write_str(" |>")?;
             pipe_operator.fmt(f)?;
         }
         Ok(())
@@ -2690,22 +2690,22 @@ impl fmt::Display for PipeOperator {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             PipeOperator::Select { exprs } => {
-                write!(f, "SELECT {}", display_comma_separated(exprs.as_slice()))
+                write!(f, " SELECT {}", display_comma_separated(exprs.as_slice()))
             }
             PipeOperator::Extend { exprs } => {
-                write!(f, "EXTEND {}", display_comma_separated(exprs.as_slice()))
+                write!(f, " EXTEND {}", display_comma_separated(exprs.as_slice()))
             }
             PipeOperator::Set { assignments } => {
-                write!(f, "SET {}", display_comma_separated(assignments.as_slice()))
+                write!(f, " SET {}", display_comma_separated(assignments.as_slice()))
             }
             PipeOperator::Drop { columns } => {
-                write!(f, "DROP {}", display_comma_separated(columns.as_slice()))
+                write!(f, " DROP {}", display_comma_separated(columns.as_slice()))
             }
             PipeOperator::As { alias } => {
-                write!(f, "AS {}", alias)
+                write!(f, " AS {}", alias)
             }
             PipeOperator::Limit { expr, offset } => {
-                write!(f, "LIMIT {}", expr)?;
+                write!(f, " LIMIT {}", expr)?;
                 if let Some(offset) = offset {
                     write!(f, " OFFSET {}", offset)?;
                 }
@@ -2715,7 +2715,7 @@ impl fmt::Display for PipeOperator {
                 full_table_exprs,
                 group_by_expr,
             } => {
-                write!(f, "AGGREGATE")?;
+                write!(f, " AGGREGATE")?;
                 if !full_table_exprs.is_empty() {
                     write!(
                         f,
@@ -2730,14 +2730,14 @@ impl fmt::Display for PipeOperator {
             }
 
             PipeOperator::Where { expr } => {
-                write!(f, "WHERE {}", expr)
+                write!(f, " WHERE {}", expr)
             }
             PipeOperator::OrderBy { exprs } => {
-                write!(f, "ORDER BY {}", display_comma_separated(exprs.as_slice()))
+                write!(f, " ORDER BY {}", display_comma_separated(exprs.as_slice()))
             }
 
             PipeOperator::TableSample { sample } => {
-                write!(f, " {}", sample)
+                write!(f, "{}", sample)
             }
         }
     }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1559,7 +1559,7 @@ impl fmt::Display for TableSampleBucket {
 }
 impl fmt::Display for TableSample {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, " {}", self.modifier)?;
+        write!(f, "{}", self.modifier)?;
         if let Some(name) = &self.name {
             write!(f, " {}", name)?;
         }
@@ -1862,7 +1862,7 @@ impl fmt::Display for TableFactor {
                     write!(f, " WITH ORDINALITY")?;
                 }
                 if let Some(TableSampleKind::BeforeTableAlias(sample)) = sample {
-                    write!(f, "{sample}")?;
+                    write!(f, " {sample}")?;
                 }
                 if let Some(alias) = alias {
                     write!(f, " AS {alias}")?;
@@ -1877,7 +1877,7 @@ impl fmt::Display for TableFactor {
                     write!(f, "{version}")?;
                 }
                 if let Some(TableSampleKind::AfterTableAlias(sample)) = sample {
-                    write!(f, "{sample}")?;
+                    write!(f, " {sample}")?;
                 }
                 Ok(())
             }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2681,7 +2681,7 @@ pub enum PipeOperator {
         group_by_expr: Vec<ExprWithAliasAndOrderBy>,
     },
     /// Selects a random sample of rows from the input table.
-    /// Syntax: `|> TABLESAMPLE <method> (<size> {ROWS | PERCENT})`
+    /// Syntax: `|> TABLESAMPLE SYSTEM (10 PERCENT)
     /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#tablesample_pipe_operator>
     TableSample { sample: Box <TableSample> },
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11047,6 +11047,7 @@ impl<'a> Parser<'a> {
                 Keyword::LIMIT,
                 Keyword::AGGREGATE,
                 Keyword::ORDER,
+                Keyword::TABLESAMPLE,
             ])?;
             match kw {
                 Keyword::SELECT => {
@@ -11108,6 +11109,12 @@ impl<'a> Parser<'a> {
                     self.expect_one_of_keywords(&[Keyword::BY])?;
                     let exprs = self.parse_comma_separated(Parser::parse_order_by_expr)?;
                     pipe_operators.push(PipeOperator::OrderBy { exprs })
+                }
+                Keyword::TABLESAMPLE => {
+                    if let Some(sample) = self.maybe_parse_table_sample()? {
+                        pipe_operators.push(PipeOperator::TableSample { sample });
+                    };
+
                 }
                 unhandled => {
                     return Err(ParserError::ParserError(format!(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12758,11 +12758,14 @@ impl<'a> Parser<'a> {
         } else {
             return Ok(None);
         };
-        self.parse_table_sample(modifier).map(|sample| Some(sample))       
+        self.parse_table_sample(modifier).map(|sample| Some(sample))
     }
 
-    fn parse_table_sample(&mut self, modifier: TableSampleModifier ) -> Result<Box<TableSample>, ParserError> {
-let name = match self.parse_one_of_keywords(&[
+    fn parse_table_sample(
+        &mut self,
+        modifier: TableSampleModifier,
+    ) -> Result<Box<TableSample>, ParserError> {
+        let name = match self.parse_one_of_keywords(&[
             Keyword::BERNOULLI,
             Keyword::ROW,
             Keyword::SYSTEM,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -12758,7 +12758,7 @@ impl<'a> Parser<'a> {
         } else {
             return Ok(None);
         };
-        self.parse_table_sample(modifier).map(|sample| Some(sample))
+        self.parse_table_sample(modifier).map(Some)
     }
 
     fn parse_table_sample(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11111,10 +11111,8 @@ impl<'a> Parser<'a> {
                     pipe_operators.push(PipeOperator::OrderBy { exprs })
                 }
                 Keyword::TABLESAMPLE => {
-                    if let Some(sample) = self.maybe_parse_table_sample()? {
-                        pipe_operators.push(PipeOperator::TableSample { sample });
-                    };
-
+                    let sample = self.parse_table_sample(TableSampleModifier::TableSample)?;
+                    pipe_operators.push(PipeOperator::TableSample { sample });
                 }
                 unhandled => {
                     return Err(ParserError::ParserError(format!(
@@ -12760,8 +12758,11 @@ impl<'a> Parser<'a> {
         } else {
             return Ok(None);
         };
+        self.parse_table_sample(modifier).map(|sample| Some(sample))       
+    }
 
-        let name = match self.parse_one_of_keywords(&[
+    fn parse_table_sample(&mut self, modifier: TableSampleModifier ) -> Result<Box<TableSample>, ParserError> {
+let name = match self.parse_one_of_keywords(&[
             Keyword::BERNOULLI,
             Keyword::ROW,
             Keyword::SYSTEM,
@@ -12842,14 +12843,14 @@ impl<'a> Parser<'a> {
             None
         };
 
-        Ok(Some(Box::new(TableSample {
+        Ok(Box::new(TableSample {
             modifier,
             name,
             quantity,
             seed,
             bucket,
             offset,
-        })))
+        }))
     }
 
     fn parse_table_sample_seed(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15156,10 +15156,10 @@ fn parse_pipeline_operator() {
     dialects.verified_stmt("SELECT * FROM users |> ORDER BY id DESC, name ASC");
 
     // tablesample pipe operator
-    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE BERNOULLI (50)");
-    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50)");
+    dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE BERNOULLI (50)");
+    dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE SYSTEM (50)");
     // TODO: Technically, REPEATABLE is not available in BigQuery, but it is used with TABLESAMPLE in other dialects
-    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
+    dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
 
     // many pipes
     dialects.verified_stmt(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15155,6 +15155,12 @@ fn parse_pipeline_operator() {
     dialects.verified_stmt("SELECT * FROM users |> ORDER BY id DESC");
     dialects.verified_stmt("SELECT * FROM users |> ORDER BY id DESC, name ASC");
 
+    // tablesample pipe operator
+    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE BERNOULLI (50)");
+    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50)");
+    // TODO: Technically, REPEATABLE is not available in BigQuery, but it is used with TABLESAMPLE in other dialects
+    dialects.verified_stmt("SELECT * FROM tbl AS t TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
+
     // many pipes
     dialects.verified_stmt(
         "SELECT * FROM CustomerOrders |> AGGREGATE SUM(cost) AS total_cost GROUP BY customer_id, state, item_type |> EXTEND COUNT(*) OVER (PARTITION BY customer_id) AS num_orders |> WHERE num_orders > 1 |> AGGREGATE AVG(total_cost) AS average GROUP BY state DESC, item_type ASC",

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15158,7 +15158,6 @@ fn parse_pipeline_operator() {
     // tablesample pipe operator
     dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE BERNOULLI (50)");
     dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE SYSTEM (50 PERCENT)");
-    // TODO: Technically, REPEATABLE is not available in BigQuery, but it is used with TABLESAMPLE in other dialects
     dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
 
     // many pipes

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15157,7 +15157,7 @@ fn parse_pipeline_operator() {
 
     // tablesample pipe operator
     dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE BERNOULLI (50)");
-    dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE SYSTEM (50)");
+    dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE SYSTEM (50 PERCENT)");
     // TODO: Technically, REPEATABLE is not available in BigQuery, but it is used with TABLESAMPLE in other dialects
     dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
 


### PR DESCRIPTION
Part of #1758

This PR adds support for the `|> TABLESAMPLE ...` pipe operator.

Open question:

[BigQuery's `TABLESAMPLE` operator](https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#tablesample_pipe_operator) does not support the full [SQL standard spec](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#sample-clause). This PR adds support for a superset of the BigQuery syntax which, e.g., includes the `REPEATABLE` clause and reuses the existing code for parsing `TABLESAMPLE` operators. Is this desired from the perspective of the project or is it preferred to stick closely to the BigQuery syntax? If so, I'm happy to change this.