### PR TITLE
Added support for `DROP OPERATOR CLASS` syntax

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -4288,3 +4288,40 @@ impl Spanned for DropOperatorFamily {
         Span::empty()
     }
 }
+
+/// `DROP OPERATOR CLASS` statement
+/// See <https://www.postgresql.org/docs/current/sql-dropopclass.html>
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct DropOperatorClass {
+    /// `IF EXISTS` clause
+    pub if_exists: bool,
+    /// One or more operator classes to drop
+    pub names: Vec<ObjectName>,
+    /// Index method (btree, hash, gist, gin, etc.)
+    pub using: Ident,
+    /// `CASCADE or RESTRICT`
+    pub drop_behavior: Option<DropBehavior>,
+}
+
+impl fmt::Display for DropOperatorClass {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DROP OPERATOR CLASS")?;
+        if self.if_exists {
+            write!(f, " IF EXISTS")?;
+        }
+        write!(f, " {}", display_comma_separated(&self.names))?;
+        write!(f, " USING {}", self.using)?;
+        if let Some(drop_behavior) = &self.drop_behavior {
+            write!(f, " {}", drop_behavior)?;
+        }
+        Ok(())
+    }
+}
+
+impl Spanned for DropOperatorClass {
+    fn span(&self) -> Span {
+        Span::empty()
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -67,7 +67,7 @@ pub use self::ddl::{
     ColumnPolicyProperty, ConstraintCharacteristics, CreateConnector, CreateDomain,
     CreateExtension, CreateFunction, CreateIndex, CreateOperator, CreateOperatorClass,
     CreateOperatorFamily, CreateTable, CreateTrigger, CreateView, Deduplicate, DeferrableInitial,
-    DropBehavior, DropExtension, DropFunction, DropOperator, DropOperatorFamily,
+    DropBehavior, DropExtension, DropFunction, DropOperator, DropOperatorClass, DropOperatorFamily,
     DropOperatorSignature, DropTrigger, GeneratedAs, GeneratedExpressionMode, IdentityParameters,
     IdentityProperty, IdentityPropertyFormatKind, IdentityPropertyKind, IdentityPropertyOrder,
     IndexColumn, IndexOption, IndexType, KeyOrIndexDisplay, Msck, NullsDistinctOption,
@@ -3586,6 +3586,12 @@ pub enum Statement {
     /// <https://www.postgresql.org/docs/current/sql-dropopfamily.html>
     DropOperatorFamily(DropOperatorFamily),
     /// ```sql
+    /// DROP OPERATOR CLASS [ IF EXISTS ] name USING index_method [ CASCADE | RESTRICT ]
+    /// ```
+    /// Note: this is a PostgreSQL-specific statement.
+    /// <https://www.postgresql.org/docs/current/sql-dropopclass.html>
+    DropOperatorClass(DropOperatorClass),
+    /// ```sql
     /// FETCH
     /// ```
     /// Retrieve rows from a query using a cursor
@@ -4852,6 +4858,9 @@ impl fmt::Display for Statement {
             Statement::DropOperator(drop_operator) => write!(f, "{drop_operator}"),
             Statement::DropOperatorFamily(drop_operator_family) => {
                 write!(f, "{drop_operator_family}")
+            }
+            Statement::DropOperatorClass(drop_operator_class) => {
+                write!(f, "{drop_operator_class}")
             }
             Statement::CreateRole(create_role) => write!(f, "{create_role}"),
             Statement::CreateSecret {

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -377,6 +377,7 @@ impl Spanned for Statement {
             Statement::DropExtension(drop_extension) => drop_extension.span(),
             Statement::DropOperator(drop_operator) => drop_operator.span(),
             Statement::DropOperatorFamily(drop_operator_family) => drop_operator_family.span(),
+            Statement::DropOperatorClass(drop_operator_class) => drop_operator_class.span(),
             Statement::CreateSecret { .. } => Span::empty(),
             Statement::CreateServer { .. } => Span::empty(),
             Statement::CreateConnector { .. } => Span::empty(),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -6976,11 +6976,11 @@ fn parse_drop_operator_family() {
 
     // Test error: DROP OPERATOR FAMILY with no names
     let sql = "DROP OPERATOR FAMILY USING btree";
-    assert!(pg().parse_sql_statements(sql).is_err());
+    assert!(pg_and_generic().parse_sql_statements(sql).is_err());
 
     // Test error: DROP OPERATOR FAMILY IF EXISTS with no names
     let sql = "DROP OPERATOR FAMILY IF EXISTS USING btree";
-    assert!(pg().parse_sql_statements(sql).is_err());
+    assert!(pg_and_generic().parse_sql_statements(sql).is_err());
 }
 
 #[test]
@@ -7039,18 +7039,18 @@ fn parse_drop_operator_class() {
 
     // Test error: DROP OPERATOR CLASS with no names
     let sql = "DROP OPERATOR CLASS USING btree";
-    assert!(pg().parse_sql_statements(sql).is_err());
+    assert!(pg_and_generic().parse_sql_statements(sql).is_err());
 
     // Test error: DROP OPERATOR CLASS IF EXISTS with no names
     let sql = "DROP OPERATOR CLASS IF EXISTS USING btree";
-    assert!(pg().parse_sql_statements(sql).is_err());
+    assert!(pg_and_generic().parse_sql_statements(sql).is_err());
 }
 
 #[test]
 fn parse_create_operator_family() {
     for index_method in &["btree", "hash", "gist", "gin", "spgist", "brin"] {
         assert_eq!(
-            pg().verified_stmt(&format!(
+            pg_and_generic().verified_stmt(&format!(
                 "CREATE OPERATOR FAMILY my_family USING {index_method}"
             )),
             Statement::CreateOperatorFamily(CreateOperatorFamily {
@@ -7059,7 +7059,7 @@ fn parse_create_operator_family() {
             })
         );
         assert_eq!(
-            pg().verified_stmt(&format!(
+            pg_and_generic().verified_stmt(&format!(
                 "CREATE OPERATOR FAMILY myschema.test_family USING {index_method}"
             )),
             Statement::CreateOperatorFamily(CreateOperatorFamily {
@@ -7085,7 +7085,7 @@ fn parse_create_operator_class() {
                 let sql = format!(
                     "CREATE OPERATOR CLASS {class_name} {default_clause}FOR TYPE INT4 USING btree{family_clause} AS OPERATOR 1 <"
                 );
-                match pg().verified_stmt(&sql) {
+                match pg_and_generic().verified_stmt(&sql) {
                     Statement::CreateOperatorClass(CreateOperatorClass {
                         name,
                         default,
@@ -7115,7 +7115,7 @@ fn parse_create_operator_class() {
     }
 
     // Test comprehensive operator class with all fields
-    match pg().verified_stmt("CREATE OPERATOR CLASS CAS_btree_ops DEFAULT FOR TYPE CAS USING btree FAMILY CAS_btree_ops AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 1 cas_cmp(CAS, CAS)") {
+    match pg_and_generic().verified_stmt("CREATE OPERATOR CLASS CAS_btree_ops DEFAULT FOR TYPE CAS USING btree FAMILY CAS_btree_ops AS OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >, FUNCTION 1 cas_cmp(CAS, CAS)") {
         Statement::CreateOperatorClass(CreateOperatorClass {
             name,
             default: true,
@@ -7134,7 +7134,7 @@ fn parse_create_operator_class() {
     }
 
     // Test operator with argument types
-    match pg().verified_stmt(
+    match pg_and_generic().verified_stmt(
         "CREATE OPERATOR CLASS test_ops FOR TYPE INT4 USING gist AS OPERATOR 1 < (INT4, INT4)",
     ) {
         Statement::CreateOperatorClass(CreateOperatorClass { ref items, .. }) => {
@@ -7159,7 +7159,7 @@ fn parse_create_operator_class() {
     }
 
     // Test operator FOR SEARCH
-    match pg().verified_stmt(
+    match pg_and_generic().verified_stmt(
         "CREATE OPERATOR CLASS test_ops FOR TYPE INT4 USING gist AS OPERATOR 1 < FOR SEARCH",
     ) {
         Statement::CreateOperatorClass(CreateOperatorClass { ref items, .. }) => {
@@ -7203,7 +7203,7 @@ fn parse_create_operator_class() {
     }
 
     // Test function with operator class arg types
-    match pg().verified_stmt("CREATE OPERATOR CLASS test_ops FOR TYPE INT4 USING btree AS FUNCTION 1 (INT4, INT4) btcmp(INT4, INT4)") {
+    match pg_and_generic().verified_stmt("CREATE OPERATOR CLASS test_ops FOR TYPE INT4 USING btree AS FUNCTION 1 (INT4, INT4) btcmp(INT4, INT4)") {
         Statement::CreateOperatorClass(CreateOperatorClass {
             ref items,
             ..
@@ -7226,11 +7226,11 @@ fn parse_create_operator_class() {
     }
 
     // Test function with no arguments (empty parentheses normalizes to no parentheses)
-    pg().one_statement_parses_to(
+    pg_and_generic().one_statement_parses_to(
         "CREATE OPERATOR CLASS test_ops FOR TYPE INT4 USING btree AS FUNCTION 1 my_func()",
         "CREATE OPERATOR CLASS test_ops FOR TYPE INT4 USING btree AS FUNCTION 1 my_func",
     );
-    match pg().verified_stmt(
+    match pg_and_generic().verified_stmt(
         "CREATE OPERATOR CLASS test_ops FOR TYPE INT4 USING btree AS FUNCTION 1 my_func",
     ) {
         Statement::CreateOperatorClass(CreateOperatorClass { ref items, .. }) => {
@@ -7255,7 +7255,7 @@ fn parse_create_operator_class() {
     }
 
     // Test multiple items including STORAGE
-    match pg().verified_stmt("CREATE OPERATOR CLASS gist_ops FOR TYPE geometry USING gist AS OPERATOR 1 <<, FUNCTION 1 gist_consistent(internal, geometry, INT4), STORAGE box") {
+    match pg_and_generic().verified_stmt("CREATE OPERATOR CLASS gist_ops FOR TYPE geometry USING gist AS OPERATOR 1 <<, FUNCTION 1 gist_consistent(internal, geometry, INT4), STORAGE box") {
         Statement::CreateOperatorClass(CreateOperatorClass {
             ref items,
             ..


### PR DESCRIPTION
As per title, this PR adds support for the [`DROP OPERATOR CLASS`](https://www.postgresql.org/docs/current/sql-dropopclass.html) syntax.