### PR TITLE
`GenericDialect`: Support pipe operator

### DIFF
--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -64,6 +64,10 @@ impl Dialect for GenericDialect {
         true
     }
 
+    fn supports_pipe_operator(&self) -> bool {
+        true
+    }
+
     fn supports_start_transaction_modifier(&self) -> bool {
         true
     }


### PR DESCRIPTION
Similar to #1911 and #1921

The docs for GenericDialect says that is can be permissive, so I thought it could support pipe operators.

This will make the out-of-the-box experience of DataFusion better