### PR TITLE
DuckDB: Allow quoted date parts in EXTRACT

### DIFF
--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -70,6 +70,11 @@ impl Dialect for DuckDbDialect {
         true
     }
 
+    /// Returns true if this dialect allows the `EXTRACT` function to use single quotes in the part being extracted.
+    fn allow_extract_single_quotes(&self) -> bool {
+        true
+    }
+
     // DuckDB is compatible with PostgreSQL syntax for this statement,
     // although not all features may be implemented.
     fn supports_explain_with_utility_options(&self) -> bool {

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -869,3 +869,9 @@ fn test_duckdb_trim() {
         duckdb().parse_sql_statements(error_sql).unwrap_err()
     );
 }
+
+#[test]
+fn parse_extract_single_quotes() {
+    let sql = "SELECT EXTRACT('month' FROM my_timestamp) FROM my_table";
+    duckdb().verified_stmt(sql);
+}


### PR DESCRIPTION
Fixes #1983.

I guess when I logged the issue I didn't have time to look at the code, the fix was quite simple.  Uses the same test query as Redshift.