### PR TITLE
feat: MERGE statements: add RETURNING and OUTPUT without INTO

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -161,6 +161,7 @@ pub enum SetExpr {
     Insert(Statement),
     Update(Statement),
     Delete(Statement),
+    Merge(Statement),
     Table(Box<Table>),
 }
 
@@ -188,6 +189,7 @@ impl fmt::Display for SetExpr {
             SetExpr::Insert(v) => v.fmt(f),
             SetExpr::Update(v) => v.fmt(f),
             SetExpr::Delete(v) => v.fmt(f),
+            SetExpr::Merge(v) => v.fmt(f),
             SetExpr::Table(t) => t.fmt(f),
             SetExpr::SetOperation {
                 left,

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -214,6 +214,7 @@ impl Spanned for SetExpr {
             SetExpr::Table(_) => Span::empty(),
             SetExpr::Update(statement) => statement.span(),
             SetExpr::Delete(statement) => statement.span(),
+            SetExpr::Merge(statement) => statement.span(),
         }
     }
 }


### PR DESCRIPTION
adds better support for parsing MERGE statements with OUTPUT/RETURNING.

- adds support for the `RETURNING` clause
- adds support for the `OUTPUT` clause without `INTO`
- adds support for `MERGE` inside CTEs

fixes https://github.com/apache/datafusion-sqlparser-rs/issues/2010
