### PR TITLE
MySQL: `[[NOT] ENFORCED]` in CHECK constraint

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1034,7 +1034,7 @@ pub enum TableConstraint {
         name: Option<Ident>,
         expr: Box<Expr>,
         /// MySQL-specific syntax
-        /// https://dev.mysql.com/doc/refman/8.4/en/create-table.html
+        /// <https://dev.mysql.com/doc/refman/8.4/en/create-table.html>
         enforced: Option<bool>,
     },
     /// MySQLs [index definition][1] for index creation. Not present on ANSI so, for now, the usage

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -687,9 +687,11 @@ impl Spanned for TableConstraint {
                     .chain(on_update.iter().map(|i| i.span()))
                     .chain(characteristics.iter().map(|i| i.span())),
             ),
-            TableConstraint::Check { name, expr } => {
-                expr.span().union_opt(&name.as_ref().map(|i| i.span))
-            }
+            TableConstraint::Check {
+                name,
+                expr,
+                enforced: _,
+            } => expr.span().union_opt(&name.as_ref().map(|i| i.span)),
             TableConstraint::Index {
                 display_as_key: _,
                 name,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8140,11 +8140,12 @@ impl<'a> Parser<'a> {
                 let expr = Box::new(self.parse_expr()?);
                 self.expect_token(&Token::RParen)?;
 
-                let enforced = match dialect_of!(self is GenericDialect | MySqlDialect) {
-                    true if self.parse_keywords(&[Keyword::NOT, Keyword::ENFORCED]) => Some(false),
-                    true if self.parse_keyword(Keyword::ENFORCED) => Some(true),
-                    // not MySQL, or is MySQL but not specified
-                    _ => None,
+                let enforced = if self.parse_keyword(Keyword::ENFORCED) {
+                    Some(true)
+                } else if self.parse_keywords(&[Keyword::NOT, Keyword::ENFORCED]) {
+                    Some(false)
+                } else {
+                    None
                 };
 
                 Ok(Some(TableConstraint::Check {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15336,3 +15336,10 @@ fn parse_truncate_only() {
         truncate
     );
 }
+
+#[test]
+fn check_enforced() {
+    all_dialects().verified_stmt(
+        "CREATE TABLE t (a INT, b INT, c INT, CHECK (a > 0) NOT ENFORCED, CHECK (b > 0) ENFORCED, CHECK (c > 0))",
+    );
+}

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -4025,10 +4025,3 @@ fn parse_drop_index() {
         _ => unreachable!(),
     }
 }
-
-#[test]
-fn check_enforced() {
-    mysql().verified_stmt(
-        "CREATE TABLE t (a INT, b INT, c INT, CHECK (a > 0) NOT ENFORCED, CHECK (b > 0) ENFORCED, CHECK (c > 0))",
-    );
-}

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -4025,3 +4025,10 @@ fn parse_drop_index() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn check_enforced() {
+    mysql().verified_stmt(
+        "CREATE TABLE t (a INT, b INT, c INT, CHECK (a > 0) NOT ENFORCED, CHECK (b > 0) ENFORCED, CHECK (c > 0))",
+    );
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5378,6 +5378,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            enforced: None,
         }],
     });
 
@@ -5396,6 +5397,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            enforced: None,
         }],
     });
 
@@ -5414,6 +5416,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            enforced: None,
         }],
     });
 
@@ -5432,6 +5435,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            enforced: None,
         }],
     });
 
@@ -5450,6 +5454,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            enforced: None,
         }],
     });
 


### PR DESCRIPTION
Add support for MySQL's `[[NOT] ENFORCED]` option for CHECK constraints.

docs: https://dev.mysql.com/doc/refman/8.4/en/create-table.html