### PR TITLE
Make `GenericDialect` support trailing commas in projections

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -116,6 +116,10 @@ impl Dialect for GenericDialect {
         true
     }
 
+    fn supports_projection_trailing_commas(&self) -> bool {
+        true
+    }
+
     fn supports_asc_desc_in_column_definition(&self) -> bool {
         true
     }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11125,8 +11125,15 @@ fn parse_trailing_comma() {
     );
     trailing_commas.verified_stmt(r#"SELECT "from" FROM "from""#);
 
-    // doesn't allow all trailing commas
-    let trailing_commas = TestedDialects::new(vec![Box::new(GenericDialect {})]);
+    // doesn't allow any trailing commas
+    let trailing_commas = TestedDialects::new(vec![Box::new(PostgreSqlDialect {})]);
+
+    assert_eq!(
+        trailing_commas
+            .parse_sql_statements("SELECT name, age, from employees;")
+            .unwrap_err(),
+        ParserError::ParserError("Expected an expression, found: from".to_string())
+    );
 
     assert_eq!(
         trailing_commas

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -11125,15 +11125,8 @@ fn parse_trailing_comma() {
     );
     trailing_commas.verified_stmt(r#"SELECT "from" FROM "from""#);
 
-    // doesn't allow any trailing commas
+    // doesn't allow all trailing commas
     let trailing_commas = TestedDialects::new(vec![Box::new(GenericDialect {})]);
-
-    assert_eq!(
-        trailing_commas
-            .parse_sql_statements("SELECT name, age, from employees;")
-            .unwrap_err(),
-        ParserError::ParserError("Expected an expression, found: from".to_string())
-    );
 
     assert_eq!(
         trailing_commas


### PR DESCRIPTION
Similar to https://github.com/apache/datafusion-sqlparser-rs/pull/1911.

The docs for GenericDialect says that is can be permissive, so I thought it could support trailing commas in projections.

This would help a bit on the "friendly sql" issue
https://github.com/apache/datafusion/issues/14514

I removed a test-case that tested that ´GenericDialect` did not support trailing commas in projections. Positive tests for trailing commas still exists in the `parse_projection_trailing_comma` test