### PR TITLE
fix: DuckDB accepts 2nd characters argument to TRIM

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2576,7 +2576,7 @@ impl<'a> Parser<'a> {
                 trim_characters: None,
             })
         } else if self.consume_token(&Token::Comma)
-            && dialect_of!(self is SnowflakeDialect | BigQueryDialect | GenericDialect)
+            && dialect_of!(self is DuckDbDialect | SnowflakeDialect | BigQueryDialect | GenericDialect)
         {
             let characters = self.parse_comma_separated(Parser::parse_expr)?;
             self.expect_token(&Token::RParen)?;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -7762,7 +7762,7 @@ fn parse_trim() {
         Box::new(MySqlDialect {}),
         //Box::new(BigQueryDialect {}),
         Box::new(SQLiteDialect {}),
-        Box::new(DuckDbDialect {}),
+        //Box::new(DuckDbDialect {}),
     ]);
 
     assert_eq!(


### PR DESCRIPTION
Like BigQuery and Snowflake, DuckDB also supports the 2nd `characters` argument to `TRIM`: https://duckdb.org/docs/stable/sql/functions/text.html#trimstring-characters

- DuckDB was added to the list of dialects potentially expecting a comma
- `test_duckdb_trim` is basically a copy of `test_bigquery_trim` using the proper dialect
- `parse_trim` test was updated to exclude DuckDB alongside BigQuery and Snowflake.
