### PR TITLE
[branch-0.56] Fix `limit` in subqueries (#1899)

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -729,7 +729,7 @@ pub enum Expr {
     /// `[ NOT ] IN (SELECT ...)`
     InSubquery {
         expr: Box<Expr>,
-        subquery: Box<SetExpr>,
+        subquery: Box<Query>,
         negated: bool,
     },
     /// `[ NOT ] IN UNNEST(array_expression)`

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3752,7 +3752,7 @@ impl<'a> Parser<'a> {
             });
         }
         self.expect_token(&Token::LParen)?;
-        let in_op = match self.maybe_parse(|p| p.parse_query_body(p.dialect.prec_unknown()))? {
+        let in_op = match self.maybe_parse(|p| p.parse_query())? {
             Some(subquery) => Expr::InSubquery {
                 expr: Box::new(expr),
                 subquery,

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -2224,7 +2224,7 @@ fn parse_in_subquery() {
     assert_eq!(
         Expr::InSubquery {
             expr: Box::new(Expr::Identifier(Ident::new("segment"))),
-            subquery: verified_query("SELECT segm FROM bar").body,
+            subquery: Box::new(verified_query("SELECT segm FROM bar")),
             negated: false,
         },
         select.selection.unwrap()
@@ -2238,7 +2238,9 @@ fn parse_in_union() {
     assert_eq!(
         Expr::InSubquery {
             expr: Box::new(Expr::Identifier(Ident::new("segment"))),
-            subquery: verified_query("(SELECT segm FROM bar) UNION (SELECT segm FROM bar2)").body,
+            subquery: Box::new(verified_query(
+                "(SELECT segm FROM bar) UNION (SELECT segm FROM bar2)"
+            )),
             negated: false,
         },
         select.selection.unwrap()
@@ -15102,4 +15104,9 @@ fn parse_return() {
     assert_eq!(stmt, Statement::Return(ReturnStatement { value: None }));
 
     let _ = all_dialects().verified_stmt("RETURN 1");
+}
+
+#[test]
+fn parse_subquery_limit() {
+    let _ = all_dialects().verified_stmt("SELECT t1_id, t1_name FROM t1 WHERE t1_id IN (SELECT t2_id FROM t2 WHERE t1_name = t2_name LIMIT 10)");
 }


### PR DESCRIPTION
- Part of https://github.com/apache/datafusion-sqlparser-rs/issues/1952

- Backport of https://github.com/apache/datafusion-sqlparser-rs/pull/1899 to 0.56.0 branch