### PR TITLE
Allow `IF NOT EXISTS` after table name for Snowflake

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -401,6 +401,11 @@ pub fn parse_create_table(
     let if_not_exists = parser.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
     let table_name = parser.parse_object_name(false)?;
 
+    // Snowflake allows `IF NOT EXIST` both before and after the table name so if we haven't
+    // already seen that before the table name, try to parse it again.
+    let if_not_exists =
+        if_not_exists || parser.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
+
     let mut builder = CreateTableBuilder::new(table_name)
         .or_replace(or_replace)
         .if_not_exists(if_not_exists)

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -446,6 +446,18 @@ fn test_snowflake_create_table_if_not_exists() {
         }
         _ => unreachable!(),
     }
+
+    for sql in [
+        r#"CREATE TABLE IF NOT EXISTS "A"."B"."C" (v VARIANT)"#,
+        r#"CREATE TABLE "A"."B"."C" IF NOT EXISTS (v VARIANT)"#,
+        r#"CREATE TRANSIENT TABLE IF NOT EXISTS "A"."B"."C" (v VARIANT)"#,
+        r#"CREATE TRANSIENT TABLE "A"."B"."C" IF NOT EXISTS (v VARIANT)"#,
+    ] {
+        // We don't use `verified_stmt` here because the parser won't produce a 1:1 result of the
+        // query. We will always put the `IF NOT EXIST` before the column name when displaying the
+        // query.
+        assert!(snowflake().parse_sql_statements(sql).is_ok());
+    }
 }
 
 #[test]


### PR DESCRIPTION
Although not documented under
https://docs.snowflake.com/en/sql-reference/sql/create-table, it is valid to put the `IF NOT EXIST` _after_ the table name when creating a table for Snowflake.

This adds support to check for `IF NOT EXIST` again after parsing the table name if it wasn't found before the name.

---

I wish I could find _some_ references of this, but sadly it's not that easy. Best I can do is to provide a screenshot from their UI executing a query with `IF NOT EXIST` after the table and show that it succeeds.

<img width="756" alt="image" src="https://github.com/user-attachments/assets/936b889a-6ad0-4b85-a6cb-169632fcb90c" />
