### PR TITLE
Merge queue prep

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -36,3 +36,17 @@ github:
     rebase: false
   features:
     issues: true
+  protected_branches:
+    main:
+      required_status_checks:
+        contexts:
+          - "codestyle"
+          - "lint"
+          - "benchmark-lint"
+          - "compile"
+          - "docs"
+          - "compile-no-std"
+          - "test (stable)"
+          - "test (beta)"
+          - "test (wasm)"
+          - "rat"

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,5 +48,5 @@ github:
           - "compile-no-std"
           - "test (stable)"
           - "test (beta)"
-          - "test (wasm)"
-          - "rat"
+          - "test (nightly)"
+          - "Release Audit Tool (RAT)"

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -23,6 +23,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,13 +17,17 @@
 
 name: Rust
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'gh-readonly-queue/**'
+  pull_request:
+  merge_group:
 
 permissions:
   contents: read
 
 jobs:
-
   codestyle:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Which issue does this PR close?

Related to https://github.com/apache/datafusion/issues/6880

## Rationale for this change

Before we enable Merge Queue, we need to prepare our CI

## What changes are included in this PR?

Merge Queue only waits for the required steps - us all checks are important hence I made them all required. 
It'll become impossible to merge a PR if some of the checks are not passed, but I believe that's the flow we use now anyways.

I also added a MQ trigger as required in the MQ docs