### PR TITLE
fix: parse snowflake fetch clause

### DIFF
--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8369,18 +8369,16 @@ fn parse_offset() {
 
 #[test]
 fn parse_fetch() {
-    let dialects = all_dialects_except(|d| d.is::<SnowflakeDialect>());
-
     let fetch_first_two_rows_only = Some(Fetch {
         with_ties: false,
         percent: false,
         quantity: Some(Expr::value(number("2"))),
     });
-    let ast = dialects.verified_query("SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY");
+    let ast = verified_query("SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = dialects.verified_query("SELECT 'foo' FETCH FIRST 2 ROWS ONLY");
+    let ast = verified_query("SELECT 'foo' FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = dialects.verified_query("SELECT foo FROM bar FETCH FIRST ROWS ONLY");
+    let ast = verified_query("SELECT foo FROM bar FETCH FIRST ROWS ONLY");
     assert_eq!(
         ast.fetch,
         Some(Fetch {
@@ -8389,11 +8387,11 @@ fn parse_fetch() {
             quantity: None,
         })
     );
-    let ast = dialects.verified_query("SELECT foo FROM bar WHERE foo = 4 FETCH FIRST 2 ROWS ONLY");
+    let ast = verified_query("SELECT foo FROM bar WHERE foo = 4 FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = dialects.verified_query("SELECT foo FROM bar ORDER BY baz FETCH FIRST 2 ROWS ONLY");
+    let ast = verified_query("SELECT foo FROM bar ORDER BY baz FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = dialects.verified_query(
+    let ast = verified_query(
         "SELECT foo FROM bar WHERE foo = 4 ORDER BY baz FETCH FIRST 2 ROWS WITH TIES",
     );
     assert_eq!(
@@ -8404,7 +8402,7 @@ fn parse_fetch() {
             quantity: Some(Expr::value(number("2"))),
         })
     );
-    let ast = dialects.verified_query("SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY");
+    let ast = verified_query("SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY");
     assert_eq!(
         ast.fetch,
         Some(Fetch {
@@ -8413,7 +8411,7 @@ fn parse_fetch() {
             quantity: Some(Expr::value(number("50"))),
         })
     );
-    let ast = dialects.verified_query(
+    let ast = verified_query(
         "SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY",
     );
     let expected_limit_clause = Some(LimitClause::LimitOffset {
@@ -8426,7 +8424,7 @@ fn parse_fetch() {
     });
     assert_eq!(ast.limit_clause, expected_limit_clause);
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = dialects.verified_query(
+    let ast = verified_query(
         "SELECT foo FROM (SELECT * FROM bar FETCH FIRST 2 ROWS ONLY) FETCH FIRST 2 ROWS ONLY",
     );
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
@@ -8439,7 +8437,7 @@ fn parse_fetch() {
         },
         _ => panic!("Test broke"),
     }
-    let ast = dialects.verified_query("SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY) OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY");
+    let ast = verified_query("SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY) OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY");
     let expected_limit_clause = &Some(LimitClause::LimitOffset {
         limit: None,
         offset: Some(Offset {
@@ -8464,24 +8462,23 @@ fn parse_fetch() {
 
 #[test]
 fn parse_fetch_variations() {
-    let dialects = all_dialects_except(|d| d.is::<SnowflakeDialect>());
-    dialects.one_statement_parses_to(
+    one_statement_parses_to(
         "SELECT foo FROM bar FETCH FIRST 10 ROW ONLY",
         "SELECT foo FROM bar FETCH FIRST 10 ROWS ONLY",
     );
-    dialects.one_statement_parses_to(
+    one_statement_parses_to(
         "SELECT foo FROM bar FETCH NEXT 10 ROW ONLY",
         "SELECT foo FROM bar FETCH FIRST 10 ROWS ONLY",
     );
-    dialects.one_statement_parses_to(
+    one_statement_parses_to(
         "SELECT foo FROM bar FETCH NEXT 10 ROWS WITH TIES",
         "SELECT foo FROM bar FETCH FIRST 10 ROWS WITH TIES",
     );
-    dialects.one_statement_parses_to(
+    one_statement_parses_to(
         "SELECT foo FROM bar FETCH NEXT ROWS WITH TIES",
         "SELECT foo FROM bar FETCH FIRST ROWS WITH TIES",
     );
-    dialects.one_statement_parses_to(
+    one_statement_parses_to(
         "SELECT foo FROM bar FETCH FIRST ROWS ONLY",
         "SELECT foo FROM bar FETCH FIRST ROWS ONLY",
     );

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8369,16 +8369,18 @@ fn parse_offset() {
 
 #[test]
 fn parse_fetch() {
+    let dialects = all_dialects_except(|d| d.is::<SnowflakeDialect>());
+
     let fetch_first_two_rows_only = Some(Fetch {
         with_ties: false,
         percent: false,
         quantity: Some(Expr::value(number("2"))),
     });
-    let ast = verified_query("SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY");
+    let ast = dialects.verified_query("SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = verified_query("SELECT 'foo' FETCH FIRST 2 ROWS ONLY");
+    let ast = dialects.verified_query("SELECT 'foo' FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = verified_query("SELECT foo FROM bar FETCH FIRST ROWS ONLY");
+    let ast = dialects.verified_query("SELECT foo FROM bar FETCH FIRST ROWS ONLY");
     assert_eq!(
         ast.fetch,
         Some(Fetch {
@@ -8387,11 +8389,11 @@ fn parse_fetch() {
             quantity: None,
         })
     );
-    let ast = verified_query("SELECT foo FROM bar WHERE foo = 4 FETCH FIRST 2 ROWS ONLY");
+    let ast = dialects.verified_query("SELECT foo FROM bar WHERE foo = 4 FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = verified_query("SELECT foo FROM bar ORDER BY baz FETCH FIRST 2 ROWS ONLY");
+    let ast = dialects.verified_query("SELECT foo FROM bar ORDER BY baz FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = verified_query(
+    let ast = dialects.verified_query(
         "SELECT foo FROM bar WHERE foo = 4 ORDER BY baz FETCH FIRST 2 ROWS WITH TIES",
     );
     assert_eq!(
@@ -8402,7 +8404,7 @@ fn parse_fetch() {
             quantity: Some(Expr::value(number("2"))),
         })
     );
-    let ast = verified_query("SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY");
+    let ast = dialects.verified_query("SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY");
     assert_eq!(
         ast.fetch,
         Some(Fetch {
@@ -8411,7 +8413,7 @@ fn parse_fetch() {
             quantity: Some(Expr::value(number("50"))),
         })
     );
-    let ast = verified_query(
+    let ast = dialects.verified_query(
         "SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY",
     );
     let expected_limit_clause = Some(LimitClause::LimitOffset {
@@ -8424,7 +8426,7 @@ fn parse_fetch() {
     });
     assert_eq!(ast.limit_clause, expected_limit_clause);
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
-    let ast = verified_query(
+    let ast = dialects.verified_query(
         "SELECT foo FROM (SELECT * FROM bar FETCH FIRST 2 ROWS ONLY) FETCH FIRST 2 ROWS ONLY",
     );
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
@@ -8437,7 +8439,7 @@ fn parse_fetch() {
         },
         _ => panic!("Test broke"),
     }
-    let ast = verified_query("SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY) OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY");
+    let ast = dialects.verified_query("SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY) OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY");
     let expected_limit_clause = &Some(LimitClause::LimitOffset {
         limit: None,
         offset: Some(Offset {
@@ -8462,23 +8464,24 @@ fn parse_fetch() {
 
 #[test]
 fn parse_fetch_variations() {
-    one_statement_parses_to(
+    let dialects = all_dialects_except(|d| d.is::<SnowflakeDialect>());
+    dialects.one_statement_parses_to(
         "SELECT foo FROM bar FETCH FIRST 10 ROW ONLY",
         "SELECT foo FROM bar FETCH FIRST 10 ROWS ONLY",
     );
-    one_statement_parses_to(
+    dialects.one_statement_parses_to(
         "SELECT foo FROM bar FETCH NEXT 10 ROW ONLY",
         "SELECT foo FROM bar FETCH FIRST 10 ROWS ONLY",
     );
-    one_statement_parses_to(
+    dialects.one_statement_parses_to(
         "SELECT foo FROM bar FETCH NEXT 10 ROWS WITH TIES",
         "SELECT foo FROM bar FETCH FIRST 10 ROWS WITH TIES",
     );
-    one_statement_parses_to(
+    dialects.one_statement_parses_to(
         "SELECT foo FROM bar FETCH NEXT ROWS WITH TIES",
         "SELECT foo FROM bar FETCH FIRST ROWS WITH TIES",
     );
-    one_statement_parses_to(
+    dialects.one_statement_parses_to(
         "SELECT foo FROM bar FETCH FIRST ROWS ONLY",
         "SELECT foo FROM bar FETCH FIRST ROWS ONLY",
     );

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -4164,18 +4164,4 @@ fn test_snowflake_fetch_clause_syntax() {
         "SELECT c1 FROM fetch_test FETCH FIRST 2 ROWS",
         canonical,
     );
-
-    snowflake()
-        .verified_only_select_with_canonical("SELECT c1 FROM fetch_test FETCH 2 ONLY", canonical);
-    let res = snowflake().parse_sql_statements("SELECT c1 FROM fetch_test FETCH 2 PERCENT");
-    assert_eq!(
-        res.unwrap_err().to_string(),
-        "sql parser error: Expected: end of statement, found: PERCENT"
-    );
-    let res =
-        snowflake().parse_sql_statements("SELECT c1 FROM fetch_test FETCH FIRST 2 ROWS WITH TIES");
-    assert_eq!(
-        res.unwrap_err().to_string(),
-        "sql parser error: Expected: end of statement, found: WITH"
-    );
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -4146,3 +4146,36 @@ END
     assert_eq!(2, exception[1].idents.len());
     assert_eq!(2, exception[1].statements.len());
 }
+
+#[test]
+fn test_snowflake_fetch_clause_syntax() {
+    let canonical = "SELECT c1 FROM fetch_test FETCH FIRST 2 ROWS ONLY";
+    snowflake().verified_only_select_with_canonical("SELECT c1 FROM fetch_test FETCH 2", canonical);
+
+    snowflake()
+        .verified_only_select_with_canonical("SELECT c1 FROM fetch_test FETCH FIRST 2", canonical);
+    snowflake()
+        .verified_only_select_with_canonical("SELECT c1 FROM fetch_test FETCH NEXT 2", canonical);
+
+    snowflake()
+        .verified_only_select_with_canonical("SELECT c1 FROM fetch_test FETCH 2 ROW", canonical);
+
+    snowflake().verified_only_select_with_canonical(
+        "SELECT c1 FROM fetch_test FETCH FIRST 2 ROWS",
+        canonical,
+    );
+
+    snowflake()
+        .verified_only_select_with_canonical("SELECT c1 FROM fetch_test FETCH 2 ONLY", canonical);
+    let res = snowflake().parse_sql_statements("SELECT c1 FROM fetch_test FETCH 2 PERCENT");
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "sql parser error: Expected: end of statement, found: PERCENT"
+    );
+    let res =
+        snowflake().parse_sql_statements("SELECT c1 FROM fetch_test FETCH FIRST 2 ROWS WITH TIES");
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        "sql parser error: Expected: end of statement, found: WITH"
+    );
+}


### PR DESCRIPTION
Snowflake treat `FETCH` in a different way. https://docs.snowflake.com/en/sql-reference/constructs/limit
Most keywords like `FIRST/NEXT`, `ROW/ROWS` and `ONLY` can be skipped.
`PERSENT` and `WITH TIES` should cause an error. 