### PR TITLE
Improve MySQL `CREATE TRIGGER` parsing

### DIFF
--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -257,6 +257,7 @@ impl MsSqlDialect {
             is_constraint: false,
             name,
             period,
+            period_before_table: false,
             events,
             table_name,
             referenced_table_name: None,
@@ -265,6 +266,7 @@ impl MsSqlDialect {
             include_each: false,
             condition: None,
             exec_body: None,
+            statements_as: true,
             statements,
             characteristics: None,
         })

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5593,9 +5593,13 @@ impl<'a> Parser<'a> {
             .then(|| self.parse_expr())
             .transpose()?;
 
-        self.expect_keyword_is(Keyword::EXECUTE)?;
-
-        let exec_body = self.parse_trigger_exec_body()?;
+        let mut exec_body = None;
+        let mut statements = None;
+        if self.parse_keyword(Keyword::EXECUTE) {
+            exec_body = Some(self.parse_trigger_exec_body()?);
+        } else {
+            statements = Some(self.parse_conditional_statements(&[Keyword::END])?);
+        }
 
         Ok(Statement::CreateTrigger {
             or_alter,
@@ -5603,6 +5607,7 @@ impl<'a> Parser<'a> {
             is_constraint,
             name,
             period,
+            period_before_table: true,
             events,
             table_name,
             referenced_table_name,
@@ -5610,8 +5615,9 @@ impl<'a> Parser<'a> {
             trigger_object,
             include_each,
             condition,
-            exec_body: Some(exec_body),
-            statements: None,
+            exec_body,
+            statements_as: false,
+            statements,
             characteristics,
         })
     }
@@ -6537,7 +6543,7 @@ impl<'a> Parser<'a> {
 
         let args = if self.consume_token(&Token::LParen) {
             if self.consume_token(&Token::RParen) {
-                None
+                Some(vec![])
             } else {
                 let args = self.parse_comma_separated(Parser::parse_function_arg)?;
                 self.expect_token(&Token::RParen)?;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9313,10 +9313,10 @@ impl<'a> Parser<'a> {
                 }),
             }))
         } else {
-            return self.expected_ref(
+            self.expected_ref(
                 "{RENAME TO | { RENAME | ADD } VALUE}",
                 self.peek_token_ref(),
-            );
+            )
         }
     }
 

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2806,9 +2806,9 @@ fn test_export_data() {
     );
 
     let err = bigquery()
-        .parse_sql_statements(concat!(
+        .parse_sql_statements(
             "EXPORT DATA AS SELECT field1, field2 FROM mydataset.table1 ORDER BY field1 LIMIT 10",
-        ))
+        )
         .unwrap_err();
     assert_eq!(
         err.to_string(),

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2376,6 +2376,7 @@ fn parse_create_trigger() {
             is_constraint: false,
             name: ObjectName::from(vec![Ident::new("reminder1")]),
             period: TriggerPeriod::After,
+            period_before_table: false,
             events: vec![TriggerEvent::Insert, TriggerEvent::Update(vec![]),],
             table_name: ObjectName::from(vec![Ident::new("Sales"), Ident::new("Customer")]),
             referenced_table_name: None,
@@ -2384,6 +2385,7 @@ fn parse_create_trigger() {
             include_each: false,
             condition: None,
             exec_body: None,
+            statements_as: true,
             statements: Some(ConditionalStatements::Sequence {
                 statements: vec![Statement::RaisError {
                     message: Box::new(Expr::Value(

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5552,6 +5552,7 @@ fn parse_create_simple_before_insert_trigger() {
         is_constraint: false,
         name: ObjectName::from(vec![Ident::new("check_insert")]),
         period: TriggerPeriod::Before,
+        period_before_table: true,
         events: vec![TriggerEvent::Insert],
         table_name: ObjectName::from(vec![Ident::new("accounts")]),
         referenced_table_name: None,
@@ -5566,6 +5567,7 @@ fn parse_create_simple_before_insert_trigger() {
                 args: None,
             },
         }),
+        statements_as: false,
         statements: None,
         characteristics: None,
     };
@@ -5582,6 +5584,7 @@ fn parse_create_after_update_trigger_with_condition() {
         is_constraint: false,
         name: ObjectName::from(vec![Ident::new("check_update")]),
         period: TriggerPeriod::After,
+        period_before_table: true,
         events: vec![TriggerEvent::Update(vec![])],
         table_name: ObjectName::from(vec![Ident::new("accounts")]),
         referenced_table_name: None,
@@ -5603,6 +5606,7 @@ fn parse_create_after_update_trigger_with_condition() {
                 args: None,
             },
         }),
+        statements_as: false,
         statements: None,
         characteristics: None,
     };
@@ -5619,6 +5623,7 @@ fn parse_create_instead_of_delete_trigger() {
         is_constraint: false,
         name: ObjectName::from(vec![Ident::new("check_delete")]),
         period: TriggerPeriod::InsteadOf,
+        period_before_table: true,
         events: vec![TriggerEvent::Delete],
         table_name: ObjectName::from(vec![Ident::new("accounts")]),
         referenced_table_name: None,
@@ -5633,6 +5638,7 @@ fn parse_create_instead_of_delete_trigger() {
                 args: None,
             },
         }),
+        statements_as: false,
         statements: None,
         characteristics: None,
     };
@@ -5649,6 +5655,7 @@ fn parse_create_trigger_with_multiple_events_and_deferrable() {
         is_constraint: true,
         name: ObjectName::from(vec![Ident::new("check_multiple_events")]),
         period: TriggerPeriod::Before,
+        period_before_table: true,
         events: vec![
             TriggerEvent::Insert,
             TriggerEvent::Update(vec![]),
@@ -5667,6 +5674,7 @@ fn parse_create_trigger_with_multiple_events_and_deferrable() {
                 args: None,
             },
         }),
+        statements_as: false,
         statements: None,
         characteristics: Some(ConstraintCharacteristics {
             deferrable: Some(true),
@@ -5687,6 +5695,7 @@ fn parse_create_trigger_with_referencing() {
         is_constraint: false,
         name: ObjectName::from(vec![Ident::new("check_referencing")]),
         period: TriggerPeriod::Before,
+        period_before_table: true,
         events: vec![TriggerEvent::Insert],
         table_name: ObjectName::from(vec![Ident::new("accounts")]),
         referenced_table_name: None,
@@ -5712,6 +5721,7 @@ fn parse_create_trigger_with_referencing() {
                 args: None,
             },
         }),
+        statements_as: false,
         statements: None,
         characteristics: None,
     };
@@ -5994,6 +6004,7 @@ fn parse_trigger_related_functions() {
             is_constraint: false,
             name: ObjectName::from(vec![Ident::new("emp_stamp")]),
             period: TriggerPeriod::Before,
+            period_before_table: true,
             events: vec![TriggerEvent::Insert, TriggerEvent::Update(vec![])],
             table_name: ObjectName::from(vec![Ident::new("emp")]),
             referenced_table_name: None,
@@ -6005,9 +6016,10 @@ fn parse_trigger_related_functions() {
                 exec_type: TriggerExecBodyType::Function,
                 func_desc: FunctionDesc {
                     name: ObjectName::from(vec![Ident::new("emp_stamp")]),
-                    args: None,
+                    args: Some(vec![]),
                 }
             }),
+            statements_as: false,
             statements: None,
             characteristics: None
         }


### PR DESCRIPTION
MySQL uses a statement body similar to MSSQL (but without the `AS` keyword) instead of `EXECUTE` body style used in Postgres and standard SQL. But unlike MSSQL, MySQL puts the trigger period before the target table. We add some flags to indicate these differences and allow parsing and round tripping MySQL triggers. The main benefit is that we can now handle MySQL triggers which include `BEGIN; ... END;` compound statements.