### PR TITLE
Add support for parameter default values in SQL Server

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5289,11 +5289,17 @@ impl<'a> Parser<'a> {
             |parser: &mut Parser| -> Result<OperateFunctionArg, ParserError> {
                 let name = parser.parse_identifier()?;
                 let data_type = parser.parse_data_type()?;
+                let default_expr = if parser.consume_token(&Token::Eq) {
+                    Some(parser.parse_expr()?)
+                } else {
+                    None
+                };
+
                 Ok(OperateFunctionArg {
                     mode: None,
                     name: Some(name),
                     data_type,
-                    default_expr: None,
+                    default_expr,
                 })
             };
         self.expect_token(&Token::LParen)?;


### PR DESCRIPTION
This PR adds support for default values for parameters, as documented here: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver17#--default-

The concept of a parameter default value already existed on the `OperateFunctionArg` struct, but was hardcoded to `None`. That logic has been updated to conditionally consume `=` & parse an Expr.

Since this is relevant for SQL Server, a new test was added to `sqlparser_mssql.rs` accordingly.