### PR TITLE
Postgres: enhance NUMERIC/DECIMAL parsing to support negative scale

### DIFF
--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -962,7 +962,7 @@ pub enum ExactNumberInfo {
     /// Only precision information, e.g. `DECIMAL(10)`
     Precision(u64),
     /// Precision and scale information, e.g. `DECIMAL(10,2)`
-    PrecisionAndScale(u64, u64),
+    PrecisionAndScale(u64, i64),
 }
 
 impl fmt::Display for ExactNumberInfo {


### PR DESCRIPTION
Closes #1923 

> Beginning in PostgreSQL 15, it is allowed to declare a numeric column with a negative scale.

**Source:** [PostgreSQL Documentation - Numeric Types](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL)

## Changes
- Modified `ExactNumberInfo::PrecisionAndScale` to use `i64` instead of `u64` for scale
- Added `parse_scale_value()` method to handle positive, negative, and explicitly positive scale values
- Updated tests to cover negative scale scenarios