### PR TITLE
feat: support multiple value for pivot

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1336,7 +1336,7 @@ pub enum TableFactor {
     Pivot {
         table: Box<TableFactor>,
         aggregate_functions: Vec<ExprWithAlias>, // Function expression
-        value_column: Vec<Expr>, // Expr is a identifier or a compound identifier
+        value_column: Vec<Expr>,                 // Expr is a identifier or a compound identifier
         value_source: PivotValueSource,
         default_on_null: Option<Expr>,
         alias: Option<TableAlias>,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1336,7 +1336,7 @@ pub enum TableFactor {
     Pivot {
         table: Box<TableFactor>,
         aggregate_functions: Vec<ExprWithAlias>, // Function expression
-        value_column: Vec<Ident>,
+        value_column: Vec<Expr>, // Expr is a identifier or a compound identifier
         value_source: PivotValueSource,
         default_on_null: Option<Expr>,
         alias: Option<TableAlias>,
@@ -2010,10 +2010,15 @@ impl fmt::Display for TableFactor {
             } => {
                 write!(
                     f,
-                    "{table} PIVOT({} FOR {} IN ({value_source})",
+                    "{table} PIVOT({} FOR ",
                     display_comma_separated(aggregate_functions),
-                    Expr::CompoundIdentifier(value_column.to_vec()),
                 )?;
+                if value_column.len() == 1 {
+                    write!(f, "{}", value_column[0])?;
+                } else {
+                    write!(f, "({})", display_comma_separated(value_column))?;
+                }
+                write!(f, " IN ({value_source})")?;
                 if let Some(expr) = default_on_null {
                     write!(f, " DEFAULT ON NULL ({expr})")?;
                 }

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1336,7 +1336,7 @@ pub enum TableFactor {
     Pivot {
         table: Box<TableFactor>,
         aggregate_functions: Vec<ExprWithAlias>, // Function expression
-        value_column: Vec<Expr>,                 // Expr is a identifier or a compound identifier
+        value_column: Vec<Expr>,
         value_source: PivotValueSource,
         default_on_null: Option<Expr>,
         alias: Option<TableAlias>,

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1971,7 +1971,7 @@ impl Spanned for TableFactor {
             } => union_spans(
                 core::iter::once(table.span())
                     .chain(aggregate_functions.iter().map(|i| i.span()))
-                    .chain(value_column.iter().map(|i| i.span))
+                    .chain(value_column.iter().map(|i| i.span()))
                     .chain(core::iter::once(value_source.span()))
                     .chain(default_on_null.as_ref().map(|i| i.span()))
                     .chain(alias.as_ref().map(|i| i.span())),

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -884,6 +884,8 @@ mod tests {
                     "PRE: EXPR: a.amount",
                     "POST: EXPR: a.amount",
                     "POST: EXPR: SUM(a.amount)",
+                    "PRE: EXPR: a.MONTH",
+                    "POST: EXPR: a.MONTH",
                     "PRE: EXPR: 'JAN'",
                     "POST: EXPR: 'JAN'",
                     "PRE: EXPR: 'FEB'",

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13838,7 +13838,7 @@ impl<'a> Parser<'a> {
         self.expect_token(&Token::LParen)?;
         let aggregate_functions = self.parse_comma_separated(Self::parse_aliased_function_call)?;
         self.expect_keyword_is(Keyword::FOR)?;
-        let value_column = if self.peek_token().token == Token::LParen {
+        let value_column = if self.peek_token_ref().token == Token::LParen {
             self.parse_parenthesized_compound_identifier_list(Mandatory, false)?
         } else {
             vec![Expr::CompoundIdentifier(self.parse_period_separated(|p| p.parse_identifier())?)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13841,11 +13841,11 @@ impl<'a> Parser<'a> {
         let aggregate_functions = self.parse_comma_separated(Self::parse_aliased_function_call)?;
         self.expect_keyword_is(Keyword::FOR)?;
         let value_column = if self.peek_token_ref().token == Token::LParen {
-            self.parse_parenthesized_compound_identifier_list(Mandatory, false)?
+            self.parse_parenthesized_column_list_inner(Mandatory, false, |p| {
+                p.parse_subexpr(self.dialect.prec_value(Precedence::Between))
+            })?
         } else {
-            vec![Expr::CompoundIdentifier(
-                self.parse_period_separated(|p| p.parse_identifier())?,
-            )]
+            vec![self.parse_subexpr(self.dialect.prec_value(Precedence::Between))?]
         };
         self.expect_keyword_is(Keyword::IN)?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10826,7 +10826,9 @@ impl<'a> Parser<'a> {
         allow_empty: bool,
     ) -> Result<Vec<Expr>, ParserError> {
         self.parse_parenthesized_column_list_inner(optional, allow_empty, |p| {
-            Ok(Expr::CompoundIdentifier(p.parse_period_separated(|p| p.parse_identifier())?))
+            Ok(Expr::CompoundIdentifier(
+                p.parse_period_separated(|p| p.parse_identifier())?,
+            ))
         })
     }
 
@@ -13841,7 +13843,9 @@ impl<'a> Parser<'a> {
         let value_column = if self.peek_token_ref().token == Token::LParen {
             self.parse_parenthesized_compound_identifier_list(Mandatory, false)?
         } else {
-            vec![Expr::CompoundIdentifier(self.parse_period_separated(|p| p.parse_identifier())?)]
+            vec![Expr::CompoundIdentifier(
+                self.parse_period_separated(|p| p.parse_identifier())?,
+            )]
         };
         self.expect_keyword_is(Keyword::IN)?;
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -10968,7 +10968,9 @@ fn parse_pivot_table() {
                         Expr::Value(
                             (Value::SingleQuotedString("John".to_string())).with_empty_span()
                         ),
-                        Expr::Value((Value::Number("30".into(), false)).with_empty_span()),
+                        Expr::Value(
+                            (Value::Number("30".parse().unwrap(), false)).with_empty_span()
+                        ),
                     ]),
                     alias: Some(Ident::new("c1"))
                 },
@@ -10977,7 +10979,9 @@ fn parse_pivot_table() {
                         Expr::Value(
                             (Value::SingleQuotedString("Mike".to_string())).with_empty_span()
                         ),
-                        Expr::Value((Value::Number("40".into(), false)).with_empty_span()),
+                        Expr::Value(
+                            (Value::Number("40".parse().unwrap(), false)).with_empty_span()
+                        ),
                     ]),
                     alias: Some(Ident::new("c2"))
                 },

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -10875,7 +10875,7 @@ fn parse_pivot_table() {
                 expected_function("b", Some("t")),
                 expected_function("c", Some("u")),
             ],
-            value_column: vec![Ident::new("a"), Ident::new("MONTH")],
+            value_column: vec![Expr::CompoundIdentifier(vec![Ident::new("a"), Ident::new("MONTH")])],
             value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
                     expr: Expr::value(number("1")),
@@ -10922,6 +10922,12 @@ fn parse_pivot_table() {
         verified_stmt(sql_without_table_alias).to_string(),
         sql_without_table_alias
     );
+
+    let sql_with_multiple_value_column = concat!(
+        "SELECT * FROM person ",
+        "PIVOT(SUM(age) AS a, AVG(class) AS c FOR (name, age) IN (('John', 30) AS c1, ('Mike', 40) AS c2))"
+    );
+    assert_eq!(verified_stmt(sql_with_multiple_value_column).to_string(), sql_with_multiple_value_column);
 }
 
 #[test]
@@ -11143,7 +11149,7 @@ fn parse_pivot_unpivot_table() {
                 expr: call("sum", [Expr::Identifier(Ident::new("population"))]),
                 alias: None
             }],
-            value_column: vec![Ident::new("year")],
+            value_column: vec![Expr::CompoundIdentifier(vec![Ident::new("year")])],
             value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
                     expr: Expr::Value(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -10925,6 +10925,71 @@ fn parse_pivot_table() {
         verified_stmt(sql_without_table_alias).to_string(),
         sql_without_table_alias
     );
+
+    let multiple_value_columns_sql = concat!(
+        "SELECT * FROM person ",
+        "PIVOT(",
+        "SUM(age) AS a, AVG(class) AS c ",
+        "FOR (name, age) IN (('John', 30) AS c1, ('Mike', 40) AS c2))",
+    );
+
+    assert_eq!(
+        verified_only_select(multiple_value_columns_sql).from[0].relation,
+        Pivot {
+            table: Box::new(TableFactor::Table {
+                name: ObjectName::from(vec![Ident::new("person")]),
+                alias: None,
+                args: None,
+                with_hints: vec![],
+                version: None,
+                partitions: vec![],
+                with_ordinality: false,
+                json_path: None,
+                sample: None,
+                index_hints: vec![],
+            }),
+            aggregate_functions: vec![
+                ExprWithAlias {
+                    expr: call("SUM", [Expr::Identifier(Ident::new("age"))]),
+                    alias: Some(Ident::new("a"))
+                },
+                ExprWithAlias {
+                    expr: call("AVG", [Expr::Identifier(Ident::new("class"))]),
+                    alias: Some(Ident::new("c"))
+                },
+            ],
+            value_column: vec![
+                Expr::Identifier(Ident::new("name")),
+                Expr::Identifier(Ident::new("age")),
+            ],
+            value_source: PivotValueSource::List(vec![
+                ExprWithAlias {
+                    expr: Expr::Tuple(vec![
+                        Expr::Value(
+                            (Value::SingleQuotedString("John".to_string())).with_empty_span()
+                        ),
+                        Expr::Value((Value::Number("30".into(), false)).with_empty_span()),
+                    ]),
+                    alias: Some(Ident::new("c1"))
+                },
+                ExprWithAlias {
+                    expr: Expr::Tuple(vec![
+                        Expr::Value(
+                            (Value::SingleQuotedString("Mike".to_string())).with_empty_span()
+                        ),
+                        Expr::Value((Value::Number("40".into(), false)).with_empty_span()),
+                    ]),
+                    alias: Some(Ident::new("c2"))
+                },
+            ]),
+            default_on_null: None,
+            alias: None,
+        }
+    );
+    assert_eq!(
+        verified_stmt(multiple_value_columns_sql).to_string(),
+        multiple_value_columns_sql
+    );
 }
 
 #[test]
@@ -11146,7 +11211,7 @@ fn parse_pivot_unpivot_table() {
                 expr: call("sum", [Expr::Identifier(Ident::new("population"))]),
                 alias: None
             }],
-            value_column: vec![Expr::CompoundIdentifier(vec![Ident::new("year")])],
+            value_column: vec![Expr::Identifier(Ident::new("year"))],
             value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
                     expr: Expr::Value(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -10925,15 +10925,6 @@ fn parse_pivot_table() {
         verified_stmt(sql_without_table_alias).to_string(),
         sql_without_table_alias
     );
-
-    let sql_with_multiple_value_column = concat!(
-        "SELECT * FROM person ",
-        "PIVOT(SUM(age) AS a, AVG(class) AS c FOR (name, age) IN (('John', 30) AS c1, ('Mike', 40) AS c2))"
-    );
-    assert_eq!(
-        verified_stmt(sql_with_multiple_value_column).to_string(),
-        sql_with_multiple_value_column
-    );
 }
 
 #[test]

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -10875,7 +10875,10 @@ fn parse_pivot_table() {
                 expected_function("b", Some("t")),
                 expected_function("c", Some("u")),
             ],
-            value_column: vec![Expr::CompoundIdentifier(vec![Ident::new("a"), Ident::new("MONTH")])],
+            value_column: vec![Expr::CompoundIdentifier(vec![
+                Ident::new("a"),
+                Ident::new("MONTH")
+            ])],
             value_source: PivotValueSource::List(vec![
                 ExprWithAlias {
                     expr: Expr::value(number("1")),
@@ -10927,7 +10930,10 @@ fn parse_pivot_table() {
         "SELECT * FROM person ",
         "PIVOT(SUM(age) AS a, AVG(class) AS c FOR (name, age) IN (('John', 30) AS c1, ('Mike', 40) AS c2))"
     );
-    assert_eq!(verified_stmt(sql_with_multiple_value_column).to_string(), sql_with_multiple_value_column);
+    assert_eq!(
+        verified_stmt(sql_with_multiple_value_column).to_string(),
+        sql_with_multiple_value_column
+    );
 }
 
 #[test]


### PR DESCRIPTION
https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-pivot.html

currently this sql is not supported.
```
SELECT * FROM person
    PIVOT (
        SUM(age) AS a, AVG(class) AS c
        FOR (name, age) IN (('John', 30) AS c1, ('Mike', 40) AS c2)
    );
```
