### PR TITLE
Moved `CreateTrigger` and `DropTrigger` out of `Statement` enum

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -3914,9 +3914,9 @@ pub enum Statement {
     /// 3. [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_function_statement)
     /// 4. [MsSql](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql)
     CreateFunction(CreateFunction),
-    /// CREATE TRIGGER statement. See struct `CreateTrigger` for details.
+    /// CREATE TRIGGER statement. See struct [CreateTrigger] for details.
     CreateTrigger(CreateTrigger),
-    /// DROP TRIGGER statement. See struct `DropTrigger` for details.
+    /// DROP TRIGGER statement. See struct [DropTrigger] for details.
     DropTrigger(DropTrigger),
     /// ```sql
     /// CREATE PROCEDURE

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -17,8 +17,8 @@
 
 use crate::ast::helpers::attached_token::AttachedToken;
 use crate::ast::{
-    BeginEndStatements, ConditionalStatementBlock, ConditionalStatements, GranteesType,
-    IfStatement, Statement, TriggerObject,
+    BeginEndStatements, ConditionalStatementBlock, ConditionalStatements, CreateTrigger,
+    GranteesType, IfStatement, Statement, TriggerObject,
 };
 use crate::dialect::Dialect;
 use crate::keywords::{self, Keyword};
@@ -251,7 +251,7 @@ impl MsSqlDialect {
         parser.expect_keyword_is(Keyword::AS)?;
         let statements = Some(parser.parse_conditional_statements(&[Keyword::END])?);
 
-        Ok(Statement::CreateTrigger {
+        Ok(Statement::CreateTrigger(CreateTrigger {
             or_alter,
             or_replace: false,
             is_constraint: false,
@@ -269,7 +269,7 @@ impl MsSqlDialect {
             statements_as: true,
             statements,
             characteristics: None,
-        })
+        }))
     }
 
     /// Parse a sequence of statements, optionally separated by semicolon.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5564,12 +5564,12 @@ impl<'a> Parser<'a> {
                 Keyword::RESTRICT => ReferentialAction::Restrict,
                 _ => unreachable!(),
             });
-        Ok(Statement::DropTrigger {
+        Ok(Statement::DropTrigger(DropTrigger {
             if_exists,
             trigger_name,
             table_name,
             option,
-        })
+        }))
     }
 
     pub fn parse_create_trigger(
@@ -5627,7 +5627,7 @@ impl<'a> Parser<'a> {
             statements = Some(self.parse_conditional_statements(&[Keyword::END])?);
         }
 
-        Ok(Statement::CreateTrigger {
+        Ok(Statement::CreateTrigger(CreateTrigger {
             or_alter,
             or_replace,
             is_constraint,
@@ -5645,7 +5645,7 @@ impl<'a> Parser<'a> {
             statements_as: false,
             statements,
             characteristics,
-        })
+        }))
     }
 
     pub fn parse_trigger_period(&mut self) -> Result<TriggerPeriod, ParserError> {

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2384,7 +2384,7 @@ fn parse_create_trigger() {
     let create_stmt = ms().verified_stmt(create_trigger);
     assert_eq!(
         create_stmt,
-        Statement::CreateTrigger {
+        Statement::CreateTrigger(CreateTrigger {
             or_alter: true,
             or_replace: false,
             is_constraint: false,
@@ -2417,7 +2417,7 @@ fn parse_create_trigger() {
                 }],
             }),
             characteristics: None,
-        }
+        })
     );
 
     let multi_statement_as_trigger = "\
@@ -2476,12 +2476,12 @@ fn parse_drop_trigger() {
     let drop_stmt = ms().one_statement_parses_to(sql_drop_trigger, "");
     assert_eq!(
         drop_stmt,
-        Statement::DropTrigger {
+        Statement::DropTrigger(DropTrigger {
             if_exists: false,
             trigger_name: ObjectName::from(vec![Ident::new("emp_stamp")]),
             table_name: None,
             option: None,
-        }
+        })
     );
 }
 

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3922,7 +3922,7 @@ fn parse_create_trigger() {
     let create_stmt = mysql().verified_stmt(sql_create_trigger);
     assert_eq!(
         create_stmt,
-        Statement::CreateTrigger {
+        Statement::CreateTrigger(CreateTrigger {
             or_alter: false,
             or_replace: false,
             is_constraint: false,
@@ -3946,7 +3946,7 @@ fn parse_create_trigger() {
             statements_as: false,
             statements: None,
             characteristics: None,
-        }
+        })
     );
 }
 
@@ -3962,12 +3962,12 @@ fn parse_drop_trigger() {
     let drop_stmt = mysql().one_statement_parses_to(sql_drop_trigger, "");
     assert_eq!(
         drop_stmt,
-        Statement::DropTrigger {
+        Statement::DropTrigger(DropTrigger {
             if_exists: false,
             trigger_name: ObjectName::from(vec![Ident::new("emp_stamp")]),
             table_name: None,
             option: None,
-        }
+        })
     );
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5671,7 +5671,7 @@ fn parse_create_domain() {
 #[test]
 fn parse_create_simple_before_insert_trigger() {
     let sql = "CREATE TRIGGER check_insert BEFORE INSERT ON accounts FOR EACH ROW EXECUTE FUNCTION check_account_insert";
-    let expected = Statement::CreateTrigger {
+    let expected = Statement::CreateTrigger(CreateTrigger {
         or_alter: false,
         or_replace: false,
         is_constraint: false,
@@ -5695,7 +5695,7 @@ fn parse_create_simple_before_insert_trigger() {
         statements_as: false,
         statements: None,
         characteristics: None,
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql), expected);
 }
@@ -5703,7 +5703,7 @@ fn parse_create_simple_before_insert_trigger() {
 #[test]
 fn parse_create_after_update_trigger_with_condition() {
     let sql = "CREATE TRIGGER check_update AFTER UPDATE ON accounts FOR EACH ROW WHEN (NEW.balance > 10000) EXECUTE FUNCTION check_account_update";
-    let expected = Statement::CreateTrigger {
+    let expected = Statement::CreateTrigger(CreateTrigger {
         or_alter: false,
         or_replace: false,
         is_constraint: false,
@@ -5734,7 +5734,7 @@ fn parse_create_after_update_trigger_with_condition() {
         statements_as: false,
         statements: None,
         characteristics: None,
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql), expected);
 }
@@ -5742,7 +5742,7 @@ fn parse_create_after_update_trigger_with_condition() {
 #[test]
 fn parse_create_instead_of_delete_trigger() {
     let sql = "CREATE TRIGGER check_delete INSTEAD OF DELETE ON accounts FOR EACH ROW EXECUTE FUNCTION check_account_deletes";
-    let expected = Statement::CreateTrigger {
+    let expected = Statement::CreateTrigger(CreateTrigger {
         or_alter: false,
         or_replace: false,
         is_constraint: false,
@@ -5766,7 +5766,7 @@ fn parse_create_instead_of_delete_trigger() {
         statements_as: false,
         statements: None,
         characteristics: None,
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql), expected);
 }
@@ -5774,7 +5774,7 @@ fn parse_create_instead_of_delete_trigger() {
 #[test]
 fn parse_create_trigger_with_multiple_events_and_deferrable() {
     let sql = "CREATE CONSTRAINT TRIGGER check_multiple_events BEFORE INSERT OR UPDATE OR DELETE ON accounts DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION check_account_changes";
-    let expected = Statement::CreateTrigger {
+    let expected = Statement::CreateTrigger(CreateTrigger {
         or_alter: false,
         or_replace: false,
         is_constraint: true,
@@ -5806,7 +5806,7 @@ fn parse_create_trigger_with_multiple_events_and_deferrable() {
             initially: Some(DeferrableInitial::Deferred),
             enforced: None,
         }),
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql), expected);
 }
@@ -5814,7 +5814,7 @@ fn parse_create_trigger_with_multiple_events_and_deferrable() {
 #[test]
 fn parse_create_trigger_with_referencing() {
     let sql = "CREATE TRIGGER check_referencing BEFORE INSERT ON accounts REFERENCING NEW TABLE AS new_accounts OLD TABLE AS old_accounts FOR EACH ROW EXECUTE FUNCTION check_account_referencing";
-    let expected = Statement::CreateTrigger {
+    let expected = Statement::CreateTrigger(CreateTrigger {
         or_alter: false,
         or_replace: false,
         is_constraint: false,
@@ -5849,7 +5849,7 @@ fn parse_create_trigger_with_referencing() {
         statements_as: false,
         statements: None,
         characteristics: None,
-    };
+    });
 
     assert_eq!(pg().verified_stmt(sql), expected);
 }
@@ -5901,12 +5901,12 @@ fn parse_drop_trigger() {
             );
             assert_eq!(
                 pg().verified_stmt(sql),
-                Statement::DropTrigger {
+                Statement::DropTrigger(DropTrigger {
                     if_exists,
                     trigger_name: ObjectName::from(vec![Ident::new("check_update")]),
                     table_name: Some(ObjectName::from(vec![Ident::new("table_name")])),
                     option
-                }
+                })
             );
         }
     }
@@ -6130,7 +6130,7 @@ fn parse_trigger_related_functions() {
 
     assert_eq!(
         create_trigger,
-        Statement::CreateTrigger {
+        Statement::CreateTrigger(CreateTrigger {
             or_alter: false,
             or_replace: false,
             is_constraint: false,
@@ -6154,18 +6154,18 @@ fn parse_trigger_related_functions() {
             statements_as: false,
             statements: None,
             characteristics: None
-        }
+        })
     );
 
     // Check the fourth statement
     assert_eq!(
         drop_trigger,
-        Statement::DropTrigger {
+        Statement::DropTrigger(DropTrigger {
             if_exists: false,
             trigger_name: ObjectName::from(vec![Ident::new("emp_stamp")]),
             table_name: Some(ObjectName::from(vec![Ident::new("emp")])),
             option: None
-        }
+        })
     );
 }
 


### PR DESCRIPTION
Moved `CreateTrigger` and `DropTrigger` out of `Statement` enum and into their own struct.

Closes issue #2022 