### PR TITLE
Redshift alter column type no set

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -893,7 +893,10 @@ pub enum AlterColumnOperation {
         data_type: DataType,
         /// PostgreSQL specific
         using: Option<Expr>,
+        /// Whether the statement included the optional `SET DATA` keywords
+        had_set: bool,
     },
+
     /// `ADD GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( sequence_options ) ]`
     ///
     /// Note: this is a PostgreSQL-specific operation.
@@ -914,12 +917,19 @@ impl fmt::Display for AlterColumnOperation {
             AlterColumnOperation::DropDefault => {
                 write!(f, "DROP DEFAULT")
             }
-            AlterColumnOperation::SetDataType { data_type, using } => {
-                if let Some(expr) = using {
-                    write!(f, "SET DATA TYPE {data_type} USING {expr}")
-                } else {
-                    write!(f, "SET DATA TYPE {data_type}")
+            AlterColumnOperation::SetDataType {
+                data_type,
+                using,
+                had_set,
+            } => {
+                if *had_set {
+                    write!(f, "SET DATA ")?;
                 }
+                write!(f, "TYPE {data_type}")?;
+                if let Some(expr) = using {
+                    write!(f, " USING {expr}")?;
+                }
+                Ok(())
             }
             AlterColumnOperation::AddGenerated {
                 generated_as,

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -924,6 +924,7 @@ impl Spanned for AlterColumnOperation {
             AlterColumnOperation::SetDataType {
                 data_type: _,
                 using,
+                had_set: _,
             } => using.as_ref().map_or(Span::empty(), |u| u.span()),
             AlterColumnOperation::AddGenerated { .. } => Span::empty(),
         }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1060,6 +1060,22 @@ pub trait Dialect: Debug + Any {
     fn supports_space_separated_column_options(&self) -> bool {
         false
     }
+
+    /// Returns true if the dialect supports `ALTER TABLE tbl ALTER COLUMN col TYPE <type>`
+    /// without specifying `SET DATA` before `TYPE`.
+    ///
+    /// - [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE.html#r_ALTER_TABLE-synopsis)
+    /// - [PostgreSQL](https://www.postgresql.org/docs/current/sql-altertable.html)
+    fn supports_alter_column_type_without_set(&self) -> bool {
+        false
+    }
+
+    /// Returns true if the dialect supports `ALTER TABLE tbl ALTER COLUMN col SET DATA TYPE <type> USING <exp>`
+    ///
+    /// - [PostgreSQL](https://www.postgresql.org/docs/current/sql-altertable.html)
+    fn supports_alter_column_type_using(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -258,4 +258,12 @@ impl Dialect for PostgreSqlDialect {
     fn supports_set_names(&self) -> bool {
         true
     }
+
+    fn supports_alter_column_type_without_set(&self) -> bool {
+        true
+    }
+
+    fn supports_alter_column_type_using(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -129,4 +129,8 @@ impl Dialect for RedshiftSqlDialect {
     fn supports_string_literal_backslash_escape(&self) -> bool {
         true
     }
+
+    fn supports_alter_column_type_without_set(&self) -> bool {
+        true
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8736,7 +8736,9 @@ impl<'a> Parser<'a> {
                 AlterColumnOperation::DropDefault {}
             } else if self.parse_keywords(&[Keyword::SET, Keyword::DATA, Keyword::TYPE]) {
                 self.parse_set_data_type(true)?
-            } else if self.parse_keyword(Keyword::TYPE) {
+            } else if self.dialect.supports_alter_column_type_without_set()
+                && self.parse_keyword(Keyword::TYPE)
+            {
                 self.parse_set_data_type(false)?
             } else if self.parse_keywords(&[Keyword::ADD, Keyword::GENERATED]) {
                 let generated_as = if self.parse_keyword(Keyword::ALWAYS) {
@@ -8905,7 +8907,9 @@ impl<'a> Parser<'a> {
 
     fn parse_set_data_type(&mut self, had_set: bool) -> Result<AlterColumnOperation, ParserError> {
         let data_type = self.parse_data_type()?;
-        let using = if self.parse_keyword(Keyword::USING) {
+        let using = if self.dialect.supports_alter_column_type_using()
+            && self.parse_keyword(Keyword::USING)
+        {
             Some(self.parse_expr()?)
         } else {
             None

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -5046,7 +5046,6 @@ fn parse_alter_table_alter_column() {
 
 #[test]
 fn parse_alter_table_alter_column_type() {
-    let alter_stmt = "ALTER TABLE tab";
     match alter_table_op(verified_stmt(
         "ALTER TABLE tab ALTER COLUMN is_active SET DATA TYPE TEXT",
     )) {
@@ -5057,28 +5056,12 @@ fn parse_alter_table_alter_column_type() {
                 AlterColumnOperation::SetDataType {
                     data_type: DataType::Text,
                     using: None,
+                    had_set: true,
                 }
             );
         }
         _ => unreachable!(),
     }
-
-    let dialect = TestedDialects::new(vec![Box::new(GenericDialect {})]);
-
-    let res =
-        dialect.parse_sql_statements(&format!("{alter_stmt} ALTER COLUMN is_active TYPE TEXT"));
-    assert_eq!(
-        ParserError::ParserError("Expected: SET/DROP NOT NULL, SET DEFAULT, or SET DATA TYPE after ALTER COLUMN, found: TYPE".to_string()),
-        res.unwrap_err()
-    );
-
-    let res = dialect.parse_sql_statements(&format!(
-        "{alter_stmt} ALTER COLUMN is_active SET DATA TYPE TEXT USING 'text'"
-    ));
-    assert_eq!(
-        ParserError::ParserError("Expected: end of statement, found: USING".to_string()),
-        res.unwrap_err()
-    );
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -5064,6 +5064,9 @@ fn parse_alter_table_alter_column_type() {
         _ => unreachable!(),
     }
 
+    let dialects = all_dialects_where(|d| d.supports_alter_column_type_without_set());
+    dialects.verified_stmt(&format!("{alter_stmt} ALTER COLUMN is_active TYPE TEXT"));
+
     let dialects = all_dialects_except(|d| d.supports_alter_column_type_without_set());
     let res =
         dialects.parse_sql_statements(&format!("{alter_stmt} ALTER COLUMN is_active TYPE TEXT"));
@@ -5071,6 +5074,11 @@ fn parse_alter_table_alter_column_type() {
         ParserError::ParserError("Expected: SET/DROP NOT NULL, SET DEFAULT, or SET DATA TYPE after ALTER COLUMN, found: TYPE".to_string()),
         res.unwrap_err()
     );
+
+    let dialects = all_dialects_where(|d| d.supports_alter_column_type_using());
+    dialects.verified_stmt(&format!(
+        "{alter_stmt} ALTER COLUMN is_active SET DATA TYPE TEXT USING 'text'"
+    ));
 
     let dialects = all_dialects_except(|d| d.supports_alter_column_type_using());
     let res = dialects.parse_sql_statements(&format!(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -764,10 +764,7 @@ fn parse_drop_extension() {
 
 #[test]
 fn parse_alter_table_alter_column() {
-    pg().one_statement_parses_to(
-        "ALTER TABLE tab ALTER COLUMN is_active TYPE TEXT USING 'text'",
-        "ALTER TABLE tab ALTER COLUMN is_active SET DATA TYPE TEXT USING 'text'",
-    );
+    pg().verified_stmt("ALTER TABLE tab ALTER COLUMN is_active TYPE TEXT USING 'text'");
 
     match alter_table_op(
         pg().verified_stmt(
@@ -783,6 +780,7 @@ fn parse_alter_table_alter_column() {
                 AlterColumnOperation::SetDataType {
                     data_type: DataType::Text,
                     using: Some(using_expr),
+                    had_set: true,
                 }
             );
         }

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -402,8 +402,3 @@ fn parse_extract_single_quotes() {
 fn parse_string_literal_backslash_escape() {
     redshift().one_statement_parses_to(r#"SELECT 'l\'auto'"#, "SELECT 'l''auto'");
 }
-
-#[test]
-fn test_alter_column_type() {
-    redshift().verified_stmt("ALTER TABLE customers ALTER COLUMN email TYPE TEXT");
-}

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -402,3 +402,8 @@ fn parse_extract_single_quotes() {
 fn parse_string_literal_backslash_escape() {
     redshift().one_statement_parses_to(r#"SELECT 'l\'auto'"#, "SELECT 'l''auto'");
 }
+
+#[test]
+fn test_alter_column_type() {
+    redshift().verified_stmt("ALTER TABLE customers ALTER COLUMN email TYPE TEXT");
+}


### PR DESCRIPTION
Expanded the support for `ALTER TABLE tbl ALTER COLUMN col TYPE <type>` to the Redshift dialect in addition to PostgreSQL. Generalized this option using the `supports_xxx` functions in the Dialect trait to maintain backwards compatibility with expected error messages in non-supporting dialects.

Improve SQL output from Ast by introducing an option to determine if `SET DATA` appears before the `TYPE` keyword.