### PR TITLE
Add support for `CREATE SCHEMA x WITH ( <properties> )`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3725,6 +3725,14 @@ pub enum Statement {
         /// `<schema name> | AUTHORIZATION <schema authorization identifier>  | <schema name>  AUTHORIZATION <schema authorization identifier>`
         schema_name: SchemaName,
         if_not_exists: bool,
+        /// Schema properties.
+        ///
+        /// ```sql
+        /// CREATE SCHEMA myschema WITH (key1='value1');
+        /// ```
+        ///
+        /// [Trino](https://trino.io/docs/current/sql/create-schema.html)
+        with: Option<Vec<SqlOption>>,
         /// Schema options.
         ///
         /// ```sql
@@ -5585,6 +5593,7 @@ impl fmt::Display for Statement {
             Statement::CreateSchema {
                 schema_name,
                 if_not_exists,
+                with,
                 options,
                 default_collate_spec,
             } => {
@@ -5597,6 +5606,10 @@ impl fmt::Display for Statement {
 
                 if let Some(collate) = default_collate_spec {
                     write!(f, " DEFAULT COLLATE {collate}")?;
+                }
+
+                if let Some(with) = with {
+                    write!(f, " WITH ({})", display_comma_separated(with))?;
                 }
 
                 if let Some(options) = options {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4862,6 +4862,12 @@ impl<'a> Parser<'a> {
             None
         };
 
+        let with = if self.peek_keyword(Keyword::WITH) {
+            Some(self.parse_options(Keyword::WITH)?)
+        } else {
+            None
+        };
+
         let options = if self.peek_keyword(Keyword::OPTIONS) {
             Some(self.parse_options(Keyword::OPTIONS)?)
         } else {
@@ -4871,6 +4877,7 @@ impl<'a> Parser<'a> {
         Ok(Statement::CreateSchema {
             schema_name,
             if_not_exists,
+            with,
             options,
             default_collate_spec,
         })

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4268,6 +4268,9 @@ fn parse_create_schema() {
     verified_stmt(r#"CREATE SCHEMA IF NOT EXISTS a OPTIONS(key1 = 'value1')"#);
     verified_stmt(r#"CREATE SCHEMA IF NOT EXISTS a OPTIONS()"#);
     verified_stmt(r#"CREATE SCHEMA IF NOT EXISTS a DEFAULT COLLATE 'und:ci' OPTIONS()"#);
+    verified_stmt(r#"CREATE SCHEMA a.b.c WITH (key1 = 'value1', key2 = 'value2')"#);
+    verified_stmt(r#"CREATE SCHEMA IF NOT EXISTS a WITH (key1 = 'value1')"#);
+    verified_stmt(r#"CREATE SCHEMA IF NOT EXISTS a WITH ()"#);
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for `CREATE SCHEMA x WITH ( LOCATION = '/some/path' )` by some dialects such as Trino. 

See documentation at https://trino.io/docs/current/sql/create-schema.html