### PR TITLE
Make `GenericDialect` support from-first syntax

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -112,6 +112,10 @@ impl Dialect for GenericDialect {
         true
     }
 
+    fn supports_from_first_select(&self) -> bool {
+        true
+    }
+
     fn supports_asc_desc_in_column_definition(&self) -> bool {
         true
     }


### PR DESCRIPTION
The docs for `GenericDialect` says that is can be permissive, so I thought it could support from-first syntax.

This would help a bit on the "friendly sql" issue https://github.com/apache/datafusion/issues/14514