### PR TITLE
Add support for dropping multiple columns in Snowflake

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -140,10 +140,10 @@ pub enum AlterTableOperation {
         name: Ident,
         drop_behavior: Option<DropBehavior>,
     },
-    /// `DROP [ COLUMN ] [ IF EXISTS ] <column_name> [ CASCADE ]`
+    /// `DROP [ COLUMN ] [ IF EXISTS ] <column_name> [ , <column_name>, ... ] [ CASCADE ]`
     DropColumn {
         has_column_keyword: bool,
-        column_name: Ident,
+        column_names: Vec<Ident>,
         if_exists: bool,
         drop_behavior: Option<DropBehavior>,
     },
@@ -631,7 +631,7 @@ impl fmt::Display for AlterTableOperation {
             AlterTableOperation::DropIndex { name } => write!(f, "DROP INDEX {name}"),
             AlterTableOperation::DropColumn {
                 has_column_keyword,
-                column_name,
+                column_names: column_name,
                 if_exists,
                 drop_behavior,
             } => write!(
@@ -639,7 +639,7 @@ impl fmt::Display for AlterTableOperation {
                 "DROP {}{}{}{}",
                 if *has_column_keyword { "COLUMN " } else { "" },
                 if *if_exists { "IF EXISTS " } else { "" },
-                column_name,
+                display_comma_separated(column_name),
                 match drop_behavior {
                     None => "",
                     Some(DropBehavior::Restrict) => " RESTRICT",

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1111,10 +1111,10 @@ impl Spanned for AlterTableOperation {
             } => name.span,
             AlterTableOperation::DropColumn {
                 has_column_keyword: _,
-                column_name,
+                column_names,
                 if_exists: _,
                 drop_behavior: _,
-            } => column_name.span,
+            } => union_spans(column_names.iter().map(|i| i.span)),
             AlterTableOperation::AttachPartition { partition } => partition.span(),
             AlterTableOperation::DetachPartition { partition } => partition.span(),
             AlterTableOperation::FreezePartition {

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1071,6 +1071,11 @@ pub trait Dialect: Debug + Any {
     fn supports_alter_column_type_using(&self) -> bool {
         false
     }
+
+    /// Returns true if the dialect supports `ALTER TABLE tbl DROP COLUMN c1, ..., cn`
+    fn supports_comma_separated_drop_column_list(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -364,6 +364,10 @@ impl Dialect for SnowflakeDialect {
     fn supports_space_separated_column_options(&self) -> bool {
         true
     }
+
+    fn supports_comma_separated_drop_column_list(&self) -> bool {
+        true
+    }
 }
 
 fn parse_file_staging_command(kw: Keyword, parser: &mut Parser) -> Result<Statement, ParserError> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8673,11 +8673,15 @@ impl<'a> Parser<'a> {
             } else {
                 let has_column_keyword = self.parse_keyword(Keyword::COLUMN); // [ COLUMN ]
                 let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
-                let column_name = self.parse_identifier()?;
+                let column_names = if self.dialect.supports_comma_separated_drop_column_list() {
+                    self.parse_comma_separated(Parser::parse_identifier)?
+                } else {
+                    vec![self.parse_identifier()?]
+                };
                 let drop_behavior = self.parse_optional_drop_behavior();
                 AlterTableOperation::DropColumn {
                     has_column_keyword,
-                    column_name,
+                    column_names,
                     if_exists,
                     drop_behavior,
                 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -4979,15 +4979,18 @@ fn parse_alter_table_drop_column() {
         "ALTER TABLE tab DROP is_active CASCADE",
     );
 
+    let dialects = all_dialects_where(|d| d.supports_comma_separated_drop_column_list());
+    dialects.verified_stmt("ALTER TABLE tbl DROP COLUMN c1, c2, c3");
+
     fn check_one(constraint_text: &str) {
         match alter_table_op(verified_stmt(&format!("ALTER TABLE tab {constraint_text}"))) {
             AlterTableOperation::DropColumn {
                 has_column_keyword: true,
-                column_name,
+                column_names,
                 if_exists,
                 drop_behavior,
             } => {
-                assert_eq!("is_active", column_name.to_string());
+                assert_eq!("is_active", column_names.first().unwrap().to_string());
                 assert!(if_exists);
                 match drop_behavior {
                     None => assert!(constraint_text.ends_with(" is_active")),

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -2876,7 +2876,7 @@ fn parse_alter_table_with_algorithm() {
                 vec![
                     AlterTableOperation::DropColumn {
                         has_column_keyword: true,
-                        column_name: Ident::new("password_digest"),
+                        column_names: vec![Ident::new("password_digest")],
                         if_exists: false,
                         drop_behavior: None,
                     },
@@ -2924,7 +2924,7 @@ fn parse_alter_table_with_lock() {
                 vec![
                     AlterTableOperation::DropColumn {
                         has_column_keyword: true,
-                        column_name: Ident::new("password_digest"),
+                        column_names: vec![Ident::new("password_digest")],
                         if_exists: false,
                         drop_behavior: None,
                     },


### PR DESCRIPTION
This is not documented but works. For example:
```sql
create or replace table multi_drop (id1 int, id2 int, id3 int);
alter table multi_drop drop column if exists id1, id2;
desc table multi_drop; -- shows id3
```