### PR TITLE
fix: begin statement for bigquery

### DIFF
--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -48,12 +48,10 @@ pub struct BigQueryDialect;
 impl Dialect for BigQueryDialect {
     fn parse_statement(&self, parser: &mut Parser) -> Option<Result<Statement, ParserError>> {
         if parser.parse_keyword(Keyword::BEGIN) {
-            if parser.peek_keyword(Keyword::TRANSACTION) {
-                parser.prev_token();
-                return None;
-            }
-            let peek_token = parser.peek_token_ref();
-            if peek_token.token == Token::SemiColon || peek_token.token == Token::EOF {
+            if parser.peek_keyword(Keyword::TRANSACTION)
+                || parser.peek_token_ref().token == Token::SemiColon
+                || parser.peek_token_ref().token == Token::EOF
+            {
                 parser.prev_token();
                 return None;
             }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2567,7 +2567,6 @@ fn test_struct_trailing_and_nested_bracket() {
     );
 }
 
-// https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#begin_transaction
 #[test]
 fn test_begin_transaction() {
     bigquery().verified_stmt("BEGIN TRANSACTION");

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2566,3 +2566,14 @@ fn test_struct_trailing_and_nested_bracket() {
         )
     );
 }
+
+// https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#begin_transaction
+#[test]
+fn test_begin_transaction() {
+    bigquery().verified_stmt("BEGIN TRANSACTION");
+}
+
+#[test]
+fn test_begin_statement() {
+    bigquery().verified_stmt("BEGIN");
+}


### PR DESCRIPTION
big query supports,

```
BEGIN [TRANSACTION];
```

but currently parse_statement is overwritten for bigquery, and this statement is not supported.

