### PR TITLE
Added missing derives to dialect marker structs

### DIFF
--- a/src/dialect/ansi.rs
+++ b/src/dialect/ansi.rs
@@ -18,7 +18,8 @@
 use crate::dialect::Dialect;
 
 /// A [`Dialect`] for [ANSI SQL](https://en.wikipedia.org/wiki/SQL:2011).
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AnsiDialect {}
 
 impl Dialect for AnsiDialect {

--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -42,7 +42,8 @@ const RESERVED_FOR_COLUMN_ALIAS: &[Keyword] = &[
 ];
 
 /// A [`Dialect`] for [Google Bigquery](https://cloud.google.com/bigquery/)
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BigQueryDialect;
 
 impl Dialect for BigQueryDialect {

--- a/src/dialect/clickhouse.rs
+++ b/src/dialect/clickhouse.rs
@@ -18,7 +18,8 @@
 use crate::dialect::Dialect;
 
 /// A [`Dialect`] for [ClickHouse](https://clickhouse.com/).
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClickHouseDialect {}
 
 impl Dialect for ClickHouseDialect {

--- a/src/dialect/databricks.rs
+++ b/src/dialect/databricks.rs
@@ -20,7 +20,8 @@ use crate::dialect::Dialect;
 /// A [`Dialect`] for [Databricks SQL](https://www.databricks.com/)
 ///
 /// See <https://docs.databricks.com/en/sql/language-manual/index.html>.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DatabricksDialect;
 
 impl Dialect for DatabricksDialect {

--- a/src/dialect/duckdb.rs
+++ b/src/dialect/duckdb.rs
@@ -18,7 +18,8 @@
 use crate::dialect::Dialect;
 
 /// A [`Dialect`] for [DuckDB](https://duckdb.org/)
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DuckDbDialect;
 
 // In most cases the redshift dialect is identical to [`PostgresSqlDialect`].

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -19,7 +19,8 @@ use crate::dialect::Dialect;
 
 /// A permissive, general purpose [`Dialect`], which parses a wide variety of SQL
 /// statements, from many different dialects.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenericDialect;
 
 impl Dialect for GenericDialect {

--- a/src/dialect/hive.rs
+++ b/src/dialect/hive.rs
@@ -18,7 +18,8 @@
 use crate::dialect::Dialect;
 
 /// A [`Dialect`] for [Hive](https://hive.apache.org/).
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HiveDialect {}
 
 impl Dialect for HiveDialect {

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -28,7 +28,8 @@ use crate::tokenizer::Token;
 use alloc::{vec, vec::Vec};
 
 /// A [`Dialect`] for [Microsoft SQL Server](https://www.microsoft.com/en-us/sql-server/)
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MsSqlDialect {}
 
 impl Dialect for MsSqlDialect {

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -35,7 +35,8 @@ const RESERVED_FOR_TABLE_ALIAS_MYSQL: &[Keyword] = &[
 ];
 
 /// A [`Dialect`] for [MySQL](https://www.mysql.com/)
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MySqlDialect {}
 
 impl Dialect for MySqlDialect {

--- a/src/dialect/oracle.rs
+++ b/src/dialect/oracle.rs
@@ -25,7 +25,8 @@ use crate::{
 use super::{Dialect, Precedence};
 
 /// A [`Dialect`] for [Oracle Databases](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/index.html)
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OracleDialect;
 
 impl Dialect for OracleDialect {

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -34,7 +34,8 @@ use crate::parser::{Parser, ParserError};
 use crate::tokenizer::Token;
 
 /// A [`Dialect`] for [PostgreSQL](https://www.postgresql.org/)
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PostgreSqlDialect {}
 
 const PERIOD_PREC: u8 = 200;

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -22,7 +22,8 @@ use core::str::Chars;
 use super::PostgreSqlDialect;
 
 /// A [`Dialect`] for [RedShift](https://aws.amazon.com/redshift/)
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RedshiftSqlDialect {}
 
 // In most cases the redshift dialect is identical to [`PostgresSqlDialect`].

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -127,7 +127,8 @@ const RESERVED_KEYWORDS_FOR_TABLE_FACTOR: &[Keyword] = &[
 ];
 
 /// A [`Dialect`] for [Snowflake](https://www.snowflake.com/)
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SnowflakeDialect;
 
 impl Dialect for SnowflakeDialect {

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -30,7 +30,8 @@ use crate::parser::{Parser, ParserError};
 /// [`CREATE TABLE`](https://sqlite.org/lang_createtable.html) statement with no
 /// type specified, as in `CREATE TABLE t1 (a)`. In the AST, these columns will
 /// have the data type [`Unspecified`](crate::ast::DataType::Unspecified).
-#[derive(Debug)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SQLiteDialect {}
 
 impl Dialect for SQLiteDialect {


### PR DESCRIPTION
This PR adds common derive macros to all dialect structs for consistency and improved usability.

## Changes

Added the following derives to all dialect structs:

* Clone
* Copy
* Default
* PartialEq
* Eq
* Hash
* PartialOrd
* Ord
* serde::Serialize (when serde feature is enabled)
* serde::Deserialize (when serde feature is enabled)

Closes issue #2190 