### PR TITLE
Postgres: Support `INTERVAL` data type options

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -346,7 +346,16 @@ pub enum DataType {
     /// [1]: https://docs.databricks.com/aws/en/sql/language-manual/data-types/timestamp-ntz-type
     TimestampNtz,
     /// Interval type.
-    Interval,
+    Interval {
+        /// [PostgreSQL] fields specification like `INTERVAL YEAR TO MONTH`.
+        ///
+        /// [PostgreSQL]: https://www.postgresql.org/docs/17/datatype-datetime.html
+        fields: Option<IntervalFields>,
+        /// [PostgreSQL] subsecond precision like `INTERVAL HOUR TO SECOND(3)`
+        ///
+        /// [PostgreSQL]: https://www.postgresql.org/docs/17/datatype-datetime.html
+        precision: Option<u64>,
+    },
     /// JSON type.
     JSON,
     /// Binary JSON type.
@@ -635,7 +644,16 @@ impl fmt::Display for DataType {
                     timezone,
                 )
             }
-            DataType::Interval => write!(f, "INTERVAL"),
+            DataType::Interval { fields, precision } => {
+                write!(f, "INTERVAL")?;
+                if let Some(fields) = fields {
+                    write!(f, " {fields}")?;
+                }
+                if let Some(precision) = precision {
+                    write!(f, "({precision})")?;
+                }
+                Ok(())
+            }
             DataType::JSON => write!(f, "JSON"),
             DataType::JSONB => write!(f, "JSONB"),
             DataType::Regclass => write!(f, "REGCLASS"),
@@ -885,6 +903,48 @@ impl fmt::Display for TimezoneInfo {
                 // for more information
                 write!(f, "TZ")
             }
+        }
+    }
+}
+
+/// Fields for [Postgres] `INTERVAL` type.
+///
+/// [Postgres]: https://www.postgresql.org/docs/17/datatype-datetime.html
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub enum IntervalFields {
+    Year,
+    Month,
+    Day,
+    Hour,
+    Minute,
+    Second,
+    YearToMonth,
+    DayToHour,
+    DayToMinute,
+    DayToSecond,
+    HourToMinute,
+    HourToSecond,
+    MinuteToSecond,
+}
+
+impl fmt::Display for IntervalFields {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IntervalFields::Year => write!(f, "YEAR"),
+            IntervalFields::Month => write!(f, "MONTH"),
+            IntervalFields::Day => write!(f, "DAY"),
+            IntervalFields::Hour => write!(f, "HOUR"),
+            IntervalFields::Minute => write!(f, "MINUTE"),
+            IntervalFields::Second => write!(f, "SECOND"),
+            IntervalFields::YearToMonth => write!(f, "YEAR TO MONTH"),
+            IntervalFields::DayToHour => write!(f, "DAY TO HOUR"),
+            IntervalFields::DayToMinute => write!(f, "DAY TO MINUTE"),
+            IntervalFields::DayToSecond => write!(f, "DAY TO SECOND"),
+            IntervalFields::HourToMinute => write!(f, "HOUR TO MINUTE"),
+            IntervalFields::HourToSecond => write!(f, "HOUR TO SECOND"),
+            IntervalFields::MinuteToSecond => write!(f, "MINUTE TO SECOND"),
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -52,7 +52,7 @@ use crate::{
 
 pub use self::data_type::{
     ArrayElemTypeDef, BinaryLength, CharLengthUnits, CharacterLength, DataType, EnumMember,
-    ExactNumberInfo, StructBracketKind, TimezoneInfo,
+    ExactNumberInfo, IntervalFields, StructBracketKind, TimezoneInfo,
 };
 pub use self::dcl::{
     AlterRoleOperation, ResetConfig, RoleOption, SecondaryRoles, SetConfigValue, Use,

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -187,4 +187,8 @@ impl Dialect for GenericDialect {
     fn supports_data_type_signed_suffix(&self) -> bool {
         true
     }
+
+    fn supports_interval_options(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1148,6 +1148,21 @@ pub trait Dialect: Debug + Any {
     fn supports_data_type_signed_suffix(&self) -> bool {
         false
     }
+
+    /// Returns true if the dialect supports the `INTERVAL` data type with [Postgres]-style options.
+    ///
+    /// Examples:
+    /// ```sql
+    /// CREATE TABLE t (i INTERVAL YEAR TO MONTH);
+    /// SELECT '1 second'::INTERVAL HOUR TO SECOND(3);
+    /// ```
+    ///
+    /// See [`crate::ast::DataType::Interval`] and [`crate::ast::IntervalFields`].
+    ///
+    /// [Postgres]: https://www.postgresql.org/docs/17/datatype-datetime.html
+    fn supports_interval_options(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -269,4 +269,11 @@ impl Dialect for PostgreSqlDialect {
     fn supports_notnull_operator(&self) -> bool {
         true
     }
+
+    /// [Postgres] supports optional field and precision options for `INTERVAL` data type.
+    ///
+    /// [Postgres]: https://www.postgresql.org/docs/17/datatype-datetime.html
+    fn supports_interval_options(&self) -> bool {
+        true
+    }
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -961,7 +961,10 @@ fn parse_typed_struct_syntax_bigquery() {
             })],
             fields: vec![StructField {
                 field_name: None,
-                field_type: DataType::Interval,
+                field_type: DataType::Interval {
+                    fields: None,
+                    precision: None
+                },
                 options: None,
             }]
         },
@@ -1300,7 +1303,10 @@ fn parse_typed_struct_syntax_bigquery_and_generic() {
             })],
             fields: vec![StructField {
                 field_name: None,
-                field_type: DataType::Interval,
+                field_type: DataType::Interval {
+                    fields: None,
+                    precision: None
+                },
                 options: None,
             }]
         },

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -12955,7 +12955,10 @@ fn test_extract_seconds_ok() {
                 expr: Box::new(Expr::Value(
                     (Value::SingleQuotedString("2 seconds".to_string())).with_empty_span()
                 )),
-                data_type: DataType::Interval,
+                data_type: DataType::Interval {
+                    fields: None,
+                    precision: None
+                },
                 format: None,
             }),
         }
@@ -12980,7 +12983,10 @@ fn test_extract_seconds_ok() {
                     expr: Box::new(Expr::Value(
                         (Value::SingleQuotedString("2 seconds".to_string())).with_empty_span(),
                     )),
-                    data_type: DataType::Interval,
+                    data_type: DataType::Interval {
+                        fields: None,
+                        precision: None,
+                    },
                     format: None,
                 }),
             })],
@@ -13034,7 +13040,10 @@ fn test_extract_seconds_single_quote_ok() {
                 expr: Box::new(Expr::Value(
                     (Value::SingleQuotedString("2 seconds".to_string())).with_empty_span()
                 )),
-                data_type: DataType::Interval,
+                data_type: DataType::Interval {
+                    fields: None,
+                    precision: None
+                },
                 format: None,
             }),
         }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5333,6 +5333,44 @@ fn parse_at_time_zone() {
 }
 
 #[test]
+fn parse_interval_data_type() {
+    pg_and_generic().verified_stmt("CREATE TABLE t (i INTERVAL)");
+    for p in 0..=6 {
+        pg_and_generic().verified_stmt(&format!("CREATE TABLE t (i INTERVAL({p}))"));
+        pg_and_generic().verified_stmt(&format!("SELECT '1 second'::INTERVAL({p})"));
+        pg_and_generic().verified_stmt(&format!("SELECT CAST('1 second' AS INTERVAL({p}))"));
+    }
+    let fields = [
+        "YEAR",
+        "MONTH",
+        "DAY",
+        "HOUR",
+        "MINUTE",
+        "SECOND",
+        "YEAR TO MONTH",
+        "DAY TO HOUR",
+        "DAY TO MINUTE",
+        "DAY TO SECOND",
+        "HOUR TO MINUTE",
+        "HOUR TO SECOND",
+        "MINUTE TO SECOND",
+    ];
+    for field in fields {
+        pg_and_generic().verified_stmt(&format!("CREATE TABLE t (i INTERVAL {field})"));
+        pg_and_generic().verified_stmt(&format!("SELECT '1 second'::INTERVAL {field}"));
+        pg_and_generic().verified_stmt(&format!("SELECT CAST('1 second' AS INTERVAL {field})"));
+    }
+    for p in 0..=6 {
+        for field in fields {
+            pg_and_generic().verified_stmt(&format!("CREATE TABLE t (i INTERVAL {field}({p}))"));
+            pg_and_generic().verified_stmt(&format!("SELECT '1 second'::INTERVAL {field}({p})"));
+            pg_and_generic()
+                .verified_stmt(&format!("SELECT CAST('1 second' AS INTERVAL {field}({p}))"));
+        }
+    }
+}
+
+#[test]
 fn parse_create_table_with_options() {
     let sql = "CREATE TABLE t (c INT) WITH (foo = 'bar', a = 123)";
     match pg().verified_stmt(sql) {


### PR DESCRIPTION
[Postgres] allows extra options for the `INTERVAL` data type; namely fields and subsecond precision. For example `'3 years 1 second'::interval year to month` casts the interval and strips the seconds, and `'1.3333 seconds'::interval(1)` returns `1.3` seconds.

This is supported by adding two optional fields to `DataType::Interval`, along with a new `enum` for the allowed fields.

Note that [MSSQL] also supports similar options, but with more complicated precision syntax, e.g. `INTERVAL HOUR(p) TO SECOND(q)`. This is not implemented in this commit because I don't have a way to test it.

[Postgres]: https://www.postgresql.org/docs/17/datatype-datetime.html
[MSSQL]: https://learn.microsoft.com/en-us/sql/odbc/reference/appendixes/sql-data-types?view=sql-server-ver17