### PR TITLE
Support remaining pipe operators

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2823,10 +2823,7 @@ impl fmt::Display for PipeOperator {
             } => Self::fmt_set_operation(f, "EXCEPT", set_quantifier, queries),
             PipeOperator::Call { function, alias } => {
                 write!(f, "CALL {}", function)?;
-                if let Some(alias) = alias {
-                    write!(f, " AS {}", alias)?;
-                }
-                Ok(())
+                Self::fmt_optional_alias(f, alias)
             }
             PipeOperator::Pivot {
                 aggregate_functions,
@@ -2841,10 +2838,7 @@ impl fmt::Display for PipeOperator {
                     Expr::CompoundIdentifier(value_column.to_vec()),
                     value_source
                 )?;
-                if let Some(alias) = alias {
-                    write!(f, " AS {}", alias)?;
-                }
-                Ok(())
+                Self::fmt_optional_alias(f, alias)
             }
             PipeOperator::Unpivot {
                 value_column,
@@ -2859,16 +2853,21 @@ impl fmt::Display for PipeOperator {
                     name_column,
                     display_comma_separated(unpivot_columns)
                 )?;
-                if let Some(alias) = alias {
-                    write!(f, " AS {}", alias)?;
-                }
-                Ok(())
+                Self::fmt_optional_alias(f, alias)
             }
         }
     }
 }
 
 impl PipeOperator {
+    /// Helper function to format optional alias for pipe operators
+    fn fmt_optional_alias(f: &mut fmt::Formatter<'_>, alias: &Option<Ident>) -> fmt::Result {
+        if let Some(alias) = alias {
+            write!(f, " AS {}", alias)?;
+        }
+        Ok(())
+    }
+
     /// Helper function to format set operations (UNION, INTERSECT, EXCEPT) with queries
     fn fmt_set_operation(
         f: &mut fmt::Formatter<'_>,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2684,6 +2684,12 @@ pub enum PipeOperator {
     /// Syntax: `|> TABLESAMPLE SYSTEM (10 PERCENT)
     /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#tablesample_pipe_operator>
     TableSample { sample: Box<TableSample> },
+    /// Renames columns in the input table.
+    ///
+    /// Syntax: `|> RENAME old_name AS new_name, ...`
+    ///
+    /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#rename_pipe_operator>
+    Rename { mappings: Vec<IdentWithAlias> },
 }
 
 impl fmt::Display for PipeOperator {
@@ -2738,6 +2744,9 @@ impl fmt::Display for PipeOperator {
 
             PipeOperator::TableSample { sample } => {
                 write!(f, "{}", sample)
+            }
+            PipeOperator::Rename { mappings } => {
+                write!(f, "RENAME {}", display_comma_separated(mappings))
             }
         }
     }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2722,7 +2722,10 @@ pub enum PipeOperator {
     /// Syntax: `|> CALL function_name(args) [AS alias]`
     ///
     /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#call_pipe_operator>
-    Call { function: Function, alias: Option<Ident> },
+    Call {
+        function: Function,
+        alias: Option<Ident>,
+    },
     /// Pivots data from rows to columns.
     ///
     /// Syntax: `|> PIVOT(aggregate_function(column) FOR pivot_column IN (value1, value2, ...)) [AS alias]`

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2877,8 +2877,6 @@ impl PipeOperator {
     ) -> fmt::Result {
         write!(f, "{}", operation)?;
         match set_quantifier {
-            SetQuantifier::All => write!(f, " ALL")?,
-            SetQuantifier::Distinct => write!(f, " DISTINCT")?,
             SetQuantifier::None => {}
             _ => {
                 write!(f, " {}", set_quantifier)?;

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2708,6 +2708,15 @@ pub enum PipeOperator {
         set_quantifier: SetQuantifier,
         queries: Vec<Box<Query>>,
     },
+    /// Returns only the rows that are present in the input table but not in the specified tables.
+    ///
+    /// Syntax: `|> EXCEPT DISTINCT (<query>), (<query>), ...`
+    ///
+    /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#except_pipe_operator>
+    Except {
+        set_quantifier: SetQuantifier,
+        queries: Vec<Box<Query>>,
+    },
 }
 
 impl fmt::Display for PipeOperator {
@@ -2793,6 +2802,28 @@ impl fmt::Display for PipeOperator {
                 queries,
             } => {
                 write!(f, "INTERSECT")?;
+                match set_quantifier {
+                    SetQuantifier::All => write!(f, " ALL")?,
+                    SetQuantifier::Distinct => write!(f, " DISTINCT")?,
+                    SetQuantifier::None => {}
+                    _ => {
+                        write!(f, " {}", set_quantifier)?;
+                    }
+                }
+                write!(f, " ")?;
+                for (i, query) in queries.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "({})", query)?;
+                }
+                Ok(())
+            }
+            PipeOperator::Except {
+                set_quantifier,
+                queries,
+            } => {
+                write!(f, "EXCEPT")?;
                 match set_quantifier {
                     SetQuantifier::All => write!(f, " ALL")?,
                     SetQuantifier::Distinct => write!(f, " DISTINCT")?,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2717,6 +2717,12 @@ pub enum PipeOperator {
         set_quantifier: SetQuantifier,
         queries: Vec<Box<Query>>,
     },
+    /// Calls a table function or procedure that returns a table.
+    ///
+    /// Syntax: `|> CALL function_name(args) [AS alias]`
+    ///
+    /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#call_pipe_operator>
+    Call { function: Function, alias: Option<Ident> },
 }
 
 impl fmt::Display for PipeOperator {
@@ -2838,6 +2844,13 @@ impl fmt::Display for PipeOperator {
                         write!(f, ", ")?;
                     }
                     write!(f, "({})", query)?;
+                }
+                Ok(())
+            }
+            PipeOperator::Call { function, alias } => {
+                write!(f, "CALL {}", function)?;
+                if let Some(alias) = alias {
+                    write!(f, " AS {}", alias)?;
                 }
                 Ok(())
             }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2861,7 +2861,7 @@ impl fmt::Display for PipeOperator {
                 )?;
                 Self::fmt_optional_alias(f, alias)
             }
-            PipeOperator::Join(join) => write!(f, "{}", join)
+            PipeOperator::Join(join) => write!(f, "{}", join),
         }
     }
 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2751,6 +2751,12 @@ pub enum PipeOperator {
         unpivot_columns: Vec<Ident>,
         alias: Option<Ident>,
     },
+    /// Joins the input table with another table.
+    ///
+    /// Syntax: `|> [JOIN_TYPE] JOIN <table> [alias] ON <condition>` or `|> [JOIN_TYPE] JOIN <table> [alias] USING (<columns>)`
+    ///
+    /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#join_pipe_operator>
+    Join(Join),
 }
 
 impl fmt::Display for PipeOperator {
@@ -2855,6 +2861,7 @@ impl fmt::Display for PipeOperator {
                 )?;
                 Self::fmt_optional_alias(f, alias)
             }
+            PipeOperator::Join(join) => write!(f, "{}", join)
         }
     }
 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2812,69 +2812,15 @@ impl fmt::Display for PipeOperator {
             PipeOperator::Union {
                 set_quantifier,
                 queries,
-            } => {
-                write!(f, "UNION")?;
-                match set_quantifier {
-                    SetQuantifier::All => write!(f, " ALL")?,
-                    SetQuantifier::Distinct => write!(f, " DISTINCT")?,
-                    SetQuantifier::None => {}
-                    _ => {
-                        write!(f, " {}", set_quantifier)?;
-                    }
-                }
-                write!(f, " ")?;
-                for (i, query) in queries.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "({})", query)?;
-                }
-                Ok(())
-            }
+            } => Self::fmt_set_operation(f, "UNION", set_quantifier, queries),
             PipeOperator::Intersect {
                 set_quantifier,
                 queries,
-            } => {
-                write!(f, "INTERSECT")?;
-                match set_quantifier {
-                    SetQuantifier::All => write!(f, " ALL")?,
-                    SetQuantifier::Distinct => write!(f, " DISTINCT")?,
-                    SetQuantifier::None => {}
-                    _ => {
-                        write!(f, " {}", set_quantifier)?;
-                    }
-                }
-                write!(f, " ")?;
-                for (i, query) in queries.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "({})", query)?;
-                }
-                Ok(())
-            }
+            } => Self::fmt_set_operation(f, "INTERSECT", set_quantifier, queries),
             PipeOperator::Except {
                 set_quantifier,
                 queries,
-            } => {
-                write!(f, "EXCEPT")?;
-                match set_quantifier {
-                    SetQuantifier::All => write!(f, " ALL")?,
-                    SetQuantifier::Distinct => write!(f, " DISTINCT")?,
-                    SetQuantifier::None => {}
-                    _ => {
-                        write!(f, " {}", set_quantifier)?;
-                    }
-                }
-                write!(f, " ")?;
-                for (i, query) in queries.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ", ")?;
-                    }
-                    write!(f, "({})", query)?;
-                }
-                Ok(())
-            }
+            } => Self::fmt_set_operation(f, "EXCEPT", set_quantifier, queries),
             PipeOperator::Call { function, alias } => {
                 write!(f, "CALL {}", function)?;
                 if let Some(alias) = alias {
@@ -2919,6 +2865,34 @@ impl fmt::Display for PipeOperator {
                 Ok(())
             }
         }
+    }
+}
+
+impl PipeOperator {
+    /// Helper function to format set operations (UNION, INTERSECT, EXCEPT) with queries
+    fn fmt_set_operation(
+        f: &mut fmt::Formatter<'_>,
+        operation: &str,
+        set_quantifier: &SetQuantifier,
+        queries: &[Box<Query>],
+    ) -> fmt::Result {
+        write!(f, "{}", operation)?;
+        match set_quantifier {
+            SetQuantifier::All => write!(f, " ALL")?,
+            SetQuantifier::Distinct => write!(f, " DISTINCT")?,
+            SetQuantifier::None => {}
+            _ => {
+                write!(f, " {}", set_quantifier)?;
+            }
+        }
+        write!(f, " ")?;
+        for (i, query) in queries.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "({})", query)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2734,6 +2734,20 @@ pub enum PipeOperator {
         value_source: PivotValueSource,
         alias: Option<Ident>,
     },
+    /// The `UNPIVOT` pipe operator transforms columns into rows.
+    ///
+    /// Syntax:
+    /// ```sql
+    /// |> UNPIVOT(value_column FOR name_column IN (column1, column2, ...)) [alias]
+    /// ```
+    ///
+    /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#unpivot_pipe_operator>
+    Unpivot {
+        value_column: Ident,
+        name_column: Ident,
+        unpivot_columns: Vec<Ident>,
+        alias: Option<Ident>,
+    },
 }
 
 impl fmt::Display for PipeOperator {
@@ -2877,6 +2891,24 @@ impl fmt::Display for PipeOperator {
                     display_comma_separated(aggregate_functions),
                     Expr::CompoundIdentifier(value_column.to_vec()),
                     value_source
+                )?;
+                if let Some(alias) = alias {
+                    write!(f, " AS {}", alias)?;
+                }
+                Ok(())
+            }
+            PipeOperator::Unpivot {
+                value_column,
+                name_column,
+                unpivot_columns,
+                alias,
+            } => {
+                write!(
+                    f,
+                    "UNPIVOT({} FOR {} IN ({}))",
+                    value_column,
+                    name_column,
+                    display_comma_separated(unpivot_columns)
                 )?;
                 if let Some(alias) = alias {
                     write!(f, " AS {}", alias)?;

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2697,7 +2697,7 @@ pub enum PipeOperator {
     /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#union_pipe_operator>
     Union {
         set_quantifier: SetQuantifier,
-        queries: Vec<Box<Query>>,
+        queries: Vec<Query>,
     },
     /// Returns only the rows that are present in both the input table and the specified tables.
     ///
@@ -2706,7 +2706,7 @@ pub enum PipeOperator {
     /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#intersect_pipe_operator>
     Intersect {
         set_quantifier: SetQuantifier,
-        queries: Vec<Box<Query>>,
+        queries: Vec<Query>,
     },
     /// Returns only the rows that are present in the input table but not in the specified tables.
     ///
@@ -2715,7 +2715,7 @@ pub enum PipeOperator {
     /// See more at <https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#except_pipe_operator>
     Except {
         set_quantifier: SetQuantifier,
-        queries: Vec<Box<Query>>,
+        queries: Vec<Query>,
     },
     /// Calls a table function or procedure that returns a table.
     ///
@@ -2873,7 +2873,7 @@ impl PipeOperator {
         f: &mut fmt::Formatter<'_>,
         operation: &str,
         set_quantifier: &SetQuantifier,
-        queries: &[Box<Query>],
+        queries: &[Query],
     ) -> fmt::Result {
         write!(f, "{}", operation)?;
         match set_quantifier {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11336,7 +11336,11 @@ impl<'a> Parser<'a> {
                     let relation = self.parse_table_factor()?;
                     let constraint = self.parse_join_constraint(false)?;
                     if matches!(constraint, JoinConstraint::None) {
-                        let join_type = if outer { "LEFT OUTER JOIN" } else { "LEFT JOIN" };
+                        let join_type = if outer {
+                            "LEFT OUTER JOIN"
+                        } else {
+                            "LEFT JOIN"
+                        };
                         return Err(ParserError::ParserError(format!(
                             "{} in pipe syntax requires ON or USING clause",
                             join_type
@@ -11359,7 +11363,11 @@ impl<'a> Parser<'a> {
                     let relation = self.parse_table_factor()?;
                     let constraint = self.parse_join_constraint(false)?;
                     if matches!(constraint, JoinConstraint::None) {
-                        let join_type = if outer { "RIGHT OUTER JOIN" } else { "RIGHT JOIN" };
+                        let join_type = if outer {
+                            "RIGHT OUTER JOIN"
+                        } else {
+                            "RIGHT JOIN"
+                        };
                         return Err(ParserError::ParserError(format!(
                             "{} in pipe syntax requires ON or USING clause",
                             join_type

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11207,7 +11207,6 @@ impl<'a> Parser<'a> {
                     pipe_operators.push(PipeOperator::Rename { mappings });
                 }
                 Keyword::UNION => {
-                    // Reuse existing set quantifier parser for consistent BY NAME support
                     let set_quantifier = self.parse_set_quantifier(&Some(SetOperator::Union));
                     let queries = self.parse_pipe_operator_queries()?;
                     pipe_operators.push(PipeOperator::Union {
@@ -11235,7 +11234,6 @@ impl<'a> Parser<'a> {
                 Keyword::CALL => {
                     let function_name = self.parse_object_name(false)?;
                     let function_expr = self.parse_function(function_name)?;
-                    // Extract Function from Expr::Function
                     if let Expr::Function(function) = function_expr {
                         let alias = self.parse_optional_pipe_alias()?;
                         pipe_operators.push(PipeOperator::Call { function, alias });

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11157,7 +11157,8 @@ impl<'a> Parser<'a> {
                     pipe_operators.push(PipeOperator::TableSample { sample });
                 }
                 Keyword::RENAME => {
-                    let mappings = self.parse_comma_separated(Parser::parse_identifier_with_optional_alias)?;
+                    let mappings =
+                        self.parse_comma_separated(Parser::parse_identifier_with_optional_alias)?;
                     pipe_operators.push(PipeOperator::Rename { mappings });
                 }
                 Keyword::UNION => {
@@ -11171,19 +11172,23 @@ impl<'a> Parser<'a> {
                         parser.expect_token(&Token::RParen)?;
                         Ok(query)
                     })?;
-                    pipe_operators.push(PipeOperator::Union { set_quantifier, queries });
+                    pipe_operators.push(PipeOperator::Union {
+                        set_quantifier,
+                        queries,
+                    });
                 }
                 Keyword::INTERSECT => {
                     // BigQuery INTERSECT pipe operator requires DISTINCT modifier
-                    let set_quantifier = if self.parse_keywords(&[Keyword::DISTINCT, Keyword::BY, Keyword::NAME]) {
-                        SetQuantifier::DistinctByName
-                    } else if self.parse_keyword(Keyword::DISTINCT) {
-                        SetQuantifier::Distinct
-                    } else {
-                        return Err(ParserError::ParserError(
-                            "INTERSECT pipe operator requires DISTINCT modifier".to_string()
-                        ));
-                    };
+                    let set_quantifier =
+                        if self.parse_keywords(&[Keyword::DISTINCT, Keyword::BY, Keyword::NAME]) {
+                            SetQuantifier::DistinctByName
+                        } else if self.parse_keyword(Keyword::DISTINCT) {
+                            SetQuantifier::Distinct
+                        } else {
+                            return Err(ParserError::ParserError(
+                                "INTERSECT pipe operator requires DISTINCT modifier".to_string(),
+                            ));
+                        };
                     // BigQuery INTERSECT pipe operator requires parentheses around queries
                     // Parse comma-separated list of parenthesized queries
                     let queries = self.parse_comma_separated(|parser| {
@@ -11192,19 +11197,23 @@ impl<'a> Parser<'a> {
                         parser.expect_token(&Token::RParen)?;
                         Ok(query)
                     })?;
-                    pipe_operators.push(PipeOperator::Intersect { set_quantifier, queries });
+                    pipe_operators.push(PipeOperator::Intersect {
+                        set_quantifier,
+                        queries,
+                    });
                 }
                 Keyword::EXCEPT => {
                     // BigQuery EXCEPT pipe operator requires DISTINCT modifier
-                    let set_quantifier = if self.parse_keywords(&[Keyword::DISTINCT, Keyword::BY, Keyword::NAME]) {
-                        SetQuantifier::DistinctByName
-                    } else if self.parse_keyword(Keyword::DISTINCT) {
-                        SetQuantifier::Distinct
-                    } else {
-                        return Err(ParserError::ParserError(
-                            "EXCEPT pipe operator requires DISTINCT modifier".to_string()
-                        ));
-                    };
+                    let set_quantifier =
+                        if self.parse_keywords(&[Keyword::DISTINCT, Keyword::BY, Keyword::NAME]) {
+                            SetQuantifier::DistinctByName
+                        } else if self.parse_keyword(Keyword::DISTINCT) {
+                            SetQuantifier::Distinct
+                        } else {
+                            return Err(ParserError::ParserError(
+                                "EXCEPT pipe operator requires DISTINCT modifier".to_string(),
+                            ));
+                        };
                     // BigQuery EXCEPT pipe operator requires parentheses around queries
                     // Parse comma-separated list of parenthesized queries
                     let queries = self.parse_comma_separated(|parser| {
@@ -11213,7 +11222,10 @@ impl<'a> Parser<'a> {
                         parser.expect_token(&Token::RParen)?;
                         Ok(query)
                     })?;
-                    pipe_operators.push(PipeOperator::Except { set_quantifier, queries });
+                    pipe_operators.push(PipeOperator::Except {
+                        set_quantifier,
+                        queries,
+                    });
                 }
                 Keyword::CALL => {
                     let function_name = self.parse_object_name(false)?;
@@ -11229,13 +11241,14 @@ impl<'a> Parser<'a> {
                         pipe_operators.push(PipeOperator::Call { function, alias });
                     } else {
                         return Err(ParserError::ParserError(
-                            "Expected function call after CALL".to_string()
+                            "Expected function call after CALL".to_string(),
                         ));
                     }
                 }
                 Keyword::PIVOT => {
                     self.expect_token(&Token::LParen)?;
-                    let aggregate_functions = self.parse_comma_separated(Self::parse_aliased_function_call)?;
+                    let aggregate_functions =
+                        self.parse_comma_separated(Self::parse_aliased_function_call)?;
                     self.expect_keyword_is(Keyword::FOR)?;
                     let value_column = self.parse_period_separated(|p| p.parse_identifier())?;
                     self.expect_keyword_is(Keyword::IN)?;
@@ -11251,7 +11264,9 @@ impl<'a> Parser<'a> {
                     } else if self.peek_sub_query() {
                         PivotValueSource::Subquery(self.parse_query()?)
                     } else {
-                        PivotValueSource::List(self.parse_comma_separated(Self::parse_expr_with_alias)?)
+                        PivotValueSource::List(
+                            self.parse_comma_separated(Self::parse_expr_with_alias)?,
+                        )
                     };
                     self.expect_token(&Token::RParen)?;
                     self.expect_token(&Token::RParen)?;
@@ -11281,24 +11296,24 @@ impl<'a> Parser<'a> {
                 Keyword::UNPIVOT => {
                     // Parse UNPIVOT(value_column FOR name_column IN (column1, column2, ...)) [alias]
                     self.expect_token(&Token::LParen)?;
-                    
+
                     // Parse value_column
                     let value_column = self.parse_identifier()?;
-                    
+
                     // Parse FOR keyword
                     self.expect_keyword(Keyword::FOR)?;
-                    
+
                     // Parse name_column
                     let name_column = self.parse_identifier()?;
-                    
+
                     // Parse IN keyword
                     self.expect_keyword(Keyword::IN)?;
-                    
+
                     // Parse (column1, column2, ...)
                     self.expect_token(&Token::LParen)?;
                     let unpivot_columns = self.parse_comma_separated(Parser::parse_identifier)?;
                     self.expect_token(&Token::RParen)?;
-                    
+
                     self.expect_token(&Token::RParen)?;
 
                     // Parse optional alias (with or without AS keyword)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -195,9 +195,6 @@ const EOF_TOKEN: TokenWithSpan = TokenWithSpan {
     },
 };
 
-// Error message constant for pipe operators that require DISTINCT
-const EXPECTED_FUNCTION_CALL_MSG: &str = "Expected function call after CALL";
-
 /// Composite types declarations using angle brackets syntax can be arbitrary
 /// nested such that the following declaration is possible:
 ///      `ARRAY<ARRAY<INT>>`
@@ -9969,15 +9966,19 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse set quantifier for pipe operators that require DISTINCT (INTERSECT, EXCEPT)
-    fn parse_distinct_required_set_quantifier(&mut self, operator_name: &str) -> Result<SetQuantifier, ParserError> {
+    fn parse_distinct_required_set_quantifier(
+        &mut self,
+        operator_name: &str,
+    ) -> Result<SetQuantifier, ParserError> {
         if self.parse_keywords(&[Keyword::DISTINCT, Keyword::BY, Keyword::NAME]) {
             Ok(SetQuantifier::DistinctByName)
         } else if self.parse_keyword(Keyword::DISTINCT) {
             Ok(SetQuantifier::Distinct)
         } else {
-            Err(ParserError::ParserError(
-                format!("{} pipe operator requires DISTINCT modifier", operator_name),
-            ))
+            Err(ParserError::ParserError(format!(
+                "{} pipe operator requires DISTINCT modifier",
+                operator_name
+            )))
         }
     }
 
@@ -11215,7 +11216,8 @@ impl<'a> Parser<'a> {
                     });
                 }
                 Keyword::INTERSECT => {
-                    let set_quantifier = self.parse_distinct_required_set_quantifier("INTERSECT")?;
+                    let set_quantifier =
+                        self.parse_distinct_required_set_quantifier("INTERSECT")?;
                     let queries = self.parse_pipe_operator_queries()?;
                     pipe_operators.push(PipeOperator::Intersect {
                         set_quantifier,
@@ -11239,7 +11241,7 @@ impl<'a> Parser<'a> {
                         pipe_operators.push(PipeOperator::Call { function, alias });
                     } else {
                         return Err(ParserError::ParserError(
-                            EXPECTED_FUNCTION_CALL_MSG.to_string(),
+                            "Expected function call after CALL".to_string(),
                         ));
                     }
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9956,12 +9956,12 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse comma-separated list of parenthesized queries for pipe operators
-    fn parse_pipe_operator_queries(&mut self) -> Result<Vec<Box<Query>>, ParserError> {
+    fn parse_pipe_operator_queries(&mut self) -> Result<Vec<Query>, ParserError> {
         self.parse_comma_separated(|parser| {
             parser.expect_token(&Token::LParen)?;
             let query = parser.parse_query()?;
             parser.expect_token(&Token::RParen)?;
-            Ok(query)
+            Ok(*query)
         })
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9988,14 +9988,7 @@ impl<'a> Parser<'a> {
             Some(self.parse_identifier()).transpose()
         } else {
             // Check if the next token is an identifier (implicit alias)
-            let checkpoint = self.index;
-            match self.parse_identifier() {
-                Ok(ident) => Ok(Some(ident)),
-                Err(_) => {
-                    self.index = checkpoint; // Rewind on failure
-                    Ok(None)
-                }
-            }
+            self.maybe_parse(|parser| parser.parse_identifier())
         }
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9965,7 +9965,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Parse set quantifier for pipe operators that require DISTINCT (INTERSECT, EXCEPT)
+    /// Parse set quantifier for pipe operators that require DISTINCT. E.g. INTERSECT and EXCEPT
     fn parse_distinct_required_set_quantifier(
         &mut self,
         operator_name: &str,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11272,22 +11272,12 @@ impl<'a> Parser<'a> {
                     });
                 }
                 Keyword::UNPIVOT => {
-                    // Parse UNPIVOT(value_column FOR name_column IN (column1, column2, ...)) [alias]
                     self.expect_token(&Token::LParen)?;
-
-                    // Parse value_column
                     let value_column = self.parse_identifier()?;
-
-                    // Parse FOR keyword
                     self.expect_keyword(Keyword::FOR)?;
-
-                    // Parse name_column
                     let name_column = self.parse_identifier()?;
-
-                    // Parse IN keyword
                     self.expect_keyword(Keyword::IN)?;
 
-                    // Parse (column1, column2, ...)
                     self.expect_token(&Token::LParen)?;
                     let unpivot_columns = self.parse_comma_separated(Parser::parse_identifier)?;
                     self.expect_token(&Token::RParen)?;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15205,88 +15205,113 @@ fn parse_pipeline_operator() {
     dialects.verified_stmt("SELECT * FROM users |> UNION ALL (SELECT * FROM admins)");
     dialects.verified_stmt("SELECT * FROM users |> UNION DISTINCT (SELECT * FROM admins)");
     dialects.verified_stmt("SELECT * FROM users |> UNION (SELECT * FROM admins)");
-    
+
     // union pipe operator with multiple queries
-    dialects.verified_stmt("SELECT * FROM users |> UNION ALL (SELECT * FROM admins), (SELECT * FROM guests)");
+    dialects.verified_stmt(
+        "SELECT * FROM users |> UNION ALL (SELECT * FROM admins), (SELECT * FROM guests)",
+    );
     dialects.verified_stmt("SELECT * FROM users |> UNION DISTINCT (SELECT * FROM admins), (SELECT * FROM guests), (SELECT * FROM employees)");
-    dialects.verified_stmt("SELECT * FROM users |> UNION (SELECT * FROM admins), (SELECT * FROM guests)");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM users |> UNION (SELECT * FROM admins), (SELECT * FROM guests)",
+    );
+
     // union pipe operator with BY NAME modifier
     dialects.verified_stmt("SELECT * FROM users |> UNION BY NAME (SELECT * FROM admins)");
     dialects.verified_stmt("SELECT * FROM users |> UNION ALL BY NAME (SELECT * FROM admins)");
     dialects.verified_stmt("SELECT * FROM users |> UNION DISTINCT BY NAME (SELECT * FROM admins)");
-    
+
     // union pipe operator with BY NAME and multiple queries
-    dialects.verified_stmt("SELECT * FROM users |> UNION BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
+    dialects.verified_stmt(
+        "SELECT * FROM users |> UNION BY NAME (SELECT * FROM admins), (SELECT * FROM guests)",
+    );
 
     // intersect pipe operator (BigQuery requires DISTINCT modifier for INTERSECT)
     dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT (SELECT * FROM admins)");
-    
+
     // intersect pipe operator with BY NAME modifier
-    dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT BY NAME (SELECT * FROM admins)");
-    
+    dialects
+        .verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT BY NAME (SELECT * FROM admins)");
+
     // intersect pipe operator with multiple queries
-    dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT (SELECT * FROM admins), (SELECT * FROM guests)");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM users |> INTERSECT DISTINCT (SELECT * FROM admins), (SELECT * FROM guests)",
+    );
+
     // intersect pipe operator with BY NAME and multiple queries
     dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
 
     // except pipe operator (BigQuery requires DISTINCT modifier for EXCEPT)
     dialects.verified_stmt("SELECT * FROM users |> EXCEPT DISTINCT (SELECT * FROM admins)");
-    
-    // except pipe operator with BY NAME modifier  
+
+    // except pipe operator with BY NAME modifier
     dialects.verified_stmt("SELECT * FROM users |> EXCEPT DISTINCT BY NAME (SELECT * FROM admins)");
-    
+
     // except pipe operator with multiple queries
-    dialects.verified_stmt("SELECT * FROM users |> EXCEPT DISTINCT (SELECT * FROM admins), (SELECT * FROM guests)");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM users |> EXCEPT DISTINCT (SELECT * FROM admins), (SELECT * FROM guests)",
+    );
+
     // except pipe operator with BY NAME and multiple queries
     dialects.verified_stmt("SELECT * FROM users |> EXCEPT DISTINCT BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
 
     // call pipe operator
     dialects.verified_stmt("SELECT * FROM users |> CALL my_function()");
     dialects.verified_stmt("SELECT * FROM users |> CALL process_data(5, 'test')");
-    dialects.verified_stmt("SELECT * FROM users |> CALL namespace.function_name(col1, col2, 'literal')");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM users |> CALL namespace.function_name(col1, col2, 'literal')",
+    );
+
     // call pipe operator with complex arguments
     dialects.verified_stmt("SELECT * FROM users |> CALL transform_data(col1 + col2)");
     dialects.verified_stmt("SELECT * FROM users |> CALL analyze_data('param1', 100, true)");
-    
+
     // call pipe operator with aliases
     dialects.verified_stmt("SELECT * FROM input_table |> CALL tvf1(arg1) AS al");
     dialects.verified_stmt("SELECT * FROM users |> CALL process_data(5) AS result_table");
     dialects.verified_stmt("SELECT * FROM users |> CALL namespace.func() AS my_alias");
-    
+
     // multiple call pipe operators in sequence
     dialects.verified_stmt("SELECT * FROM input_table |> CALL tvf1(arg1) |> CALL tvf2(arg2, arg3)");
-    dialects.verified_stmt("SELECT * FROM data |> CALL transform(col1) |> CALL validate() |> CALL process(param)");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM data |> CALL transform(col1) |> CALL validate() |> CALL process(param)",
+    );
+
     // multiple call pipe operators with aliases
-    dialects.verified_stmt("SELECT * FROM input_table |> CALL tvf1(arg1) AS step1 |> CALL tvf2(arg2) AS step2");
-    dialects.verified_stmt("SELECT * FROM data |> CALL preprocess() AS clean_data |> CALL analyze(mode) AS results");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM input_table |> CALL tvf1(arg1) AS step1 |> CALL tvf2(arg2) AS step2",
+    );
+    dialects.verified_stmt(
+        "SELECT * FROM data |> CALL preprocess() AS clean_data |> CALL analyze(mode) AS results",
+    );
+
     // call pipe operators mixed with other pipe operators
-    dialects.verified_stmt("SELECT * FROM users |> CALL transform() |> WHERE status = 'active' |> CALL process(param)");
-    dialects.verified_stmt("SELECT * FROM data |> CALL preprocess() AS clean |> SELECT col1, col2 |> CALL validate()");
+    dialects.verified_stmt(
+        "SELECT * FROM users |> CALL transform() |> WHERE status = 'active' |> CALL process(param)",
+    );
+    dialects.verified_stmt(
+        "SELECT * FROM data |> CALL preprocess() AS clean |> SELECT col1, col2 |> CALL validate()",
+    );
 
     // pivot pipe operator
-    dialects.verified_stmt("SELECT * FROM monthly_sales |> PIVOT(SUM(amount) FOR quarter IN ('Q1', 'Q2', 'Q3', 'Q4'))");
+    dialects.verified_stmt(
+        "SELECT * FROM monthly_sales |> PIVOT(SUM(amount) FOR quarter IN ('Q1', 'Q2', 'Q3', 'Q4'))",
+    );
     dialects.verified_stmt("SELECT * FROM sales_data |> PIVOT(AVG(revenue) FOR region IN ('North', 'South', 'East', 'West'))");
-    
+
     // pivot pipe operator with multiple aggregate functions
     dialects.verified_stmt("SELECT * FROM data |> PIVOT(SUM(sales) AS total_sales, COUNT(*) AS num_transactions FOR month IN ('Jan', 'Feb', 'Mar'))");
-    
+
     // pivot pipe operator with compound column names
     dialects.verified_stmt("SELECT * FROM sales |> PIVOT(SUM(amount) FOR product.category IN ('Electronics', 'Clothing'))");
-    
+
     // pivot pipe operator mixed with other pipe operators
     dialects.verified_stmt("SELECT * FROM sales_data |> WHERE year = 2023 |> PIVOT(SUM(revenue) FOR quarter IN ('Q1', 'Q2', 'Q3', 'Q4'))");
-    
+
     // pivot pipe operator with aliases
     dialects.verified_stmt("SELECT * FROM monthly_sales |> PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2')) AS quarterly_sales");
     dialects.verified_stmt("SELECT * FROM data |> PIVOT(AVG(price) FOR category IN ('A', 'B', 'C')) AS avg_by_category");
     dialects.verified_stmt("SELECT * FROM sales |> PIVOT(COUNT(*) AS transactions, SUM(amount) AS total FOR region IN ('North', 'South')) AS regional_summary");
-    
+
     // pivot pipe operator with implicit aliases (without AS keyword)
     dialects.verified_query_with_canonical(
         "SELECT * FROM monthly_sales |> PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2')) quarterly_sales",
@@ -15298,22 +15323,29 @@ fn parse_pipeline_operator() {
     );
 
     // unpivot pipe operator basic usage
-    dialects.verified_stmt("SELECT * FROM sales |> UNPIVOT(revenue FOR quarter IN (Q1, Q2, Q3, Q4))");
+    dialects
+        .verified_stmt("SELECT * FROM sales |> UNPIVOT(revenue FOR quarter IN (Q1, Q2, Q3, Q4))");
     dialects.verified_stmt("SELECT * FROM data |> UNPIVOT(value FOR category IN (A, B, C))");
-    dialects.verified_stmt("SELECT * FROM metrics |> UNPIVOT(measurement FOR metric_type IN (cpu, memory, disk))");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM metrics |> UNPIVOT(measurement FOR metric_type IN (cpu, memory, disk))",
+    );
+
     // unpivot pipe operator with multiple columns
     dialects.verified_stmt("SELECT * FROM quarterly_sales |> UNPIVOT(amount FOR period IN (jan, feb, mar, apr, may, jun))");
-    dialects.verified_stmt("SELECT * FROM report |> UNPIVOT(score FOR subject IN (math, science, english, history))");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM report |> UNPIVOT(score FOR subject IN (math, science, english, history))",
+    );
+
     // unpivot pipe operator mixed with other pipe operators
     dialects.verified_stmt("SELECT * FROM sales_data |> WHERE year = 2023 |> UNPIVOT(revenue FOR quarter IN (Q1, Q2, Q3, Q4))");
-    
+
     // unpivot pipe operator with aliases
     dialects.verified_stmt("SELECT * FROM quarterly_sales |> UNPIVOT(amount FOR period IN (Q1, Q2)) AS unpivoted_sales");
-    dialects.verified_stmt("SELECT * FROM data |> UNPIVOT(value FOR category IN (A, B, C)) AS transformed_data");
+    dialects.verified_stmt(
+        "SELECT * FROM data |> UNPIVOT(value FOR category IN (A, B, C)) AS transformed_data",
+    );
     dialects.verified_stmt("SELECT * FROM metrics |> UNPIVOT(measurement FOR metric_type IN (cpu, memory)) AS metric_measurements");
-    
+
     // unpivot pipe operator with implicit aliases (without AS keyword)
     dialects.verified_query_with_canonical(
         "SELECT * FROM quarterly_sales |> UNPIVOT(amount FOR period IN (Q1, Q2)) unpivoted_sales",
@@ -15337,142 +15369,162 @@ fn parse_pipeline_operator_negative_tests() {
     // Test that plain EXCEPT without DISTINCT fails
     assert_eq!(
         ParserError::ParserError("EXCEPT pipe operator requires DISTINCT modifier".to_string()),
-        dialects.parse_sql_statements("SELECT * FROM users |> EXCEPT (SELECT * FROM admins)").unwrap_err()
+        dialects
+            .parse_sql_statements("SELECT * FROM users |> EXCEPT (SELECT * FROM admins)")
+            .unwrap_err()
     );
 
-    // Test that EXCEPT ALL fails  
+    // Test that EXCEPT ALL fails
     assert_eq!(
         ParserError::ParserError("EXCEPT pipe operator requires DISTINCT modifier".to_string()),
-        dialects.parse_sql_statements("SELECT * FROM users |> EXCEPT ALL (SELECT * FROM admins)").unwrap_err()
+        dialects
+            .parse_sql_statements("SELECT * FROM users |> EXCEPT ALL (SELECT * FROM admins)")
+            .unwrap_err()
     );
 
     // Test that EXCEPT BY NAME without DISTINCT fails
     assert_eq!(
         ParserError::ParserError("EXCEPT pipe operator requires DISTINCT modifier".to_string()),
-        dialects.parse_sql_statements("SELECT * FROM users |> EXCEPT BY NAME (SELECT * FROM admins)").unwrap_err()
+        dialects
+            .parse_sql_statements("SELECT * FROM users |> EXCEPT BY NAME (SELECT * FROM admins)")
+            .unwrap_err()
     );
 
     // Test that EXCEPT ALL BY NAME fails
     assert_eq!(
         ParserError::ParserError("EXCEPT pipe operator requires DISTINCT modifier".to_string()),
-        dialects.parse_sql_statements("SELECT * FROM users |> EXCEPT ALL BY NAME (SELECT * FROM admins)").unwrap_err()
+        dialects
+            .parse_sql_statements(
+                "SELECT * FROM users |> EXCEPT ALL BY NAME (SELECT * FROM admins)"
+            )
+            .unwrap_err()
     );
 
     // Test that plain INTERSECT without DISTINCT fails
     assert_eq!(
         ParserError::ParserError("INTERSECT pipe operator requires DISTINCT modifier".to_string()),
-        dialects.parse_sql_statements("SELECT * FROM users |> INTERSECT (SELECT * FROM admins)").unwrap_err()
+        dialects
+            .parse_sql_statements("SELECT * FROM users |> INTERSECT (SELECT * FROM admins)")
+            .unwrap_err()
     );
 
-    // Test that INTERSECT ALL fails  
+    // Test that INTERSECT ALL fails
     assert_eq!(
         ParserError::ParserError("INTERSECT pipe operator requires DISTINCT modifier".to_string()),
-        dialects.parse_sql_statements("SELECT * FROM users |> INTERSECT ALL (SELECT * FROM admins)").unwrap_err()
+        dialects
+            .parse_sql_statements("SELECT * FROM users |> INTERSECT ALL (SELECT * FROM admins)")
+            .unwrap_err()
     );
 
     // Test that INTERSECT BY NAME without DISTINCT fails
     assert_eq!(
         ParserError::ParserError("INTERSECT pipe operator requires DISTINCT modifier".to_string()),
-        dialects.parse_sql_statements("SELECT * FROM users |> INTERSECT BY NAME (SELECT * FROM admins)").unwrap_err()
+        dialects
+            .parse_sql_statements("SELECT * FROM users |> INTERSECT BY NAME (SELECT * FROM admins)")
+            .unwrap_err()
     );
 
     // Test that INTERSECT ALL BY NAME fails
     assert_eq!(
         ParserError::ParserError("INTERSECT pipe operator requires DISTINCT modifier".to_string()),
-        dialects.parse_sql_statements("SELECT * FROM users |> INTERSECT ALL BY NAME (SELECT * FROM admins)").unwrap_err()
+        dialects
+            .parse_sql_statements(
+                "SELECT * FROM users |> INTERSECT ALL BY NAME (SELECT * FROM admins)"
+            )
+            .unwrap_err()
     );
 
     // Test that CALL without function name fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> CALL").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> CALL")
+        .is_err());
 
-    // Test that CALL without parentheses fails  
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> CALL my_function").is_err()
-    );
+    // Test that CALL without parentheses fails
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> CALL my_function")
+        .is_err());
 
     // Test that CALL with invalid function syntax fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> CALL 123invalid").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> CALL 123invalid")
+        .is_err());
 
     // Test that CALL with malformed arguments fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> CALL my_function(,)").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> CALL my_function(,)")
+        .is_err());
 
     // Test that CALL with invalid alias syntax fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> CALL my_function() AS").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> CALL my_function() AS")
+        .is_err());
 
     // Test that PIVOT without parentheses fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> PIVOT SUM(amount) FOR month IN ('Jan')").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> PIVOT SUM(amount) FOR month IN ('Jan')")
+        .is_err());
 
     // Test that PIVOT without FOR keyword fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> PIVOT(SUM(amount) month IN ('Jan'))").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> PIVOT(SUM(amount) month IN ('Jan'))")
+        .is_err());
 
     // Test that PIVOT without IN keyword fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> PIVOT(SUM(amount) FOR month ('Jan'))").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> PIVOT(SUM(amount) FOR month ('Jan'))")
+        .is_err());
 
     // Test that PIVOT with empty IN list fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> PIVOT(SUM(amount) FOR month IN ())").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> PIVOT(SUM(amount) FOR month IN ())")
+        .is_err());
 
     // Test that PIVOT with invalid alias syntax fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> PIVOT(SUM(amount) FOR month IN ('Jan')) AS").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> PIVOT(SUM(amount) FOR month IN ('Jan')) AS")
+        .is_err());
 
     // Test UNPIVOT negative cases
-    
+
     // Test that UNPIVOT without parentheses fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> UNPIVOT value FOR name IN col1, col2").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> UNPIVOT value FOR name IN col1, col2")
+        .is_err());
 
     // Test that UNPIVOT without FOR keyword fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> UNPIVOT(value name IN (col1, col2))").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> UNPIVOT(value name IN (col1, col2))")
+        .is_err());
 
     // Test that UNPIVOT without IN keyword fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR name (col1, col2))").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR name (col1, col2))")
+        .is_err());
 
     // Test that UNPIVOT with missing value column fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> UNPIVOT(FOR name IN (col1, col2))").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> UNPIVOT(FOR name IN (col1, col2))")
+        .is_err());
 
     // Test that UNPIVOT with missing name column fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR IN (col1, col2))").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR IN (col1, col2))")
+        .is_err());
 
     // Test that UNPIVOT with empty IN list fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR name IN ())").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR name IN ())")
+        .is_err());
 
     // Test that UNPIVOT with invalid alias syntax fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR name IN (col1, col2)) AS").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR name IN (col1, col2)) AS")
+        .is_err());
 
     // Test that UNPIVOT with missing closing parenthesis fails
-    assert!(
-        dialects.parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR name IN (col1, col2)").is_err()
-    );
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR name IN (col1, col2)")
+        .is_err());
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15201,6 +15201,24 @@ fn parse_pipeline_operator() {
         "SELECT * FROM users |> RENAME id AS user_id",
     );
 
+    // union pipe operator
+    dialects.verified_stmt("SELECT * FROM users |> UNION ALL (SELECT * FROM admins)");
+    dialects.verified_stmt("SELECT * FROM users |> UNION DISTINCT (SELECT * FROM admins)");
+    dialects.verified_stmt("SELECT * FROM users |> UNION (SELECT * FROM admins)");
+    
+    // union pipe operator with multiple queries
+    dialects.verified_stmt("SELECT * FROM users |> UNION ALL (SELECT * FROM admins), (SELECT * FROM guests)");
+    dialects.verified_stmt("SELECT * FROM users |> UNION DISTINCT (SELECT * FROM admins), (SELECT * FROM guests), (SELECT * FROM employees)");
+    dialects.verified_stmt("SELECT * FROM users |> UNION (SELECT * FROM admins), (SELECT * FROM guests)");
+    
+    // union pipe operator with BY NAME modifier
+    dialects.verified_stmt("SELECT * FROM users |> UNION BY NAME (SELECT * FROM admins)");
+    dialects.verified_stmt("SELECT * FROM users |> UNION ALL BY NAME (SELECT * FROM admins)");
+    dialects.verified_stmt("SELECT * FROM users |> UNION DISTINCT BY NAME (SELECT * FROM admins)");
+    
+    // union pipe operator with BY NAME and multiple queries
+    dialects.verified_stmt("SELECT * FROM users |> UNION BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
+
     // many pipes
     dialects.verified_stmt(
         "SELECT * FROM CustomerOrders |> AGGREGATE SUM(cost) AS total_cost GROUP BY customer_id, state, item_type |> EXTEND COUNT(*) OVER (PARTITION BY customer_id) AS num_orders |> WHERE num_orders > 1 |> AGGREGATE AVG(total_cost) AS average GROUP BY state DESC, item_type ASC",

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15364,25 +15364,29 @@ fn parse_pipeline_operator() {
     // join pipe operator - INNER JOIN
     dialects.verified_stmt("SELECT * FROM users |> JOIN orders ON users.id = orders.user_id");
     dialects.verified_stmt("SELECT * FROM users |> INNER JOIN orders ON users.id = orders.user_id");
-    
+
     // join pipe operator - LEFT JOIN
     dialects.verified_stmt("SELECT * FROM users |> LEFT JOIN orders ON users.id = orders.user_id");
-    dialects.verified_stmt("SELECT * FROM users |> LEFT OUTER JOIN orders ON users.id = orders.user_id");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM users |> LEFT OUTER JOIN orders ON users.id = orders.user_id",
+    );
+
     // join pipe operator - RIGHT JOIN
     dialects.verified_stmt("SELECT * FROM users |> RIGHT JOIN orders ON users.id = orders.user_id");
-    dialects.verified_stmt("SELECT * FROM users |> RIGHT OUTER JOIN orders ON users.id = orders.user_id");
-    
+    dialects.verified_stmt(
+        "SELECT * FROM users |> RIGHT OUTER JOIN orders ON users.id = orders.user_id",
+    );
+
     // join pipe operator - FULL JOIN
     dialects.verified_stmt("SELECT * FROM users |> FULL JOIN orders ON users.id = orders.user_id");
     dialects.verified_query_with_canonical(
         "SELECT * FROM users |> FULL OUTER JOIN orders ON users.id = orders.user_id",
         "SELECT * FROM users |> FULL JOIN orders ON users.id = orders.user_id",
     );
-    
+
     // join pipe operator - CROSS JOIN
     dialects.verified_stmt("SELECT * FROM users |> CROSS JOIN orders");
-    
+
     // join pipe operator with USING
     dialects.verified_query_with_canonical(
         "SELECT * FROM users |> JOIN orders USING (user_id)",
@@ -15392,22 +15396,22 @@ fn parse_pipeline_operator() {
         "SELECT * FROM users |> LEFT JOIN orders USING (user_id, order_date)",
         "SELECT * FROM users |> LEFT JOIN orders USING(user_id, order_date)",
     );
-    
+
     // join pipe operator with alias
     dialects.verified_query_with_canonical(
         "SELECT * FROM users |> JOIN orders o ON users.id = o.user_id",
         "SELECT * FROM users |> JOIN orders AS o ON users.id = o.user_id",
     );
     dialects.verified_stmt("SELECT * FROM users |> LEFT JOIN orders AS o ON users.id = o.user_id");
-    
+
     // join pipe operator with complex ON condition
     dialects.verified_stmt("SELECT * FROM users |> JOIN orders ON users.id = orders.user_id AND orders.status = 'active'");
     dialects.verified_stmt("SELECT * FROM users |> LEFT JOIN orders ON users.id = orders.user_id AND orders.amount > 100");
-    
+
     // multiple join pipe operators
     dialects.verified_stmt("SELECT * FROM users |> JOIN orders ON users.id = orders.user_id |> JOIN products ON orders.product_id = products.id");
     dialects.verified_stmt("SELECT * FROM users |> LEFT JOIN orders ON users.id = orders.user_id |> RIGHT JOIN products ON orders.product_id = products.id");
-    
+
     // join pipe operator with other pipe operators
     dialects.verified_stmt("SELECT * FROM users |> JOIN orders ON users.id = orders.user_id |> WHERE orders.amount > 100");
     dialects.verified_stmt("SELECT * FROM users |> WHERE users.active = true |> LEFT JOIN orders ON users.id = orders.user_id");
@@ -15590,7 +15594,9 @@ fn parse_pipeline_operator_negative_tests() {
 
     // Test that CROSS JOIN with ON condition fails
     assert!(dialects
-        .parse_sql_statements("SELECT * FROM users |> CROSS JOIN orders ON users.id = orders.user_id")
+        .parse_sql_statements(
+            "SELECT * FROM users |> CROSS JOIN orders ON users.id = orders.user_id"
+        )
         .is_err());
 
     // Test that CROSS JOIN with USING condition fails

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15360,6 +15360,58 @@ fn parse_pipeline_operator() {
     dialects.verified_stmt(
         "SELECT * FROM CustomerOrders |> AGGREGATE SUM(cost) AS total_cost GROUP BY customer_id, state, item_type |> EXTEND COUNT(*) OVER (PARTITION BY customer_id) AS num_orders |> WHERE num_orders > 1 |> AGGREGATE AVG(total_cost) AS average GROUP BY state DESC, item_type ASC",
     );
+
+    // join pipe operator - INNER JOIN
+    dialects.verified_stmt("SELECT * FROM users |> JOIN orders ON users.id = orders.user_id");
+    dialects.verified_stmt("SELECT * FROM users |> INNER JOIN orders ON users.id = orders.user_id");
+    
+    // join pipe operator - LEFT JOIN
+    dialects.verified_stmt("SELECT * FROM users |> LEFT JOIN orders ON users.id = orders.user_id");
+    dialects.verified_stmt("SELECT * FROM users |> LEFT OUTER JOIN orders ON users.id = orders.user_id");
+    
+    // join pipe operator - RIGHT JOIN
+    dialects.verified_stmt("SELECT * FROM users |> RIGHT JOIN orders ON users.id = orders.user_id");
+    dialects.verified_stmt("SELECT * FROM users |> RIGHT OUTER JOIN orders ON users.id = orders.user_id");
+    
+    // join pipe operator - FULL JOIN
+    dialects.verified_stmt("SELECT * FROM users |> FULL JOIN orders ON users.id = orders.user_id");
+    dialects.verified_query_with_canonical(
+        "SELECT * FROM users |> FULL OUTER JOIN orders ON users.id = orders.user_id",
+        "SELECT * FROM users |> FULL JOIN orders ON users.id = orders.user_id",
+    );
+    
+    // join pipe operator - CROSS JOIN
+    dialects.verified_stmt("SELECT * FROM users |> CROSS JOIN orders");
+    
+    // join pipe operator with USING
+    dialects.verified_query_with_canonical(
+        "SELECT * FROM users |> JOIN orders USING (user_id)",
+        "SELECT * FROM users |> JOIN orders USING(user_id)",
+    );
+    dialects.verified_query_with_canonical(
+        "SELECT * FROM users |> LEFT JOIN orders USING (user_id, order_date)",
+        "SELECT * FROM users |> LEFT JOIN orders USING(user_id, order_date)",
+    );
+    
+    // join pipe operator with alias
+    dialects.verified_query_with_canonical(
+        "SELECT * FROM users |> JOIN orders o ON users.id = o.user_id",
+        "SELECT * FROM users |> JOIN orders AS o ON users.id = o.user_id",
+    );
+    dialects.verified_stmt("SELECT * FROM users |> LEFT JOIN orders AS o ON users.id = o.user_id");
+    
+    // join pipe operator with complex ON condition
+    dialects.verified_stmt("SELECT * FROM users |> JOIN orders ON users.id = orders.user_id AND orders.status = 'active'");
+    dialects.verified_stmt("SELECT * FROM users |> LEFT JOIN orders ON users.id = orders.user_id AND orders.amount > 100");
+    
+    // multiple join pipe operators
+    dialects.verified_stmt("SELECT * FROM users |> JOIN orders ON users.id = orders.user_id |> JOIN products ON orders.product_id = products.id");
+    dialects.verified_stmt("SELECT * FROM users |> LEFT JOIN orders ON users.id = orders.user_id |> RIGHT JOIN products ON orders.product_id = products.id");
+    
+    // join pipe operator with other pipe operators
+    dialects.verified_stmt("SELECT * FROM users |> JOIN orders ON users.id = orders.user_id |> WHERE orders.amount > 100");
+    dialects.verified_stmt("SELECT * FROM users |> WHERE users.active = true |> LEFT JOIN orders ON users.id = orders.user_id");
+    dialects.verified_stmt("SELECT * FROM users |> JOIN orders ON users.id = orders.user_id |> SELECT users.name, orders.amount");
 }
 
 #[test]
@@ -15524,6 +15576,41 @@ fn parse_pipeline_operator_negative_tests() {
     // Test that UNPIVOT with missing closing parenthesis fails
     assert!(dialects
         .parse_sql_statements("SELECT * FROM users |> UNPIVOT(value FOR name IN (col1, col2)")
+        .is_err());
+
+    // Test that JOIN without table name fails
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> JOIN ON users.id = orders.user_id")
+        .is_err());
+
+    // Test that JOIN without ON or USING condition fails (except CROSS JOIN)
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> JOIN orders")
+        .is_err());
+
+    // Test that CROSS JOIN with ON condition fails
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> CROSS JOIN orders ON users.id = orders.user_id")
+        .is_err());
+
+    // Test that CROSS JOIN with USING condition fails
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> CROSS JOIN orders USING (user_id)")
+        .is_err());
+
+    // Test that JOIN with empty USING list fails
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> JOIN orders USING ()")
+        .is_err());
+
+    // Test that JOIN with malformed ON condition fails
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> JOIN orders ON")
+        .is_err());
+
+    // Test that JOIN with invalid USING syntax fails
+    assert!(dialects
+        .parse_sql_statements("SELECT * FROM users |> JOIN orders USING user_id")
         .is_err());
 }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15219,20 +15219,16 @@ fn parse_pipeline_operator() {
     // union pipe operator with BY NAME and multiple queries
     dialects.verified_stmt("SELECT * FROM users |> UNION BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
 
-    // intersect pipe operator (BigQuery does not support ALL modifier for INTERSECT)
-    dialects.verified_stmt("SELECT * FROM users |> INTERSECT (SELECT * FROM admins)");
+    // intersect pipe operator (BigQuery requires DISTINCT modifier for INTERSECT)
     dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT (SELECT * FROM admins)");
     
     // intersect pipe operator with BY NAME modifier
-    dialects.verified_stmt("SELECT * FROM users |> INTERSECT BY NAME (SELECT * FROM admins)");
     dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT BY NAME (SELECT * FROM admins)");
     
     // intersect pipe operator with multiple queries
-    dialects.verified_stmt("SELECT * FROM users |> INTERSECT (SELECT * FROM admins), (SELECT * FROM guests)");
     dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT (SELECT * FROM admins), (SELECT * FROM guests)");
     
     // intersect pipe operator with BY NAME and multiple queries
-    dialects.verified_stmt("SELECT * FROM users |> INTERSECT BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
     dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
 
     // except pipe operator (BigQuery requires DISTINCT modifier for EXCEPT)
@@ -15279,6 +15275,30 @@ fn parse_pipeline_operator_negative_tests() {
     assert_eq!(
         ParserError::ParserError("EXCEPT pipe operator requires DISTINCT modifier".to_string()),
         dialects.parse_sql_statements("SELECT * FROM users |> EXCEPT ALL BY NAME (SELECT * FROM admins)").unwrap_err()
+    );
+
+    // Test that plain INTERSECT without DISTINCT fails
+    assert_eq!(
+        ParserError::ParserError("INTERSECT pipe operator requires DISTINCT modifier".to_string()),
+        dialects.parse_sql_statements("SELECT * FROM users |> INTERSECT (SELECT * FROM admins)").unwrap_err()
+    );
+
+    // Test that INTERSECT ALL fails  
+    assert_eq!(
+        ParserError::ParserError("INTERSECT pipe operator requires DISTINCT modifier".to_string()),
+        dialects.parse_sql_statements("SELECT * FROM users |> INTERSECT ALL (SELECT * FROM admins)").unwrap_err()
+    );
+
+    // Test that INTERSECT BY NAME without DISTINCT fails
+    assert_eq!(
+        ParserError::ParserError("INTERSECT pipe operator requires DISTINCT modifier".to_string()),
+        dialects.parse_sql_statements("SELECT * FROM users |> INTERSECT BY NAME (SELECT * FROM admins)").unwrap_err()
+    );
+
+    // Test that INTERSECT ALL BY NAME fails
+    assert_eq!(
+        ParserError::ParserError("INTERSECT pipe operator requires DISTINCT modifier".to_string()),
+        dialects.parse_sql_statements("SELECT * FROM users |> INTERSECT ALL BY NAME (SELECT * FROM admins)").unwrap_err()
     );
 }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15193,6 +15193,14 @@ fn parse_pipeline_operator() {
     dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE SYSTEM (50 PERCENT)");
     dialects.verified_stmt("SELECT * FROM tbl |> TABLESAMPLE SYSTEM (50) REPEATABLE (10)");
 
+    // rename pipe operator
+    dialects.verified_stmt("SELECT * FROM users |> RENAME old_name AS new_name");
+    dialects.verified_stmt("SELECT * FROM users |> RENAME id AS user_id, name AS user_name");
+    dialects.verified_query_with_canonical(
+        "SELECT * FROM users |> RENAME id user_id",
+        "SELECT * FROM users |> RENAME id AS user_id",
+    );
+
     // many pipes
     dialects.verified_stmt(
         "SELECT * FROM CustomerOrders |> AGGREGATE SUM(cost) AS total_cost GROUP BY customer_id, state, item_type |> EXTEND COUNT(*) OVER (PARTITION BY customer_id) AS num_orders |> WHERE num_orders > 1 |> AGGREGATE AVG(total_cost) AS average GROUP BY state DESC, item_type ASC",

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15219,6 +15219,22 @@ fn parse_pipeline_operator() {
     // union pipe operator with BY NAME and multiple queries
     dialects.verified_stmt("SELECT * FROM users |> UNION BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
 
+    // intersect pipe operator (BigQuery does not support ALL modifier for INTERSECT)
+    dialects.verified_stmt("SELECT * FROM users |> INTERSECT (SELECT * FROM admins)");
+    dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT (SELECT * FROM admins)");
+    
+    // intersect pipe operator with BY NAME modifier
+    dialects.verified_stmt("SELECT * FROM users |> INTERSECT BY NAME (SELECT * FROM admins)");
+    dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT BY NAME (SELECT * FROM admins)");
+    
+    // intersect pipe operator with multiple queries
+    dialects.verified_stmt("SELECT * FROM users |> INTERSECT (SELECT * FROM admins), (SELECT * FROM guests)");
+    dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT (SELECT * FROM admins), (SELECT * FROM guests)");
+    
+    // intersect pipe operator with BY NAME and multiple queries
+    dialects.verified_stmt("SELECT * FROM users |> INTERSECT BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
+    dialects.verified_stmt("SELECT * FROM users |> INTERSECT DISTINCT BY NAME (SELECT * FROM admins), (SELECT * FROM guests)");
+
     // many pipes
     dialects.verified_stmt(
         "SELECT * FROM CustomerOrders |> AGGREGATE SUM(cost) AS total_cost GROUP BY customer_id, state, item_type |> EXTEND COUNT(*) OVER (PARTITION BY customer_id) AS num_orders |> WHERE num_orders > 1 |> AGGREGATE AVG(total_cost) AS average GROUP BY state DESC, item_type ASC",


### PR DESCRIPTION
Fixes https://github.com/apache/datafusion-sqlparser-rs/issues/1758

This PR adds support for the remaining SQL pipe operators as defined by BigQuery.