### PR TITLE
Allow wilrdacrd for all `SEMANTIC_VIEW` types

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13951,7 +13951,7 @@ impl<'a> Parser<'a> {
                         "DIMENSIONS clause can only be specified once".to_string(),
                     ));
                 }
-                dimensions = self.parse_comma_separated(Parser::parse_expr)?;
+                dimensions = self.parse_comma_separated(Parser::parse_wildcard_expr)?;
             } else if self.parse_keyword(Keyword::METRICS) {
                 if !metrics.is_empty() {
                     return Err(ParserError::ParserError(
@@ -13965,7 +13965,7 @@ impl<'a> Parser<'a> {
                         "FACTS clause can only be specified once".to_string(),
                     ));
                 }
-                facts = self.parse_comma_separated(Parser::parse_expr)?;
+                facts = self.parse_comma_separated(Parser::parse_wildcard_expr)?;
             } else if self.parse_keyword(Keyword::WHERE) {
                 if where_clause.is_some() {
                     return Err(ParserError::ParserError(

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -16952,6 +16952,11 @@ fn test_parse_semantic_view_table_factor() {
             None,
         ),
         ("SELECT * FROM SEMANTIC_VIEW(model METRICS orders.*)", None),
+        ("SELECT * FROM SEMANTIC_VIEW(model FACTS fact.*)", None),
+        (
+            "SELECT * FROM SEMANTIC_VIEW(model DIMENSIONS dim.* METRICS orders.*)",
+            None,
+        ),
         // We can parse in any order but will always produce a result in a fixed order.
         (
             "SELECT * FROM SEMANTIC_VIEW(model WHERE x > 0 DIMENSIONS dim1)",


### PR DESCRIPTION
Followup on #2016, I didn't update all the types. `DIMENSIONS` also support wildcard, from [the docs](https://docs.snowflake.com/en/sql-reference/constructs/semantic_view)

> To specify all dimensions in a logical table, use an asterisk as a wildcard, qualified by the logical table name (for example, `my_logical_table.*`).

To avoid too restrictive parsing, although not currently valid according to documentation syntax, this also adds support for wildcard expression for `FACTS`.