### PR TITLE
Support wildcard metrics for `SEMANTIC_VIEW`

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1429,7 +1429,7 @@ pub enum TableFactor {
         /// List of dimensions or expression referring to dimensions (e.g. DATE_PART('year', col))
         dimensions: Vec<Expr>,
         /// List of metrics (references to objects like orders.value, value, orders.*)
-        metrics: Vec<ObjectName>,
+        metrics: Vec<Expr>,
         /// List of facts or expressions referring to facts or dimensions.
         facts: Vec<Expr>,
         /// WHERE clause for filtering

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13958,8 +13958,7 @@ impl<'a> Parser<'a> {
                         "METRICS clause can only be specified once".to_string(),
                     ));
                 }
-                metrics = self
-                    .parse_comma_separated(|parser| parser.parse_object_name_inner(true, true))?;
+                metrics = self.parse_comma_separated(Parser::parse_wildcard_expr)?;
             } else if self.parse_keyword(Keyword::FACTS) {
                 if !facts.is_empty() {
                     return Err(ParserError::ParserError(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13958,7 +13958,8 @@ impl<'a> Parser<'a> {
                         "METRICS clause can only be specified once".to_string(),
                     ));
                 }
-                metrics = self.parse_comma_separated(|parser| parser.parse_object_name(true))?;
+                metrics = self
+                    .parse_comma_separated(|parser| parser.parse_object_name_inner(true, true))?;
             } else if self.parse_keyword(Keyword::FACTS) {
                 if !facts.is_empty() {
                     return Err(ParserError::ParserError(
@@ -13975,7 +13976,10 @@ impl<'a> Parser<'a> {
                 where_clause = Some(self.parse_expr()?);
             } else {
                 return parser_err!(
-                    "Expected one of DIMENSIONS, METRICS, FACTS or WHERE",
+                    format!(
+                        "Expected one of DIMENSIONS, METRICS, FACTS or WHERE, got {}",
+                        self.peek_token().token
+                    ),
                     self.peek_token().span.start
                 )?;
             }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -16951,6 +16951,7 @@ fn test_parse_semantic_view_table_factor() {
             "SELECT * FROM SEMANTIC_VIEW(model METRICS orders.col, orders.col2)",
             None,
         ),
+        ("SELECT * FROM SEMANTIC_VIEW(model METRICS orders.*)", None),
         // We can parse in any order but will always produce a result in a fixed order.
         (
             "SELECT * FROM SEMANTIC_VIEW(model WHERE x > 0 DIMENSIONS dim1)",

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -16981,7 +16981,6 @@ fn test_parse_semantic_view_table_factor() {
     let invalid_sqls = [
         "SELECT * FROM SEMANTIC_VIEW(model DIMENSIONS dim1 INVALID inv1)",
         "SELECT * FROM SEMANTIC_VIEW(model DIMENSIONS dim1 DIMENSIONS dim2)",
-        "SELECT * FROM SEMANTIC_VIEW(model METRICS SUM(met1.avg))",
     ];
 
     for sql in invalid_sqls {


### PR DESCRIPTION
This adds support for the valid syntax of using wildcard metrics. It also improves the error message on unexpected tokens.