### PR TITLE
feat: Hive: support `SORT BY` direction

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -341,7 +341,7 @@ pub struct Select {
     /// DISTRIBUTE BY (Hive)
     pub distribute_by: Vec<Expr>,
     /// SORT BY (Hive)
-    pub sort_by: Vec<Expr>,
+    pub sort_by: Vec<OrderByExpr>,
     /// HAVING
     pub having: Option<Expr>,
     /// WINDOW AS

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11580,7 +11580,7 @@ impl<'a> Parser<'a> {
         };
 
         let sort_by = if self.parse_keywords(&[Keyword::SORT, Keyword::BY]) {
-            self.parse_comma_separated(Parser::parse_expr)?
+            self.parse_comma_separated(Parser::parse_order_by_expr)?
         } else {
             vec![]
         };

--- a/tests/sqlparser_hive.rs
+++ b/tests/sqlparser_hive.rs
@@ -341,6 +341,9 @@ fn lateral_view() {
 fn sort_by() {
     let sort_by = "SELECT * FROM db.table SORT BY a";
     hive().verified_stmt(sort_by);
+
+    let sort_by_with_direction = "SELECT * FROM db.table SORT BY a, b DESC";
+    hive().verified_stmt(sort_by_with_direction);
 }
 
 #[test]


### PR DESCRIPTION
In Hive SQL, we can add ASC, DESC after sort by columns. but currently this parser doesn't support it.

https://cwiki.apache.org/confluence/display/Hive/LanguageManual+SortBy.