### PR TITLE
Added missing `From` impls for `Statement` variants

### DIFF
--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -504,8 +504,8 @@ impl CreateTableBuilder {
         self.require_user = require_user;
         self
     }
-    /// Consume the builder and produce a `Statement::CreateTable`.
-    pub fn build(self) -> Statement {
+    /// Consume the builder and produce a `CreateTable`.
+    pub fn build(self) -> CreateTable {
         CreateTable {
             or_replace: self.or_replace,
             temporary: self.temporary,
@@ -561,7 +561,6 @@ impl CreateTableBuilder {
             initialize: self.initialize,
             require_user: self.require_user,
         }
-        .into()
     }
 }
 
@@ -572,118 +571,70 @@ impl TryFrom<Statement> for CreateTableBuilder {
     // ownership.
     fn try_from(stmt: Statement) -> Result<Self, Self::Error> {
         match stmt {
-            Statement::CreateTable(CreateTable {
-                or_replace,
-                temporary,
-                external,
-                global,
-                if_not_exists,
-                transient,
-                volatile,
-                iceberg,
-                dynamic,
-                name,
-                columns,
-                constraints,
-                hive_distribution,
-                hive_formats,
-                file_format,
-                location,
-                query,
-                without_rowid,
-                like,
-                clone,
-                version,
-                comment,
-                on_commit,
-                on_cluster,
-                primary_key,
-                order_by,
-                partition_by,
-                cluster_by,
-                clustered_by,
-                inherits,
-                partition_of,
-                for_values,
-                strict,
-                copy_grants,
-                enable_schema_evolution,
-                change_tracking,
-                data_retention_time_in_days,
-                max_data_extension_time_in_days,
-                default_ddl_collation,
-                with_aggregation_policy,
-                with_row_access_policy,
-                with_tags,
-                base_location,
-                external_volume,
-                catalog,
-                catalog_sync,
-                storage_serialization_policy,
-                table_options,
-                target_lag,
-                warehouse,
-                refresh_mode,
-                initialize,
-                require_user,
-            }) => Ok(Self {
-                or_replace,
-                temporary,
-                external,
-                global,
-                if_not_exists,
-                transient,
-                dynamic,
-                name,
-                columns,
-                constraints,
-                hive_distribution,
-                hive_formats,
-                file_format,
-                location,
-                query,
-                without_rowid,
-                like,
-                clone,
-                version,
-                comment,
-                on_commit,
-                on_cluster,
-                primary_key,
-                order_by,
-                partition_by,
-                cluster_by,
-                clustered_by,
-                inherits,
-                partition_of,
-                for_values,
-                strict,
-                iceberg,
-                copy_grants,
-                enable_schema_evolution,
-                change_tracking,
-                data_retention_time_in_days,
-                max_data_extension_time_in_days,
-                default_ddl_collation,
-                with_aggregation_policy,
-                with_row_access_policy,
-                with_tags,
-                volatile,
-                base_location,
-                external_volume,
-                catalog,
-                catalog_sync,
-                storage_serialization_policy,
-                table_options,
-                target_lag,
-                warehouse,
-                refresh_mode,
-                initialize,
-                require_user,
-            }),
+            Statement::CreateTable(create_table) => Ok(create_table.into()),
             _ => Err(ParserError::ParserError(format!(
                 "Expected create table statement, but received: {stmt}"
             ))),
+        }
+    }
+}
+
+impl From<CreateTable> for CreateTableBuilder {
+    fn from(table: CreateTable) -> Self {
+        Self {
+            or_replace: table.or_replace,
+            temporary: table.temporary,
+            external: table.external,
+            global: table.global,
+            if_not_exists: table.if_not_exists,
+            transient: table.transient,
+            volatile: table.volatile,
+            iceberg: table.iceberg,
+            dynamic: table.dynamic,
+            name: table.name,
+            columns: table.columns,
+            constraints: table.constraints,
+            hive_distribution: table.hive_distribution,
+            hive_formats: table.hive_formats,
+            file_format: table.file_format,
+            location: table.location,
+            query: table.query,
+            without_rowid: table.without_rowid,
+            like: table.like,
+            clone: table.clone,
+            version: table.version,
+            comment: table.comment,
+            on_commit: table.on_commit,
+            on_cluster: table.on_cluster,
+            primary_key: table.primary_key,
+            order_by: table.order_by,
+            partition_by: table.partition_by,
+            cluster_by: table.cluster_by,
+            clustered_by: table.clustered_by,
+            inherits: table.inherits,
+            partition_of: table.partition_of,
+            for_values: table.for_values,
+            strict: table.strict,
+            copy_grants: table.copy_grants,
+            enable_schema_evolution: table.enable_schema_evolution,
+            change_tracking: table.change_tracking,
+            data_retention_time_in_days: table.data_retention_time_in_days,
+            max_data_extension_time_in_days: table.max_data_extension_time_in_days,
+            default_ddl_collation: table.default_ddl_collation,
+            with_aggregation_policy: table.with_aggregation_policy,
+            with_row_access_policy: table.with_row_access_policy,
+            with_tags: table.with_tags,
+            base_location: table.base_location,
+            external_volume: table.external_volume,
+            catalog: table.catalog,
+            catalog_sync: table.catalog_sync,
+            storage_serialization_policy: table.storage_serialization_policy,
+            table_options: table.table_options,
+            target_lag: table.target_lag,
+            warehouse: table.warehouse,
+            refresh_mode: table.refresh_mode,
+            initialize: table.initialize,
+            require_user: table.require_user,
         }
     }
 }
@@ -707,7 +658,8 @@ mod tests {
     pub fn test_from_valid_statement() {
         let builder = CreateTableBuilder::new(ObjectName::from(vec![Ident::new("table_name")]));
 
-        let stmt = builder.clone().build();
+        let create_table = builder.clone().build();
+        let stmt: Statement = create_table.into();
 
         assert_eq!(builder, CreateTableBuilder::try_from(stmt).unwrap());
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -11876,6 +11876,24 @@ impl From<DropTrigger> for Statement {
     }
 }
 
+impl From<DropOperator> for Statement {
+    fn from(d: DropOperator) -> Self {
+        Self::DropOperator(d)
+    }
+}
+
+impl From<DropOperatorFamily> for Statement {
+    fn from(d: DropOperatorFamily) -> Self {
+        Self::DropOperatorFamily(d)
+    }
+}
+
+impl From<DropOperatorClass> for Statement {
+    fn from(d: DropOperatorClass) -> Self {
+        Self::DropOperatorClass(d)
+    }
+}
+
 impl From<DenyStatement> for Statement {
     fn from(d: DenyStatement) -> Self {
         Self::Deny(d)

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -11774,6 +11774,24 @@ impl From<CreateConnector> for Statement {
     }
 }
 
+impl From<CreateOperator> for Statement {
+    fn from(c: CreateOperator) -> Self {
+        Self::CreateOperator(c)
+    }
+}
+
+impl From<CreateOperatorFamily> for Statement {
+    fn from(c: CreateOperatorFamily) -> Self {
+        Self::CreateOperatorFamily(c)
+    }
+}
+
+impl From<CreateOperatorClass> for Statement {
+    fn from(c: CreateOperatorClass) -> Self {
+        Self::CreateOperatorClass(c)
+    }
+}
+
 impl From<AlterSchema> for Statement {
     fn from(a: AlterSchema) -> Self {
         Self::AlterSchema(a)
@@ -11783,6 +11801,36 @@ impl From<AlterSchema> for Statement {
 impl From<AlterType> for Statement {
     fn from(a: AlterType) -> Self {
         Self::AlterType(a)
+    }
+}
+
+impl From<AlterOperator> for Statement {
+    fn from(a: AlterOperator) -> Self {
+        Self::AlterOperator(a)
+    }
+}
+
+impl From<AlterOperatorFamily> for Statement {
+    fn from(a: AlterOperatorFamily) -> Self {
+        Self::AlterOperatorFamily(a)
+    }
+}
+
+impl From<AlterOperatorClass> for Statement {
+    fn from(a: AlterOperatorClass) -> Self {
+        Self::AlterOperatorClass(a)
+    }
+}
+
+impl From<Merge> for Statement {
+    fn from(m: Merge) -> Self {
+        Self::Merge(m)
+    }
+}
+
+impl From<AlterUser> for Statement {
+    fn from(a: AlterUser) -> Self {
+        Self::AlterUser(a)
     }
 }
 

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -28,11 +28,11 @@ use crate::ast::helpers::stmt_data_loading::{
 };
 use crate::ast::{
     AlterTable, AlterTableOperation, AlterTableType, CatalogSyncNamespaceMode, ColumnOption,
-    ColumnPolicy, ColumnPolicyProperty, ContactEntry, CopyIntoSnowflakeKind, CreateTableLikeKind,
-    DollarQuotedString, Ident, IdentityParameters, IdentityProperty, IdentityPropertyFormatKind,
-    IdentityPropertyKind, IdentityPropertyOrder, InitializeKind, ObjectName, ObjectNamePart,
-    RefreshModeKind, RowAccessPolicy, ShowObjects, SqlOption, Statement,
-    StorageSerializationPolicy, TagsColumnOption, Value, WrappedCollection,
+    ColumnPolicy, ColumnPolicyProperty, ContactEntry, CopyIntoSnowflakeKind, CreateTable,
+    CreateTableLikeKind, DollarQuotedString, Ident, IdentityParameters, IdentityProperty,
+    IdentityPropertyFormatKind, IdentityPropertyKind, IdentityPropertyOrder, InitializeKind,
+    ObjectName, ObjectNamePart, RefreshModeKind, RowAccessPolicy, ShowObjects, SqlOption,
+    Statement, StorageSerializationPolicy, TagsColumnOption, Value, WrappedCollection,
 };
 use crate::dialect::{Dialect, Precedence};
 use crate::keywords::Keyword;
@@ -272,9 +272,13 @@ impl Dialect for SnowflakeDialect {
                 // OK - this is CREATE STAGE statement
                 return Some(parse_create_stage(or_replace, temporary, parser));
             } else if parser.parse_keyword(Keyword::TABLE) {
-                return Some(parse_create_table(
-                    or_replace, global, temporary, volatile, transient, iceberg, dynamic, parser,
-                ));
+                return Some(
+                    parse_create_table(
+                        or_replace, global, temporary, volatile, transient, iceberg, dynamic,
+                        parser,
+                    )
+                    .map(Into::into),
+                );
             } else if parser.parse_keyword(Keyword::DATABASE) {
                 return Some(parse_create_database(or_replace, transient, parser));
             } else {
@@ -719,7 +723,7 @@ pub fn parse_create_table(
     iceberg: bool,
     dynamic: bool,
     parser: &mut Parser,
-) -> Result<Statement, ParserError> {
+) -> Result<CreateTable, ParserError> {
     let if_not_exists = parser.parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
     let table_name = parser.parse_object_name(false)?;
 

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -148,7 +148,7 @@ impl Parser<'_> {
     /// ```sql
     /// ALTER USER [ IF EXISTS ] [ <name> ] [ OPTIONS ]
     /// ```
-    pub fn parse_alter_user(&mut self) -> Result<Statement, ParserError> {
+    pub fn parse_alter_user(&mut self) -> Result<AlterUser, ParserError> {
         let if_exists = self.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
         let name = self.parse_identifier()?;
         let _ = self.parse_keyword(Keyword::WITH);
@@ -309,7 +309,7 @@ impl Parser<'_> {
             None
         };
 
-        Ok(Statement::AlterUser(AlterUser {
+        Ok(AlterUser {
             if_exists,
             name,
             rename_to,
@@ -329,7 +329,7 @@ impl Parser<'_> {
             set_props,
             unset_props,
             password,
-        }))
+        })
     }
 
     fn parse_mfa_method(&mut self) -> Result<MfaMethodKind, ParserError> {

--- a/src/parser/merge.rs
+++ b/src/parser/merge.rs
@@ -18,7 +18,7 @@ use alloc::{boxed::Box, format, vec, vec::Vec};
 use crate::{
     ast::{
         Merge, MergeAction, MergeClause, MergeClauseKind, MergeInsertExpr, MergeInsertKind,
-        MergeUpdateExpr, ObjectName, OutputClause, SetExpr, Statement,
+        MergeUpdateExpr, ObjectName, OutputClause, SetExpr,
     },
     dialect::{BigQueryDialect, GenericDialect, MySqlDialect},
     keywords::Keyword,
@@ -36,11 +36,13 @@ impl Parser<'_> {
         &mut self,
         merge_token: TokenWithSpan,
     ) -> Result<Box<SetExpr>, ParserError> {
-        Ok(Box::new(SetExpr::Merge(self.parse_merge(merge_token)?)))
+        Ok(Box::new(SetExpr::Merge(
+            self.parse_merge(merge_token)?.into(),
+        )))
     }
 
     /// Parse a `MERGE` statement
-    pub fn parse_merge(&mut self, merge_token: TokenWithSpan) -> Result<Statement, ParserError> {
+    pub fn parse_merge(&mut self, merge_token: TokenWithSpan) -> Result<Merge, ParserError> {
         let into = self.parse_keyword(Keyword::INTO);
 
         let table = self.parse_table_factor()?;
@@ -55,7 +57,7 @@ impl Parser<'_> {
             None => None,
         };
 
-        Ok(Statement::Merge(Merge {
+        Ok(Merge {
             merge_token: merge_token.into(),
             into,
             table,
@@ -63,7 +65,7 @@ impl Parser<'_> {
             on: Box::new(on),
             clauses,
             output,
-        }))
+        })
     }
 
     fn parse_merge_clauses(&mut self) -> Result<Vec<MergeClause>, ParserError> {


### PR DESCRIPTION
Since my last PR adding the missing `From` impls for `Statement` enum variants to convert any given variant `X` into `Statement::X(X)` using the `From` trait, several such `X` variants have been added without the associated `From` impl.

This PR adds several (I hope all) missing `From` impls, and reasonably cleans up some of the code which was using the more verbose conversion.

Luca