### PR TITLE
MySQL: Allow optional `SIGNED` suffix on integer data types

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -183,4 +183,8 @@ impl Dialect for GenericDialect {
     fn supports_select_wildcard_exclude(&self) -> bool {
         true
     }
+
+    fn supports_data_type_signed_suffix(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1136,6 +1136,18 @@ pub trait Dialect: Debug + Any {
     fn supports_notnull_operator(&self) -> bool {
         false
     }
+
+    /// Returns true if this dialect allows an optional `SIGNED` suffix after integer data types.
+    ///
+    /// Example:
+    /// ```sql
+    /// CREATE TABLE t (i INT(20) SIGNED);
+    /// ```
+    ///
+    /// Note that this is canonicalized to `INT(20)`.
+    fn supports_data_type_signed_suffix(&self) -> bool {
+        false
+    }
 }
 
 /// This represents the operators for which precedence must be defined

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -154,6 +154,10 @@ impl Dialect for MySqlDialect {
     fn supports_comma_separated_set_assignments(&self) -> bool {
         true
     }
+
+    fn supports_data_type_signed_suffix(&self) -> bool {
+        true
+    }
 }
 
 /// `LOCK TABLES`

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9848,6 +9848,9 @@ impl<'a> Parser<'a> {
                     if self.parse_keyword(Keyword::UNSIGNED) {
                         Ok(DataType::TinyIntUnsigned(optional_precision?))
                     } else {
+                        if dialect.supports_data_type_signed_suffix() {
+                            let _ = self.parse_keyword(Keyword::SIGNED);
+                        }
                         Ok(DataType::TinyInt(optional_precision?))
                     }
                 }
@@ -9864,6 +9867,9 @@ impl<'a> Parser<'a> {
                     if self.parse_keyword(Keyword::UNSIGNED) {
                         Ok(DataType::SmallIntUnsigned(optional_precision?))
                     } else {
+                        if dialect.supports_data_type_signed_suffix() {
+                            let _ = self.parse_keyword(Keyword::SIGNED);
+                        }
                         Ok(DataType::SmallInt(optional_precision?))
                     }
                 }
@@ -9872,6 +9878,9 @@ impl<'a> Parser<'a> {
                     if self.parse_keyword(Keyword::UNSIGNED) {
                         Ok(DataType::MediumIntUnsigned(optional_precision?))
                     } else {
+                        if dialect.supports_data_type_signed_suffix() {
+                            let _ = self.parse_keyword(Keyword::SIGNED);
+                        }
                         Ok(DataType::MediumInt(optional_precision?))
                     }
                 }
@@ -9880,6 +9889,9 @@ impl<'a> Parser<'a> {
                     if self.parse_keyword(Keyword::UNSIGNED) {
                         Ok(DataType::IntUnsigned(optional_precision?))
                     } else {
+                        if dialect.supports_data_type_signed_suffix() {
+                            let _ = self.parse_keyword(Keyword::SIGNED);
+                        }
                         Ok(DataType::Int(optional_precision?))
                     }
                 }
@@ -9909,6 +9921,9 @@ impl<'a> Parser<'a> {
                     if self.parse_keyword(Keyword::UNSIGNED) {
                         Ok(DataType::IntegerUnsigned(optional_precision?))
                     } else {
+                        if dialect.supports_data_type_signed_suffix() {
+                            let _ = self.parse_keyword(Keyword::SIGNED);
+                        }
                         Ok(DataType::Integer(optional_precision?))
                     }
                 }
@@ -9917,6 +9932,9 @@ impl<'a> Parser<'a> {
                     if self.parse_keyword(Keyword::UNSIGNED) {
                         Ok(DataType::BigIntUnsigned(optional_precision?))
                     } else {
+                        if dialect.supports_data_type_signed_suffix() {
+                            let _ = self.parse_keyword(Keyword::SIGNED);
+                        }
                         Ok(DataType::BigInt(optional_precision?))
                     }
                 }


### PR DESCRIPTION
In MySQL, a data type like `INT(20) SIGNED` is equivalent to `INT(20)`. In other dialects, this may be interpreted differently; e.g. in Postgres, `SELECT 1::integer signed` indicates an alias of "signed". So we parse the optional `SIGNED` suffix only on dialects that allow it (I currently don't know of any other than MySQL).