### PR TITLE
Postgres constraint NOT VALID and VALIDATE CONSTRAINT

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -67,8 +67,11 @@ impl fmt::Display for ReplicaIdentity {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub enum AlterTableOperation {
-    /// `ADD <table_constraint>`
-    AddConstraint(TableConstraint),
+    /// `ADD <table_constraint> [NOT VALID]`
+    AddConstraint {
+        constraint: TableConstraint,
+        not_valid: bool,
+    },
     /// `ADD [COLUMN] [IF NOT EXISTS] <column_def>`
     AddColumn {
         /// `[COLUMN]`.
@@ -494,7 +497,16 @@ impl fmt::Display for AlterTableOperation {
                 display_separated(new_partitions, " "),
                 ine = if *if_not_exists { " IF NOT EXISTS" } else { "" }
             ),
-            AlterTableOperation::AddConstraint(c) => write!(f, "ADD {c}"),
+            AlterTableOperation::AddConstraint {
+                not_valid,
+                constraint,
+            } => {
+                write!(f, "ADD {constraint}")?;
+                if *not_valid {
+                    write!(f, " NOT VALID")?;
+                }
+                Ok(())
+            }
             AlterTableOperation::AddColumn {
                 column_keyword,
                 if_not_exists,

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -347,6 +347,10 @@ pub enum AlterTableOperation {
         equals: bool,
         value: ValueWithSpan,
     },
+    /// `VALIDATE CONSTRAINT <name>`
+    ValidateConstraint {
+        name: Ident,
+    },
 }
 
 /// An `ALTER Policy` (`Statement::AlterPolicy`) operation
@@ -783,6 +787,9 @@ impl fmt::Display for AlterTableOperation {
             }
             AlterTableOperation::ReplicaIdentity { identity } => {
                 write!(f, "REPLICA IDENTITY {identity}")
+            }
+            AlterTableOperation::ValidateConstraint { name } => {
+                write!(f, "VALIDATE CONSTRAINT {name}")
             }
         }
     }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1074,7 +1074,10 @@ impl Spanned for CreateTableOptions {
 impl Spanned for AlterTableOperation {
     fn span(&self) -> Span {
         match self {
-            AlterTableOperation::AddConstraint(table_constraint) => table_constraint.span(),
+            AlterTableOperation::AddConstraint {
+                constraint,
+                not_valid: _,
+            } => constraint.span(),
             AlterTableOperation::AddColumn {
                 column_keyword: _,
                 if_not_exists: _,

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1198,6 +1198,7 @@ impl Spanned for AlterTableOperation {
             AlterTableOperation::AutoIncrement { value, .. } => value.span(),
             AlterTableOperation::Lock { .. } => Span::empty(),
             AlterTableOperation::ReplicaIdentity { .. } => Span::empty(),
+            AlterTableOperation::ValidateConstraint { name } => name.span,
         }
     }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1035,14 +1035,14 @@ pub trait Dialect: Debug + Any {
 
     /// Returns true if the dialect supports `ADD <table_constraint> [NOT VALID]` in `ALTER TABLE` statements.
     ///
-    /// -[PostgreSQL](https://www.postgresql.org/docs/17/sql-altertable.html)
+    /// - [PostgreSQL](https://www.postgresql.org/docs/17/sql-altertable.html)
     fn supports_constraint_not_valid(&self) -> bool {
         false
     }
 
     /// Returns true if the dialect supports `VALIDATE CONSTRAINT <constraint_name>` in `ALTER TABLE` statements.
     ///
-    /// -[PostgreSQL](https://www.postgresql.org/docs/17/sql-altertable.html)
+    /// - [PostgreSQL](https://www.postgresql.org/docs/17/sql-altertable.html)
     fn supports_validate_constraint(&self) -> bool {
         false
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1036,7 +1036,7 @@ pub trait Dialect: Debug + Any {
     /// Returns true if the dialect supports `ADD <table_constraint> [NOT VALID]` in `ALTER TABLE` statements.
     ///
     /// -[PostgreSQL](https://www.postgresql.org/docs/17/sql-altertable.html)
-    fn supports_constraint_not_validation(&self) -> bool {
+    fn supports_constraint_not_valid(&self) -> bool {
         false
     }
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1032,6 +1032,20 @@ pub trait Dialect: Debug + Any {
     fn supports_space_separated_column_options(&self) -> bool {
         false
     }
+
+    /// Returns true if the dialect supports `ADD <table_constraint> [NOT VALID]` in `ALTER TABLE` statements.
+    ///
+    /// -[PostgreSQL](https://www.postgresql.org/docs/17/sql-altertable.html)
+    fn supports_constraint_not_validation(&self) -> bool {
+        false
+    }
+
+    /// Returns true if the dialect supports `VALIDATE CONSTRAINT <constraint_name>` in `ALTER TABLE` statements.
+    ///
+    /// -[PostgreSQL](https://www.postgresql.org/docs/17/sql-altertable.html)
+    fn supports_validate_constraint(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -259,7 +259,7 @@ impl Dialect for PostgreSqlDialect {
         true
     }
 
-    fn supports_constraint_not_validation(&self) -> bool {
+    fn supports_constraint_not_valid(&self) -> bool {
         true
     }
 

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -258,4 +258,12 @@ impl Dialect for PostgreSqlDialect {
     fn supports_set_names(&self) -> bool {
         true
     }
+
+    fn supports_constraint_not_validation(&self) -> bool {
+        true
+    }
+
+    fn supports_validate_constraint(&self) -> bool {
+        true
+    }
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -980,6 +980,7 @@ define_keywords!(
     UUID,
     VACUUM,
     VALID,
+    VALIDATE,
     VALIDATION_MODE,
     VALUE,
     VALUES,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8477,7 +8477,11 @@ impl<'a> Parser<'a> {
     pub fn parse_alter_table_operation(&mut self) -> Result<AlterTableOperation, ParserError> {
         let operation = if self.parse_keyword(Keyword::ADD) {
             if let Some(constraint) = self.parse_optional_table_constraint()? {
-                AlterTableOperation::AddConstraint(constraint)
+                let not_valid = self.parse_keywords(&[Keyword::NOT, Keyword::VALID]);
+                AlterTableOperation::AddConstraint {
+                    constraint,
+                    not_valid,
+                }
             } else if dialect_of!(self is ClickHouseDialect|GenericDialect)
                 && self.parse_keyword(Keyword::PROJECTION)
             {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8477,7 +8477,10 @@ impl<'a> Parser<'a> {
     pub fn parse_alter_table_operation(&mut self) -> Result<AlterTableOperation, ParserError> {
         let operation = if self.parse_keyword(Keyword::ADD) {
             if let Some(constraint) = self.parse_optional_table_constraint()? {
-                let not_valid = self.parse_keywords(&[Keyword::NOT, Keyword::VALID]);
+                let mut not_valid = false;
+                if self.dialect.supports_constraint_not_valid() {
+                    not_valid = self.parse_keywords(&[Keyword::NOT, Keyword::VALID]);
+                }
                 AlterTableOperation::AddConstraint {
                     constraint,
                     not_valid,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8899,6 +8899,11 @@ impl<'a> Parser<'a> {
             };
 
             AlterTableOperation::ReplicaIdentity { identity }
+        } else if self.parse_keywords(&[Keyword::VALIDATE, Keyword::CONSTRAINT])
+            && self.dialect.supports_validate_constraint()
+        {
+            let name = self.parse_identifier()?;
+            AlterTableOperation::ValidateConstraint { name }
         } else {
             let options: Vec<SqlOption> =
                 self.parse_options_with_keywords(&[Keyword::SET, Keyword::TBLPROPERTIES])?;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -474,20 +474,25 @@ pub fn index_column(stmt: Statement) -> Expr {
             }
         }
         Statement::AlterTable { operations, .. } => match operations.first().unwrap() {
-            AlterTableOperation::AddConstraint(TableConstraint::Index { columns, .. }) => {
-                columns.first().unwrap().column.expr.clone()
+            AlterTableOperation::AddConstraint { constraint, .. } => {
+                match constraint {
+                    TableConstraint::Index { columns, .. } => {
+                        columns.first().unwrap().column.expr.clone()
+                    }
+                    TableConstraint::Unique { columns, .. } => {
+                        columns.first().unwrap().column.expr.clone()
+                    }
+                    TableConstraint::PrimaryKey { columns, .. } => {
+                        columns.first().unwrap().column.expr.clone()
+                    }
+                    TableConstraint::FulltextOrSpatial {
+                        columns,
+                        ..
+                    } => columns.first().unwrap().column.expr.clone(),
+                    _ => panic!("Expected an index, unique, primary, full text, or spatial constraint (foreign key does not support general key part expressions)"),
+                }
             }
-            AlterTableOperation::AddConstraint(TableConstraint::Unique { columns, .. }) => {
-                columns.first().unwrap().column.expr.clone()
-            }
-            AlterTableOperation::AddConstraint(TableConstraint::PrimaryKey { columns, .. }) => {
-                columns.first().unwrap().column.expr.clone()
-            }
-            AlterTableOperation::AddConstraint(TableConstraint::FulltextOrSpatial {
-                columns,
-                ..
-            }) => columns.first().unwrap().column.expr.clone(),
-            _ => panic!("Expected an index, unique, primary, full text, or spatial constraint (foreign key does not support general key part expressions)"),
+            _ => panic!("Expected a constraint"),
         },
         _ => panic!("Expected CREATE INDEX, ALTER TABLE, or CREATE TABLE, got: {stmt:?}"),
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4956,7 +4956,7 @@ fn parse_alter_table_constraints() {
         match alter_table_op(verified_stmt(&format!(
             "ALTER TABLE tab ADD {constraint_text}"
         ))) {
-            AlterTableOperation::AddConstraint(constraint) => {
+            AlterTableOperation::AddConstraint { constraint, .. } => {
                 assert_eq!(constraint_text, constraint.to_string());
             }
             _ => unreachable!(),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -606,9 +606,10 @@ fn parse_alter_table_constraints_unique_nulls_distinct() {
         .verified_stmt("ALTER TABLE t ADD CONSTRAINT b UNIQUE NULLS NOT DISTINCT (c)")
     {
         Statement::AlterTable { operations, .. } => match &operations[0] {
-            AlterTableOperation::AddConstraint(TableConstraint::Unique {
-                nulls_distinct, ..
-            }) => {
+            AlterTableOperation::AddConstraint {
+                constraint: TableConstraint::Unique { nulls_distinct, .. },
+                ..
+            } => {
                 assert_eq!(nulls_distinct, &NullsDistinctOption::NotDistinct)
             }
             _ => unreachable!(),
@@ -6226,6 +6227,33 @@ fn parse_ts_datatypes() {
                     name: "x".into(),
                     data_type: DataType::TsQuery,
                     options: vec![],
+                }]
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_alter_table_constraint_not_valid() {
+    match pg_and_generic().verified_stmt(
+        "ALTER TABLE foo ADD CONSTRAINT bar FOREIGN KEY (baz) REFERENCES other(ref) NOT VALID",
+    ) {
+        Statement::AlterTable { operations, .. } => {
+            assert_eq!(
+                operations,
+                vec![AlterTableOperation::AddConstraint {
+                    constraint: TableConstraint::ForeignKey {
+                        name: Some("bar".into()),
+                        index_name: None,
+                        columns: vec!["baz".into()],
+                        foreign_table: ObjectName::from(vec!["other".into()]),
+                        referred_columns: vec!["ref".into()],
+                        on_delete: None,
+                        on_update: None,
+                        characteristics: None,
+                    },
+                    not_valid: true,
                 }]
             );
         }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -6236,7 +6236,7 @@ fn parse_ts_datatypes() {
 
 #[test]
 fn parse_alter_table_constraint_not_valid() {
-    match pg_and_generic().verified_stmt(
+    match pg().verified_stmt(
         "ALTER TABLE foo ADD CONSTRAINT bar FOREIGN KEY (baz) REFERENCES other(ref) NOT VALID",
     ) {
         Statement::AlterTable { operations, .. } => {

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -6260,3 +6260,16 @@ fn parse_alter_table_constraint_not_valid() {
         _ => unreachable!(),
     }
 }
+
+#[test]
+fn parse_alter_table_validate_constraint() {
+    match pg().verified_stmt("ALTER TABLE foo VALIDATE CONSTRAINT bar") {
+        Statement::AlterTable { operations, .. } => {
+            assert_eq!(
+                operations,
+                vec![AlterTableOperation::ValidateConstraint { name: "bar".into() }]
+            );
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
closes #1907 

Handles creating constraints with `NOT VALID`, as well as `ALTER TABLE table VALIDATE CONSTRAINT constraint`