### PR TITLE
Align Snowflake dialect to new test of reserved keywords

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -301,9 +301,8 @@ impl Dialect for SnowflakeDialect {
         true
     }
 
-    fn is_select_item_alias(&self, explicit: bool, kw: &Keyword, parser: &mut Parser) -> bool {
-        explicit
-            || match kw {
+  fn is_column_alias(&self, kw: &Keyword, parser: &mut Parser) -> bool {
+        match kw {
             // The following keywords can be considered an alias as long as 
             // they are not followed by other tokens that may change their meaning
             // e.g. `SELECT * EXCEPT (col1) FROM tbl`

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -301,7 +301,7 @@ impl Dialect for SnowflakeDialect {
         true
     }
 
-  fn is_column_alias(&self, kw: &Keyword, parser: &mut Parser) -> bool {
+    fn is_column_alias(&self, kw: &Keyword, parser: &mut Parser) -> bool {
         match kw {
             // The following keywords can be considered an alias as long as 
             // they are not followed by other tokens that may change their meaning

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -3416,9 +3416,37 @@ fn parse_ls_and_rm() {
 }
 
 #[test]
+fn test_sql_keywords_as_select_item_ident() {
+    // Some keywords that should be parsed as an alias
+    let unreserved_kws = vec!["CLUSTER", "FETCH", "RETURNING", "LIMIT", "EXCEPT", "SORT"];
+    for kw in unreserved_kws {
+        snowflake().verified_stmt(&format!("SELECT 1, {kw}"));
+    }
+
+    // Some keywords that should not be parsed as an alias
+    let reserved_kws = vec![
+        "FROM",
+        "GROUP",
+        "HAVING",
+        "INTERSECT",
+        "INTO",
+        "ORDER",
+        "SELECT",
+        "UNION",
+        "WHERE",
+        "WITH",
+    ];
+    for kw in reserved_kws {
+        assert!(snowflake()
+            .parse_sql_statements(&format!("SELECT 1, {kw}"))
+            .is_err());
+    }
+}
+
+#[test]
 fn test_sql_keywords_as_select_item_aliases() {
     // Some keywords that should be parsed as an alias
-    let unreserved_kws = vec!["CLUSTER", "FETCH", "RETURNING", "LIMIT", "EXCEPT"];
+    let unreserved_kws = vec!["CLUSTER", "FETCH", "RETURNING", "LIMIT", "EXCEPT", "SORT"];
     for kw in unreserved_kws {
         snowflake()
             .one_statement_parses_to(&format!("SELECT 1 {kw}"), &format!("SELECT 1 AS {kw}"));


### PR DESCRIPTION
We've encountered a problem parsing statements like `SELECT 1, sort FROM tbl` which are valid in Snowflake.

The reason is that in the Snowflake dialect, supports_projection_trailing_commas is `true`. The flow then checks the keyword after the comma to see if it's reserved (`FROM` for example), and if not, it stops parsing the projection. However, the check relies on `Dialect::is_column_alias` which wasn't implemented in the Snowflake dialog. 

The solution is to align the behavior of the Snowflake dialect to other dialects by overriding `Dialect::is_column_alias` instead of `Dialect::is_select_item_alias`.