### PR TITLE
Add license header to display_utils.rs and pretty_print.rs

### DIFF
--- a/src/display_utils.rs
+++ b/src/display_utils.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 //! Utilities for formatting SQL AST nodes with pretty printing support.
 //!
 //! The module provides formatters that implement the `Display` trait with support

--- a/tests/pretty_print.rs
+++ b/tests/pretty_print.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 


### PR DESCRIPTION
- Part of https://github.com/apache/datafusion-sqlparser-rs/issues/1837

When I tried to make a release caiddate for 0.57.0 I got some errors about files not having the Apache License:
```
Running rat license checker on /Users/andrewlamb/Software/sqlparser-rs/dev/dist/apache-datafusion-sqlparser-rs-0.57.0-rc1/apache-datafusion-sqlparser-rs-0.57.0.tar.gz
NOT APPROVED: src/display_utils.rs (apache-datafusion-sqlparser-rs-0.57.0/src/display_utils.rs): false
NOT APPROVED: tests/pretty_print.rs (apache-datafusion-sqlparser-rs-0.57.0/tests/pretty_print.rs): false
```

This PR adds the missing licenses

I will make another PR to add a license checking CI test