### PR TITLE
Increase version of sqlparser_derive from 0.3.0 to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 # of dev-dependencies because of
 # https://github.com/rust-lang/cargo/issues/1596
 serde_json = { version = "1.0", optional = true }
-sqlparser_derive = { version = "0.3.0", path = "derive", optional = true }
+sqlparser_derive = { version = "0.4.0", path = "derive", optional = true }
 
 [dev-dependencies]
 simple_logger = "5.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "sqlparser_derive"
 description = "Procedural (proc) macros for sqlparser"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["sqlparser-rs authors"]
 homepage = "https://github.com/sqlparser-rs/sqlparser-rs"
 documentation = "https://docs.rs/sqlparser_derive/"


### PR DESCRIPTION
Bump the version of the internal dependency so that users of the library can leverage the recursion protection added in https://github.com/apache/datafusion-sqlparser-rs/pull/1522.