### PR TITLE
chore: Replace archived actions-rs/install action 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,11 +88,8 @@ jobs:
       uses: ./.github/actions/setup-builder
       with:
         rust-version: ${{ matrix.rust }}
+    - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
     - name: Install Tarpaulin
-      uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-tarpaulin
-        version: 0.14.2
-        use-tool-cache: true
+      run: cargo install cargo-tarpaulin
     - name: Test
       run: cargo test --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,9 @@ name: Rust
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   codestyle:


### PR DESCRIPTION
The actions-rs org has been archived for years at this point and it doesn't look like it's coming back. For security reasons we are going to remove it from the allow list soon.

In this PR I have replaced the usage of `actions-rs/install` with a well known rust cache action and a normal `cargo install`