### PR TITLE
Added derive trait `Copy` to `OrderByOptions` struct

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2569,7 +2569,7 @@ impl fmt::Display for InterpolateExpr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 pub struct OrderByOptions {


### PR DESCRIPTION
As per title, I have added the `Copy` trait to the `OrderByOptions` struct as I believe it should implement it, being a very small struct composed solely of `Option<bool>` fields.