### PR TITLE
Implement `core::error::Error` for `ParserError` and `TokenizerError`

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -204,8 +204,7 @@ impl fmt::Display for ParserError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParserError {}
+impl core::error::Error for ParserError {}
 
 // By default, allow expressions up to this deep before erroring
 const DEFAULT_REMAINING_DEPTH: usize = 50;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -2553,9 +2553,8 @@ mod tests {
             message: "test".into(),
             location: Location { line: 1, column: 1 },
         };
-        #[cfg(feature = "std")]
         {
-            use std::error::Error;
+            use core::error::Error;
             assert!(err.source().is_none());
         }
         assert_eq!(err.to_string(), "test at Line: 1, Column: 1");

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -782,8 +782,7 @@ impl fmt::Display for TokenizerError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TokenizerError {}
+impl core::error::Error for TokenizerError {}
 
 struct State<'a> {
     peekable: Peekable<Chars<'a>>,


### PR DESCRIPTION
This PR updates `ParserError` and `TokenizerError` to implement `core::error::Error` instead of `std::error::Error`.

This change enables the Error trait implementation for these types in no_std environments unconditionally, removing the need for `#[cfg(feature = "std")]` guards.