### PR TITLE
feat: support datetime_field as expr for bigquery

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -924,6 +924,9 @@ pub enum Expr {
         syntax: ExtractSyntax,
         expr: Box<Expr>,
     },
+    /// In BigQuery, the `DATE_TRUNC` and `DATETIME_TRUNC` functions can be used to truncate a timestamp to a different granularity.
+    /// e.g. `DATE_TRUNC(CURRENT_DATE(), DAY)`
+    DateTimeField(DateTimeField),
     /// ```sql
     /// CEIL(<expr> [TO DateTimeField])
     /// ```
@@ -1937,6 +1940,7 @@ impl fmt::Display for Expr {
             Expr::Prior(expr) => write!(f, "PRIOR {expr}"),
             Expr::Lambda(lambda) => write!(f, "{lambda}"),
             Expr::MemberOf(member_of) => write!(f, "{member_of}"),
+            Expr::DateTimeField(field) => write!(f, "{field}"),
         }
     }
 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1625,6 +1625,7 @@ impl Spanned for Expr {
             Expr::Prior(expr) => expr.span(),
             Expr::Lambda(_) => Span::empty(),
             Expr::MemberOf(member_of) => member_of.value.span().union(&member_of.array.span()),
+            Expr::DateTimeField(_) => Span::empty(),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14896,6 +14896,12 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse_function_args(&mut self) -> Result<FunctionArg, ParserError> {
+        if dialect_of!(self is BigQueryDialect) && self.next_token_is_temporal_unit() {
+            let unit = self.parse_date_time_field()?;
+            return Ok(FunctionArg::Unnamed(FunctionArgExpr::Expr(
+                Expr::DateTimeField(unit),
+            )));
+        }
         let arg = if self.dialect.supports_named_fn_args_with_expr_name() {
             self.maybe_parse(|p| {
                 let name = p.parse_expr()?;


### PR DESCRIPTION
bigquery supports 
```
SELECT DATETIME_TRUNC(CURRENT_DATETIME, WEEK(MONDAY))
```
`WEEK(MONDAY)` should be parsed to datetime_field

