### PR TITLE
Add support for `LANGUAGE` clause in `CREATE PROCEDURE`

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3914,6 +3914,7 @@ pub enum Statement {
         or_alter: bool,
         name: ObjectName,
         params: Option<Vec<ProcedureParam>>,
+        language: Option<Ident>,
         body: ConditionalStatements,
     },
     /// ```sql
@@ -4817,6 +4818,7 @@ impl fmt::Display for Statement {
                 name,
                 or_alter,
                 params,
+                language,
                 body,
             } => {
                 write!(
@@ -4830,6 +4832,10 @@ impl fmt::Display for Statement {
                     if !p.is_empty() {
                         write!(f, " ({})", display_comma_separated(p))?;
                     }
+                }
+
+                if let Some(language) = language {
+                    write!(f, " LANGUAGE {language}")?;
                 }
 
                 write!(f, " AS {body}")

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15767,6 +15767,13 @@ impl<'a> Parser<'a> {
     pub fn parse_create_procedure(&mut self, or_alter: bool) -> Result<Statement, ParserError> {
         let name = self.parse_object_name(false)?;
         let params = self.parse_optional_procedure_parameters()?;
+
+        let language = if self.parse_keyword(Keyword::LANGUAGE) {
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
+
         self.expect_keyword_is(Keyword::AS)?;
 
         let body = self.parse_conditional_statements(&[Keyword::END])?;
@@ -15775,6 +15782,7 @@ impl<'a> Parser<'a> {
             name,
             or_alter,
             params,
+            language,
             body,
         })
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -15349,3 +15349,33 @@ fn check_enforced() {
         "CREATE TABLE t (a INT, b INT, c INT, CHECK (a > 0) NOT ENFORCED, CHECK (b > 0) ENFORCED, CHECK (c > 0))",
     );
 }
+
+#[test]
+fn parse_create_procedure_with_language() {
+    let sql = r#"CREATE PROCEDURE test_proc LANGUAGE sql AS BEGIN SELECT 1; END"#;
+    match verified_stmt(sql) {
+        Statement::CreateProcedure {
+            or_alter,
+            name,
+            params,
+            language,
+            ..
+        } => {
+            assert_eq!(or_alter, false);
+            assert_eq!(name.to_string(), "test_proc");
+            assert_eq!(params, Some(vec![]));
+            assert_eq!(
+                language,
+                Some(Ident {
+                    value: "sql".into(),
+                    quote_style: None,
+                    span: Span {
+                        start: Location::empty(),
+                        end: Location::empty()
+                    }
+                })
+            );
+        }
+        _ => unreachable!(),
+    }
+}

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -171,7 +171,8 @@ fn parse_create_procedure() {
                 value: "test".into(),
                 quote_style: None,
                 span: Span::empty(),
-            }])
+            }]),
+            language: None,
         }
     )
 }


### PR DESCRIPTION
sqlparser-rs doesn't currently support the `LANGUAGE` clause in `CREATE PROCEDURE` ([see grammar](https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#routine-characteristic)). This PR adds support for it.

Looks like the 'routine characteristics' clause isn't supported at all. I'll probably write separate PRs for those at some point.