### PR TITLE
Added derive for arbitrary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ recursive-protection = ["std", "recursive"]
 json_example = ["serde_json", "serde"]
 derive-dialect = ["sqlparser_derive"]
 visitor = ["sqlparser_derive"]
+arbitrary = ["dep:arbitrary"]
 
 [dependencies]
 bigdecimal = { version = "0.4.1", features = ["serde"], optional = true }
@@ -56,6 +57,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 # https://github.com/rust-lang/cargo/issues/1596
 serde_json = { version = "1.0", optional = true }
 sqlparser_derive = { version = "0.4.0", path = "derive", optional = true }
+arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 simple_logger = "5.0"

--- a/src/ast/comments.rs
+++ b/src/ast/comments.rs
@@ -26,6 +26,7 @@ use crate::tokenizer::{Location, Span};
 
 /// An opaque container for comments from a parse SQL source code.
 #[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Comments(Vec<CommentWithSpan>);
 
 impl Comments {
@@ -152,6 +153,7 @@ impl From<Comments> for Vec<CommentWithSpan> {
 
 /// A source code comment with information of its entire span.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CommentWithSpan {
     /// The source code comment iself
     pub comment: Comment,
@@ -169,6 +171,7 @@ impl Deref for CommentWithSpan {
 
 /// A unified type of the different source code comment formats.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Comment {
     /// A single line comment, typically introduced with a prefix and spanning
     /// until end-of-line or end-of-file in the source code.

--- a/src/ast/data_type.rs
+++ b/src/ast/data_type.rs
@@ -33,6 +33,7 @@ use super::{value::escape_single_quote_string, ColumnDef};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A member of an ENUM type.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum EnumMember {
     /// Just a name.
     Name(String),
@@ -46,6 +47,7 @@ pub enum EnumMember {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DataType {
     /// Table type in [PostgreSQL], e.g. CREATE FUNCTION RETURNS TABLE(...).
     ///
@@ -897,6 +899,7 @@ fn format_clickhouse_datetime_precision_and_timezone(
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum StructBracketKind {
     /// Example: `STRUCT(a INT, b STRING)`
     Parentheses,
@@ -911,6 +914,7 @@ pub enum StructBracketKind {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TimezoneInfo {
     /// No information about time zone, e.g. TIMESTAMP
     None,
@@ -958,6 +962,7 @@ impl fmt::Display for TimezoneInfo {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum IntervalFields {
     /// `YEAR` field
     Year,
@@ -1014,6 +1019,7 @@ impl fmt::Display for IntervalFields {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ExactNumberInfo {
     /// No additional information, e.g. `DECIMAL`.
     None,
@@ -1045,6 +1051,7 @@ impl fmt::Display for ExactNumberInfo {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CharacterLength {
     /// Integer length with optional unit (e.g. `CHAR(10)` or `VARCHAR(10 CHARACTERS)`).
     IntegerLength {
@@ -1080,6 +1087,7 @@ impl fmt::Display for CharacterLength {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CharLengthUnits {
     /// CHARACTERS unit
     Characters,
@@ -1106,6 +1114,7 @@ impl fmt::Display for CharLengthUnits {
 /// Information about [binary length][1], including length and possibly unit.
 ///
 /// [1]: https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#binary-length
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum BinaryLength {
     /// Integer length for binary types (e.g. `VARBINARY(100)`).
     IntegerLength {
@@ -1137,6 +1146,7 @@ impl fmt::Display for BinaryLength {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ArrayElemTypeDef {
     /// Use `ARRAY` style without an explicit element type.
     None,
@@ -1155,6 +1165,7 @@ pub enum ArrayElemTypeDef {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GeometricTypeKind {
     /// Point geometry
     Point,

--- a/src/ast/dcl.rs
+++ b/src/ast/dcl.rs
@@ -41,6 +41,7 @@ use crate::tokenizer::Span;
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum RoleOption {
     /// Enable or disable BYPASSRLS.
     BypassRLS(bool),
@@ -116,6 +117,7 @@ impl fmt::Display for RoleOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SetConfigValue {
     /// Use the default value.
     Default,
@@ -131,6 +133,7 @@ pub enum SetConfigValue {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ResetConfig {
     /// Reset all configuration parameters.
     ALL,
@@ -142,6 +145,7 @@ pub enum ResetConfig {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterRoleOperation {
     /// Generic
     RenameRole {
@@ -242,6 +246,7 @@ impl fmt::Display for AlterRoleOperation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Use {
     /// Switch to the given catalog (e.g. `USE CATALOG ...`).
     Catalog(ObjectName),
@@ -284,6 +289,7 @@ impl fmt::Display for Use {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SecondaryRoles {
     /// Use all secondary roles.
     All,
@@ -308,6 +314,7 @@ impl fmt::Display for SecondaryRoles {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateRole {
     /// Role names to create.
     pub names: Vec<ObjectName>,
@@ -435,6 +442,7 @@ impl Spanned for CreateRole {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Grant {
     /// Privileges being granted.
     pub privileges: Privileges,
@@ -489,6 +497,7 @@ impl From<Grant> for crate::ast::Statement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Revoke {
     /// Privileges to revoke.
     pub privileges: Privileges,

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -60,6 +60,7 @@ use crate::tokenizer::{Span, Token};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct IndexColumn {
     /// The indexed column expression.
     pub column: OrderByExpr,
@@ -98,6 +99,7 @@ impl fmt::Display for IndexColumn {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ReplicaIdentity {
     /// No replica identity (`REPLICA IDENTITY NOTHING`).
     Nothing,
@@ -124,6 +126,7 @@ impl fmt::Display for ReplicaIdentity {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterTableOperation {
     /// `ADD <table_constraint> [NOT VALID]`
     AddConstraint {
@@ -536,6 +539,7 @@ pub enum AlterTableOperation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterPolicyOperation {
     /// Rename the policy to `new_name`.
     Rename {
@@ -586,6 +590,7 @@ impl fmt::Display for AlterPolicyOperation {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Algorithm option for `ALTER TABLE` operations (MySQL-specific).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterTableAlgorithm {
     /// Default algorithm selection.
     Default,
@@ -615,6 +620,7 @@ impl fmt::Display for AlterTableAlgorithm {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Locking behavior for `ALTER TABLE` (MySQL-specific).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterTableLock {
     /// `DEFAULT` lock behavior.
     Default,
@@ -641,6 +647,7 @@ impl fmt::Display for AlterTableLock {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// New owner specification for `ALTER TABLE ... OWNER TO ...`
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Owner {
     /// A specific user/role identifier.
     Ident(Ident),
@@ -667,6 +674,7 @@ impl fmt::Display for Owner {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// New connector owner specification for `ALTER CONNECTOR ... OWNER TO ...`
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterConnectorOwner {
     /// `USER <ident>` connector owner.
     User(Ident),
@@ -687,6 +695,7 @@ impl fmt::Display for AlterConnectorOwner {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Alterations that can be applied to an index.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterIndexOperation {
     /// Rename the index to `index_name`.
     RenameIndex {
@@ -1052,6 +1061,7 @@ impl fmt::Display for AlterIndexOperation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterType {
     /// Name of the type being altered (may be schema-qualified).
     pub name: ObjectName,
@@ -1063,6 +1073,7 @@ pub struct AlterType {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterTypeOperation {
     /// Rename the type.
     Rename(AlterTypeRename),
@@ -1076,6 +1087,7 @@ pub enum AlterTypeOperation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterTypeRename {
     /// The new name for the type.
     pub new_name: Ident,
@@ -1085,6 +1097,7 @@ pub struct AlterTypeRename {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterTypeAddValue {
     /// If true, do not error when the value already exists (`IF NOT EXISTS`).
     pub if_not_exists: bool,
@@ -1098,6 +1111,7 @@ pub struct AlterTypeAddValue {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterTypeAddValuePosition {
     /// Place the new value before the given neighbor value.
     Before(Ident),
@@ -1109,6 +1123,7 @@ pub enum AlterTypeAddValuePosition {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterTypeRenameValue {
     /// Existing value identifier to rename.
     pub from: Ident,
@@ -1155,6 +1170,7 @@ impl fmt::Display for AlterTypeOperation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterOperator {
     /// Operator name (can be schema-qualified)
     pub name: ObjectName,
@@ -1170,6 +1186,7 @@ pub struct AlterOperator {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterOperatorOperation {
     /// `OWNER TO { new_owner | CURRENT_ROLE | CURRENT_USER | SESSION_USER }`
     OwnerTo(Owner),
@@ -1190,6 +1207,7 @@ pub enum AlterOperatorOperation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OperatorOption {
     /// `RESTRICT = { res_proc | NONE }`
     Restrict(Option<ObjectName>),
@@ -1255,6 +1273,7 @@ impl fmt::Display for OperatorOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterColumnOperation {
     /// `SET NOT NULL`
     SetNotNull,
@@ -1350,6 +1369,7 @@ impl fmt::Display for AlterColumnOperation {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum KeyOrIndexDisplay {
     /// Nothing to display
     None,
@@ -1399,6 +1419,7 @@ impl fmt::Display for KeyOrIndexDisplay {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum IndexType {
     /// B-Tree index (commonly default for many databases).
     BTree,
@@ -1442,6 +1463,7 @@ impl fmt::Display for IndexType {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum IndexOption {
     /// `USING { BTREE | HASH }`: Index type to use for the index.
     ///
@@ -1466,6 +1488,7 @@ impl fmt::Display for IndexOption {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum NullsDistinctOption {
     /// Not specified
     None,
@@ -1489,6 +1512,7 @@ impl fmt::Display for NullsDistinctOption {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A parameter of a stored procedure or function declaration.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ProcedureParam {
     /// Parameter name.
     pub name: Ident,
@@ -1520,6 +1544,7 @@ impl fmt::Display for ProcedureParam {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ColumnDef {
     /// Column name.
     pub name: Ident,
@@ -1562,6 +1587,7 @@ impl fmt::Display for ColumnDef {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ViewColumnDef {
     /// Column identifier.
     pub name: Ident,
@@ -1575,6 +1601,7 @@ pub struct ViewColumnDef {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Representation of how multiple `ColumnOption`s are grouped for a column.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ColumnOptions {
     /// Options separated by comma: `OPTIONS(a, b, c)`.
     CommaSeparated(Vec<ColumnOption>),
@@ -1631,6 +1658,7 @@ impl fmt::Display for ViewColumnDef {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ColumnOptionDef {
     /// Optional name of the constraint.
     pub name: Option<Ident>,
@@ -1654,6 +1682,7 @@ impl fmt::Display for ColumnOptionDef {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum IdentityPropertyKind {
     /// An identity property declared via the `AUTOINCREMENT` key word
     /// Example:
@@ -1699,6 +1728,7 @@ impl fmt::Display for IdentityPropertyKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct IdentityProperty {
     /// Optional parameters specifying seed/increment for the identity column.
     pub parameters: Option<IdentityPropertyFormatKind>,
@@ -1723,6 +1753,7 @@ pub struct IdentityProperty {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum IdentityPropertyFormatKind {
     /// A parameters of identity column declared like parameters of function call
     /// Example:
@@ -1761,6 +1792,7 @@ impl fmt::Display for IdentityPropertyFormatKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct IdentityParameters {
     /// The initial seed expression for the identity column.
     pub seed: Expr,
@@ -1777,6 +1809,7 @@ pub struct IdentityParameters {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum IdentityPropertyOrder {
     /// `ORDER` - preserve ordering for generated values (where supported).
     Order,
@@ -1803,6 +1836,7 @@ impl fmt::Display for IdentityPropertyOrder {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ColumnPolicy {
     /// `MASKING POLICY (<property>)`
     MaskingPolicy(ColumnPolicyProperty),
@@ -1831,6 +1865,7 @@ impl fmt::Display for ColumnPolicy {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Properties describing a column policy (masking or projection).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ColumnPolicyProperty {
     /// This flag indicates that the column policy option is declared using the `WITH` prefix.
     /// Example
@@ -1854,6 +1889,7 @@ pub struct ColumnPolicyProperty {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TagsColumnOption {
     /// This flag indicates that the tags option is declared using the `WITH` prefix.
     /// Example:
@@ -1881,6 +1917,7 @@ impl fmt::Display for TagsColumnOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ColumnOption {
     /// `NULL`
     Null,
@@ -2149,6 +2186,7 @@ impl fmt::Display for ColumnOption {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GeneratedAs {
     /// `GENERATED ALWAYS`
     Always,
@@ -2163,6 +2201,7 @@ pub enum GeneratedAs {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GeneratedExpressionMode {
     /// `VIRTUAL` generated expression
     Virtual,
@@ -2220,6 +2259,7 @@ pub(crate) fn display_option_spaced<T: fmt::Display>(option: &Option<T>) -> impl
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Default, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ConstraintCharacteristics {
     /// `[ DEFERRABLE | NOT DEFERRABLE ]`
     pub deferrable: Option<bool>,
@@ -2233,6 +2273,7 @@ pub struct ConstraintCharacteristics {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DeferrableInitial {
     /// `INITIALLY IMMEDIATE`
     Immediate,
@@ -2300,6 +2341,7 @@ impl fmt::Display for ConstraintCharacteristics {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ReferentialAction {
     /// `RESTRICT` - disallow action if it would break referential integrity.
     Restrict,
@@ -2331,6 +2373,7 @@ impl fmt::Display for ReferentialAction {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DropBehavior {
     /// `RESTRICT` - refuse to drop if there are any dependent objects.
     Restrict,
@@ -2351,6 +2394,7 @@ impl fmt::Display for DropBehavior {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UserDefinedTypeRepresentation {
     /// Composite type: `CREATE TYPE name AS (attributes)`
     Composite {
@@ -2406,6 +2450,7 @@ impl fmt::Display for UserDefinedTypeRepresentation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct UserDefinedTypeCompositeAttributeDef {
     /// Attribute name.
     pub name: Ident,
@@ -2450,6 +2495,7 @@ impl fmt::Display for UserDefinedTypeCompositeAttributeDef {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UserDefinedTypeInternalLength {
     /// Fixed internal length: `INTERNALLENGTH = <number>`
     Fixed(u64),
@@ -2487,6 +2533,7 @@ impl fmt::Display for UserDefinedTypeInternalLength {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Alignment {
     /// Single-byte alignment: `ALIGNMENT = char`
     Char,
@@ -2531,6 +2578,7 @@ impl fmt::Display for Alignment {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UserDefinedTypeStorage {
     /// No compression or out-of-line storage: `STORAGE = plain`
     Plain,
@@ -2573,6 +2621,7 @@ impl fmt::Display for UserDefinedTypeStorage {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UserDefinedTypeRangeOption {
     /// The element type that the range type will represent: `SUBTYPE = subtype`
     Subtype(DataType),
@@ -2628,6 +2677,7 @@ impl fmt::Display for UserDefinedTypeRangeOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UserDefinedTypeSqlDefinitionOption {
     /// Function to convert from external text representation to internal: `INPUT = input_function`
     Input(ObjectName),
@@ -2713,6 +2763,7 @@ impl fmt::Display for UserDefinedTypeSqlDefinitionOption {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Partition {
     /// ClickHouse supports PARTITION ID 'partition_id' syntax.
     Identifier(Ident),
@@ -2743,6 +2794,7 @@ impl fmt::Display for Partition {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Deduplicate {
     /// DEDUPLICATE ALL
     All,
@@ -2766,6 +2818,7 @@ impl fmt::Display for Deduplicate {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ClusteredBy {
     /// columns used for clustering
     pub columns: Vec<Ident>,
@@ -2793,6 +2846,7 @@ impl fmt::Display for ClusteredBy {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateIndex {
     /// index name
     pub name: Option<ObjectName>,
@@ -2884,6 +2938,7 @@ impl fmt::Display for CreateIndex {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateTable {
     /// `OR REPLACE` clause
     pub or_replace: bool,
@@ -3345,6 +3400,7 @@ impl fmt::Display for CreateTable {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ForValues {
     /// `FOR VALUES IN (expr, ...)`
     In(Vec<Expr>),
@@ -3398,6 +3454,7 @@ impl fmt::Display for ForValues {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PartitionBoundValue {
     /// An expression representing a partition bound value.
     Expr(Expr),
@@ -3432,6 +3489,7 @@ impl fmt::Display for PartitionBoundValue {
 ///     { NOT NULL | NULL | CHECK (expression) }
 /// ```
 /// See [PostgreSQL](https://www.postgresql.org/docs/current/sql-createdomain.html)
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateDomain {
     /// The name of the domain to be created.
     pub name: ObjectName,
@@ -3470,6 +3528,7 @@ impl fmt::Display for CreateDomain {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// CREATE FUNCTION statement
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateFunction {
     /// True if this is a `CREATE OR ALTER FUNCTION` statement
     ///
@@ -3640,6 +3699,7 @@ impl fmt::Display for CreateFunction {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateConnector {
     /// The name of the connector to be created.
     pub name: Ident,
@@ -3699,6 +3759,7 @@ impl fmt::Display for CreateConnector {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterSchemaOperation {
     /// Set the default collation for the schema.
     SetDefaultCollate {
@@ -3764,6 +3825,7 @@ impl fmt::Display for AlterSchemaOperation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum RenameTableNameKind {
     /// `AS new_table_name`
     As(ObjectName),
@@ -3784,6 +3846,7 @@ impl fmt::Display for RenameTableNameKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// An `ALTER SCHEMA` (`Statement::AlterSchema`) statement.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterSchema {
     /// The schema name to alter.
     pub name: ObjectName,
@@ -3821,6 +3884,7 @@ impl Spanned for RenameTableNameKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Whether the syntax used for the trigger object (ROW or STATEMENT) is `FOR` or `FOR EACH`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TriggerObjectKind {
     /// The `FOR` syntax is used.
     For(TriggerObject),
@@ -3853,6 +3917,7 @@ impl Display for TriggerObjectKind {
 ///
 /// Postgres: <https://www.postgresql.org/docs/current/sql-createtrigger.html>
 /// SQL Server: <https://learn.microsoft.com/en-us/sql/t-sql/statements/create-trigger-transact-sql>
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateTrigger {
     /// True if this is a `CREATE OR ALTER TRIGGER` statement
     ///
@@ -4043,6 +4108,7 @@ impl Display for CreateTrigger {
 /// DROP TRIGGER [ IF EXISTS ] name ON table_name [ CASCADE | RESTRICT ]
 /// ```
 ///
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DropTrigger {
     /// Whether to include the `IF EXISTS` clause.
     pub if_exists: bool,
@@ -4085,6 +4151,7 @@ impl fmt::Display for DropTrigger {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Truncate {
     /// Table names to truncate
     pub table_names: Vec<super::TruncateTableTarget>,
@@ -4160,6 +4227,7 @@ impl Spanned for Truncate {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Msck {
     /// Table name to check
     #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
@@ -4195,6 +4263,7 @@ impl Spanned for Msck {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateView {
     /// True if this is a `CREATE OR ALTER VIEW` statement
     ///
@@ -4314,6 +4383,7 @@ impl fmt::Display for CreateView {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateExtension {
     /// Extension name
     pub name: Ident,
@@ -4373,6 +4443,7 @@ impl Spanned for CreateExtension {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DropExtension {
     /// One or more extension names to drop
     pub names: Vec<Ident>,
@@ -4407,6 +4478,7 @@ impl Spanned for DropExtension {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterTableType {
     /// Iceberg table type
     /// <https://docs.snowflake.com/en/sql-reference/sql/alter-iceberg-table>
@@ -4423,6 +4495,7 @@ pub enum AlterTableType {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterTable {
     /// Table name
     #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
@@ -4476,6 +4549,7 @@ impl fmt::Display for AlterTable {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DropFunction {
     /// Whether to include the `IF EXISTS` clause.
     pub if_exists: bool,
@@ -4511,6 +4585,7 @@ impl Spanned for DropFunction {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateOperator {
     /// Operator name (can be schema-qualified)
     pub name: ObjectName,
@@ -4531,6 +4606,7 @@ pub struct CreateOperator {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateOperatorFamily {
     /// Operator family name (can be schema-qualified)
     pub name: ObjectName,
@@ -4543,6 +4619,7 @@ pub struct CreateOperatorFamily {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateOperatorClass {
     /// Operator class name (can be schema-qualified)
     pub name: ObjectName,
@@ -4613,6 +4690,7 @@ impl fmt::Display for CreateOperatorClass {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OperatorArgTypes {
     /// Left-hand operand data type for the operator.
     pub left: DataType,
@@ -4630,6 +4708,7 @@ impl fmt::Display for OperatorArgTypes {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OperatorClassItem {
     /// `OPERATOR` clause describing a specific operator implementation.
     Operator {
@@ -4664,6 +4743,7 @@ pub enum OperatorClassItem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OperatorPurpose {
     /// Purpose: used for index/search operations.
     ForSearch,
@@ -4731,6 +4811,7 @@ impl fmt::Display for OperatorPurpose {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DropOperator {
     /// `IF EXISTS` clause
     pub if_exists: bool,
@@ -4744,6 +4825,7 @@ pub struct DropOperator {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DropOperatorSignature {
     /// Operator name
     pub name: ObjectName,
@@ -4790,6 +4872,7 @@ impl Spanned for DropOperator {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DropOperatorFamily {
     /// `IF EXISTS` clause
     pub if_exists: bool,
@@ -4827,6 +4910,7 @@ impl Spanned for DropOperatorFamily {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DropOperatorClass {
     /// `IF EXISTS` clause
     pub if_exists: bool,
@@ -4863,6 +4947,7 @@ impl Spanned for DropOperatorClass {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OperatorFamilyItem {
     /// `OPERATOR` clause in an operator family modification.
     Operator {
@@ -4892,6 +4977,7 @@ pub enum OperatorFamilyItem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OperatorFamilyDropItem {
     /// `OPERATOR` clause for DROP within an operator family.
     Operator {
@@ -4980,6 +5066,7 @@ impl fmt::Display for OperatorFamilyDropItem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterOperatorFamily {
     /// Operator family name (can be schema-qualified)
     pub name: ObjectName,
@@ -4993,6 +5080,7 @@ pub struct AlterOperatorFamily {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterOperatorFamilyOperation {
     /// `ADD { OPERATOR ... | FUNCTION ... } [, ...]`
     Add {
@@ -5062,6 +5150,7 @@ impl Spanned for AlterOperatorFamily {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterOperatorClass {
     /// Operator class name (can be schema-qualified)
     pub name: ObjectName,
@@ -5075,6 +5164,7 @@ pub struct AlterOperatorClass {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AlterOperatorClassOperation {
     /// `RENAME TO new_name`
     /// Rename the operator class to a new name.
@@ -5127,6 +5217,7 @@ impl Spanned for AlterOperatorClass {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreatePolicy {
     /// Name of the policy.
     pub name: Ident,
@@ -5180,6 +5271,7 @@ impl fmt::Display for CreatePolicy {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CreatePolicyType {
     /// Policy allows operations unless explicitly denied.
     Permissive,
@@ -5204,6 +5296,7 @@ impl fmt::Display for CreatePolicyType {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CreatePolicyCommand {
     /// Applies to all commands.
     All,
@@ -5235,6 +5328,7 @@ impl fmt::Display for CreatePolicyCommand {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DropPolicy {
     /// `true` when `IF EXISTS` was present.
     pub if_exists: bool,
@@ -5284,6 +5378,7 @@ impl From<DropPolicy> for crate::ast::Statement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterPolicy {
     /// Policy name to alter.
     pub name: Ident,

--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -40,6 +40,7 @@ use super::{
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Insert {
     /// Token for the `INSERT` keyword (or its substitutes)
     pub insert_token: AttachedToken,
@@ -197,6 +198,7 @@ impl Display for Insert {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Delete {
     /// Token for the `DELETE` keyword
     pub delete_token: AttachedToken,
@@ -275,6 +277,7 @@ impl Display for Delete {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Update {
     /// Token for the `UPDATE` keyword
     pub update_token: AttachedToken,
@@ -349,6 +352,7 @@ impl Display for Update {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Merge {
     /// The `MERGE` token that starts the statement.
     pub merge_token: AttachedToken,
@@ -405,6 +409,7 @@ impl Display for Merge {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MergeClause {
     /// The `WHEN` token that starts the sub-expression.
     pub when_token: AttachedToken,
@@ -444,6 +449,7 @@ impl Display for MergeClause {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MergeClauseKind {
     /// `WHEN MATCHED`
     Matched,
@@ -483,6 +489,7 @@ impl Display for MergeClauseKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MergeAction {
     /// An `INSERT` clause
     ///
@@ -528,6 +535,7 @@ impl Display for MergeAction {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MergeInsertKind {
     /// The insert expression is defined from an explicit `VALUES` clause
     ///
@@ -573,6 +581,7 @@ impl Display for MergeInsertKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MergeInsertExpr {
     /// The `INSERT` token that starts the sub-expression.
     pub insert_token: AttachedToken,
@@ -618,6 +627,7 @@ impl Display for MergeInsertExpr {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MergeUpdateExpr {
     /// The `UPDATE` token that starts the sub-expression.
     pub update_token: AttachedToken,
@@ -650,6 +660,7 @@ impl Display for MergeUpdateExpr {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OutputClause {
     /// `OUTPUT` clause
     Output {

--- a/src/ast/helpers/attached_token.rs
+++ b/src/ast/helpers/attached_token.rs
@@ -80,6 +80,7 @@ use sqlparser_derive::{Visit, VisitMut};
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AttachedToken(pub TokenWithSpan);
 
 impl AttachedToken {

--- a/src/ast/helpers/key_value_options.rs
+++ b/src/ast/helpers/key_value_options.rs
@@ -35,6 +35,7 @@ use crate::ast::{display_comma_separated, display_separated, Value};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A collection of key-value options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct KeyValueOptions {
     /// The list of key-value options.
     pub options: Vec<KeyValueOption>,
@@ -46,6 +47,7 @@ pub struct KeyValueOptions {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// The delimiter used between key-value options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum KeyValueOptionsDelimiter {
     /// Options are separated by spaces.
     Space,
@@ -57,6 +59,7 @@ pub enum KeyValueOptionsDelimiter {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A single key-value option.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct KeyValueOption {
     /// The name of the option.
     pub option_name: String,
@@ -73,6 +76,7 @@ pub struct KeyValueOption {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// The kind of value for a key-value option.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum KeyValueOptionKind {
     /// A single value.
     Single(Value),

--- a/src/ast/helpers/stmt_create_database.rs
+++ b/src/ast/helpers/stmt_create_database.rs
@@ -54,6 +54,7 @@ use crate::parser::ParserError;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateDatabaseBuilder {
     /// The database name to create.
     pub db_name: ObjectName,

--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -63,6 +63,7 @@ use crate::parser::ParserError;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateTableBuilder {
     /// Whether the statement uses `OR REPLACE`.
     pub or_replace: bool,

--- a/src/ast/helpers/stmt_data_loading.rs
+++ b/src/ast/helpers/stmt_data_loading.rs
@@ -35,6 +35,7 @@ use sqlparser_derive::{Visit, VisitMut};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Parameters for a named stage object used in data loading/unloading.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct StageParamsObject {
     /// Optional URL for the stage.
     pub url: Option<String>,
@@ -53,6 +54,7 @@ pub struct StageParamsObject {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum StageLoadSelectItemKind {
     /// A standard SQL select item expression.
     SelectItem(SelectItem),
@@ -73,6 +75,7 @@ impl fmt::Display for StageLoadSelectItemKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A single item in the `SELECT` list for data loading from staged files.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct StageLoadSelectItem {
     /// Optional alias for the input source.
     pub alias: Option<Ident>,
@@ -130,6 +133,7 @@ impl fmt::Display for StageLoadSelectItem {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A command to stage files to a named stage.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FileStagingCommand {
     /// The stage to which files are being staged.
     #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -199,6 +199,7 @@ fn format_statement_list(f: &mut fmt::Formatter, statements: &[Statement]) -> fm
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Ident {
     /// The value of the identifier without quotes.
     pub value: String,
@@ -348,6 +349,7 @@ impl fmt::Display for Ident {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ObjectName(pub Vec<ObjectNamePart>);
 
 impl From<Vec<Ident>> for ObjectName {
@@ -372,6 +374,7 @@ impl fmt::Display for ObjectName {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ObjectNamePart {
     /// A single identifier part, e.g. `schema` or `table`.
     Identifier(Ident),
@@ -405,6 +408,7 @@ impl fmt::Display for ObjectNamePart {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ObjectNamePartFunction {
     /// The function name that produces the object name part.
     pub name: Ident,
@@ -424,6 +428,7 @@ impl fmt::Display for ObjectNamePartFunction {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Array {
     /// The list of expressions between brackets
     pub elem: Vec<Expr>,
@@ -454,6 +459,7 @@ impl fmt::Display for Array {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Interval {
     /// The interval value expression (commonly a string literal).
     pub value: Box<Expr>,
@@ -516,6 +522,7 @@ impl fmt::Display for Interval {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct StructField {
     /// Optional name of the struct field.
     pub field_name: Option<Ident>,
@@ -547,6 +554,7 @@ impl fmt::Display for StructField {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct UnionField {
     /// Name of the union field.
     pub field_name: Ident,
@@ -566,6 +574,7 @@ impl fmt::Display for UnionField {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DictionaryField {
     /// Dictionary key identifier.
     pub key: Ident,
@@ -583,6 +592,7 @@ impl fmt::Display for DictionaryField {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Map {
     /// Entries of the map as key/value pairs.
     pub entries: Vec<MapEntry>,
@@ -600,6 +610,7 @@ impl Display for Map {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MapEntry {
     /// Key expression of the map entry.
     pub key: Box<Expr>,
@@ -618,6 +629,7 @@ impl fmt::Display for MapEntry {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CastFormat {
     /// A simple cast format specified by a `Value`.
     Value(Value),
@@ -629,6 +641,7 @@ pub enum CastFormat {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum JsonPathElem {
     /// Accesses an object field using dot notation, e.g. `obj:foo.bar.baz`.
     ///
@@ -656,6 +669,7 @@ pub enum JsonPathElem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct JsonPath {
     /// Sequence of path elements that form the JSON path.
     pub path: Vec<JsonPathElem>,
@@ -691,6 +705,7 @@ impl fmt::Display for JsonPath {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CastKind {
     /// The standard SQL cast syntax, e.g. `CAST(<expr> as <datatype>)`
     Cast,
@@ -713,6 +728,7 @@ pub enum CastKind {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ConstraintReferenceMatchKind {
     /// `MATCH FULL`
     Full,
@@ -741,6 +757,7 @@ impl fmt::Display for ConstraintReferenceMatchKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ExtractSyntax {
     /// `EXTRACT( <date_or_time_part> FROM <date_or_time_expr> )`
     From,
@@ -759,6 +776,7 @@ pub enum ExtractSyntax {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CeilFloorKind {
     /// `CEIL( <expr> TO <DateTimeField>)`
     DateTimeField(DateTimeField),
@@ -771,6 +789,7 @@ pub enum CeilFloorKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CaseWhen {
     /// The `WHEN` condition expression.
     pub condition: Expr,
@@ -813,6 +832,7 @@ impl fmt::Display for CaseWhen {
     derive(Visit, VisitMut),
     visit(with = "visit_expr")
 )]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Expr {
     /// Identifier e.g. table name or column name
     Identifier(Ident),
@@ -1329,6 +1349,7 @@ impl Expr {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Subscript {
     /// Accesses the element of the array at the given index.
     Index {
@@ -1398,6 +1419,7 @@ impl fmt::Display for Subscript {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AccessExpr {
     /// Accesses a field using dot notation, e.g. `foo.bar.baz`.
     Dot(Expr),
@@ -1418,6 +1440,7 @@ impl fmt::Display for AccessExpr {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct LambdaFunction {
     /// The parameters to the lambda function.
     pub params: OneOrManyWithParens<Ident>,
@@ -1449,6 +1472,7 @@ impl fmt::Display for LambdaFunction {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum LambdaSyntax {
     /// Arrow syntax: `param -> expr` or `(param1, param2) -> expr`
     ///
@@ -1489,6 +1513,7 @@ pub enum LambdaSyntax {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OneOrManyWithParens<T> {
     /// A single `T`, unparenthesized.
     One(T),
@@ -2160,6 +2185,7 @@ impl fmt::Display for Expr {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum WindowType {
     /// An inline window specification.
     WindowSpec(WindowSpec),
@@ -2186,6 +2212,7 @@ impl Display for WindowType {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct WindowSpec {
     /// Optional window name.
     ///
@@ -2257,6 +2284,7 @@ impl fmt::Display for WindowSpec {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct WindowFrame {
     /// Units for the frame (e.g. `ROWS`, `RANGE`, `GROUPS`).
     pub units: WindowFrameUnits,
@@ -2286,6 +2314,7 @@ impl Default for WindowFrame {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Units used to describe the window frame scope.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum WindowFrameUnits {
     /// `ROWS` unit.
     Rows,
@@ -2312,6 +2341,7 @@ impl fmt::Display for WindowFrameUnits {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// How NULL values are treated in certain window functions.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum NullTreatment {
     /// Ignore NULL values (e.g. `IGNORE NULLS`).
     IgnoreNulls,
@@ -2332,6 +2362,7 @@ impl fmt::Display for NullTreatment {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum WindowFrameBound {
     /// `CURRENT ROW`
     CurrentRow,
@@ -2357,6 +2388,7 @@ impl fmt::Display for WindowFrameBound {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Indicates partition operation type for partition management statements.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AddDropSync {
     /// Add partitions.
     ADD,
@@ -2380,6 +2412,7 @@ impl fmt::Display for AddDropSync {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Object kinds supported by `SHOW CREATE` statements.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ShowCreateObject {
     /// An event object for `SHOW CREATE EVENT`.
     Event,
@@ -2412,6 +2445,7 @@ impl fmt::Display for ShowCreateObject {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Objects that can be targeted by a `COMMENT` statement.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CommentObject {
     /// A table column.
     Column,
@@ -2447,6 +2481,7 @@ impl fmt::Display for CommentObject {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Password specification variants used in user-related statements.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Password {
     /// A concrete password expression.
     Password(Expr),
@@ -2473,6 +2508,7 @@ pub enum Password {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CaseStatement {
     /// The `CASE` token that starts the statement.
     pub case_token: AttachedToken,
@@ -2546,6 +2582,7 @@ impl fmt::Display for CaseStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct IfStatement {
     /// The initial `IF` block containing the condition and statements.
     pub if_block: ConditionalStatementBlock,
@@ -2598,6 +2635,7 @@ impl fmt::Display for IfStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct WhileStatement {
     /// Block executed while the condition holds.
     pub while_block: ConditionalStatementBlock,
@@ -2638,6 +2676,7 @@ impl fmt::Display for WhileStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ConditionalStatementBlock {
     /// Token representing the start of the block (e.g., WHEN/IF/WHILE).
     pub start_token: AttachedToken,
@@ -2688,6 +2727,7 @@ impl fmt::Display for ConditionalStatementBlock {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Statements used inside conditional blocks (`IF`, `WHEN`, `WHILE`).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ConditionalStatements {
     /// Simple sequence of statements (no `BEGIN`/`END`).
     Sequence {
@@ -2733,6 +2773,7 @@ impl fmt::Display for ConditionalStatements {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct BeginEndStatements {
     /// Token representing the `BEGIN` keyword (may include span info).
     pub begin_token: AttachedToken,
@@ -2777,6 +2818,7 @@ impl fmt::Display for BeginEndStatements {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RaiseStatement {
     /// Optional value provided to the RAISE statement.
     pub value: Option<RaiseStatementValue>,
@@ -2799,6 +2841,7 @@ impl fmt::Display for RaiseStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum RaiseStatementValue {
     /// `RAISE USING MESSAGE = 'error'`
     UsingMessage(Expr),
@@ -2825,6 +2868,7 @@ impl fmt::Display for RaiseStatementValue {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DeclareAssignment {
     /// Plain expression specified.
     Expr(Box<Expr>),
@@ -2883,6 +2927,7 @@ impl fmt::Display for DeclareAssignment {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DeclareType {
     /// Cursor variable type. e.g. [Snowflake] [PostgreSQL] [MsSql]
     ///
@@ -2941,6 +2986,7 @@ impl fmt::Display for DeclareType {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Declare {
     /// The name(s) being declared.
     /// Example: `DECLARE a, b, c DEFAULT 42;
@@ -3037,6 +3083,7 @@ impl fmt::Display for Declare {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Options allowed within a `CREATE TABLE` statement.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CreateTableOptions {
     /// No options specified.
     #[default]
@@ -3080,6 +3127,7 @@ impl fmt::Display for CreateTableOptions {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FromTable {
     /// An explicit `FROM` keyword was specified.
     WithFromKeyword(Vec<TableWithJoins>),
@@ -3104,6 +3152,7 @@ impl Display for FromTable {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Variants for the `SET` family of statements.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Set {
     /// SQL Standard-style
     /// SET a = 1;
@@ -3301,6 +3350,7 @@ impl Display for Set {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ExceptionWhen {
     /// Identifiers that trigger this branch (error conditions).
     pub idents: Vec<Ident>,
@@ -3329,6 +3379,7 @@ impl Display for ExceptionWhen {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Analyze {
     #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
     /// Name of the table to analyze.
@@ -3395,6 +3446,7 @@ impl fmt::Display for Analyze {
     derive(Visit, VisitMut),
     visit(with = "visit_statement")
 )]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Statement {
     /// ```sql
     /// ANALYZE
@@ -4745,6 +4797,7 @@ impl From<ddl::Msck> for Statement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CurrentGrantsKind {
     /// `COPY CURRENT GRANTS` (copy current grants to target).
     CopyCurrentGrants,
@@ -4766,6 +4819,7 @@ impl fmt::Display for CurrentGrantsKind {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `RAISERROR` options
 /// See <https://learn.microsoft.com/en-us/sql/t-sql/language-elements/raiserror-transact-sql?view=sql-server-ver16#options>
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum RaisErrorOption {
     /// Log the error.
     Log,
@@ -6128,6 +6182,7 @@ impl fmt::Display for Statement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SequenceOptions {
     /// `INCREMENT [BY] <expr>` option; second value indicates presence of `BY` keyword.
     IncrementBy(Expr, bool),
@@ -6188,6 +6243,7 @@ impl fmt::Display for SequenceOptions {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SetAssignment {
     /// Optional context scope (e.g., SESSION or LOCAL).
     pub scope: Option<ContextModifier>,
@@ -6215,6 +6271,7 @@ impl fmt::Display for SetAssignment {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TruncateTableTarget {
     /// name of the table being truncated
     #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
@@ -6251,6 +6308,7 @@ impl fmt::Display for TruncateTableTarget {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TruncateIdentityOption {
     /// Restart identity values (RESTART IDENTITY).
     Restart,
@@ -6263,6 +6321,7 @@ pub enum TruncateIdentityOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CascadeOption {
     /// Apply cascading action (e.g., CASCADE).
     Cascade,
@@ -6283,6 +6342,7 @@ impl Display for CascadeOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum BeginTransactionKind {
     /// Standard `TRANSACTION` keyword.
     Transaction,
@@ -6304,6 +6364,7 @@ impl Display for BeginTransactionKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MinMaxValue {
     /// Clause is not specified.
     Empty,
@@ -6318,6 +6379,7 @@ pub enum MinMaxValue {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[non_exhaustive]
 /// Behavior to apply for `INSERT` when a conflict occurs.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OnInsert {
     /// ON DUPLICATE KEY UPDATE (MySQL when the key already exists, then execute an update instead)
     DuplicateKeyUpdate(Vec<Assignment>),
@@ -6329,6 +6391,7 @@ pub enum OnInsert {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Optional aliases for `INSERT` targets: row alias and optional column aliases.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InsertAliases {
     /// Row alias (table-style alias) for the inserted values.
     pub row_alias: ObjectName,
@@ -6340,6 +6403,7 @@ pub struct InsertAliases {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `ON CONFLICT` clause representation.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OnConflict {
     /// Optional conflict target specifying columns or constraint.
     pub conflict_target: Option<ConflictTarget>,
@@ -6350,6 +6414,7 @@ pub struct OnConflict {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Target specification for an `ON CONFLICT` clause.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ConflictTarget {
     /// Target specified as a list of columns.
     Columns(Vec<Ident>),
@@ -6360,6 +6425,7 @@ pub enum ConflictTarget {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Action to perform when an `ON CONFLICT` target is matched.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OnConflictAction {
     /// Do nothing on conflict.
     DoNothing,
@@ -6371,6 +6437,7 @@ pub enum OnConflictAction {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Details for `DO UPDATE` action of an `ON CONFLICT` clause.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DoUpdate {
     /// Column assignments to perform on update.
     pub assignments: Vec<Assignment>,
@@ -6433,6 +6500,7 @@ impl fmt::Display for OnConflictAction {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Privileges {
     /// All privileges applicable to the object type
     All {
@@ -6470,6 +6538,7 @@ impl fmt::Display for Privileges {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FetchDirection {
     /// Fetch a specific count of rows.
     Count {
@@ -6563,6 +6632,7 @@ impl fmt::Display for FetchDirection {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FetchPosition {
     /// Use `FROM <pos>` position specifier.
     From,
@@ -6585,6 +6655,7 @@ impl fmt::Display for FetchPosition {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Action {
     /// Add a search optimization.
     AddSearchOptimization,
@@ -6797,6 +6868,7 @@ impl fmt::Display for Action {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// See <https://docs.snowflake.com/en/sql-reference/sql/grant-privilege>
 /// under `globalPrivileges` in the `CREATE` privilege.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ActionCreateObjectType {
     /// An account-level object.
     Account,
@@ -6863,6 +6935,7 @@ impl fmt::Display for ActionCreateObjectType {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// See <https://docs.snowflake.com/en/sql-reference/sql/grant-privilege>
 /// under `globalPrivileges` in the `APPLY` privilege.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ActionApplyType {
     /// Apply an aggregation policy.
     AggregationPolicy,
@@ -6908,6 +6981,7 @@ impl fmt::Display for ActionApplyType {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// See <https://docs.snowflake.com/en/sql-reference/sql/grant-privilege>
 /// under `globalPrivileges` in the `EXECUTE` privilege.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ActionExecuteObjectType {
     /// Alert object.
     Alert,
@@ -6938,6 +7012,7 @@ impl fmt::Display for ActionExecuteObjectType {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// See <https://docs.snowflake.com/en/sql-reference/sql/grant-privilege>
 /// under `globalPrivileges` in the `MANAGE` privilege.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ActionManageType {
     /// Account support cases management.
     AccountSupportCases,
@@ -6974,6 +7049,7 @@ impl fmt::Display for ActionManageType {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// See <https://docs.snowflake.com/en/sql-reference/sql/grant-privilege>
 /// under `globalPrivileges` in the `MODIFY` privilege.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ActionModifyType {
     /// Modify log level.
     LogLevel,
@@ -7001,6 +7077,7 @@ impl fmt::Display for ActionModifyType {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// See <https://docs.snowflake.com/en/sql-reference/sql/grant-privilege>
 /// under `globalPrivileges` in the `MONITOR` privilege.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ActionMonitorType {
     /// Monitor execution.
     Execution,
@@ -7024,6 +7101,7 @@ impl fmt::Display for ActionMonitorType {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Grantee {
     /// The category/type of grantee (role, user, share, etc.).
     pub grantee_type: GranteesType,
@@ -7071,6 +7149,7 @@ impl fmt::Display for Grantee {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// The kind of principal receiving privileges.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GranteesType {
     /// A role principal.
     Role,
@@ -7096,6 +7175,7 @@ pub enum GranteesType {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GranteeName {
     /// A bare identifier
     ObjectName(ObjectName),
@@ -7123,6 +7203,7 @@ impl fmt::Display for GranteeName {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GrantObjects {
     /// Grant privileges on `ALL SEQUENCES IN SCHEMA <schema_name> [, ...]`
     AllSequencesInSchema {
@@ -7390,6 +7471,7 @@ impl fmt::Display for GrantObjects {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DenyStatement {
     /// The privileges to deny.
     pub privileges: Privileges,
@@ -7424,6 +7506,7 @@ impl fmt::Display for DenyStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Assignment {
     /// The left-hand side of the assignment.
     pub target: AssignmentTarget,
@@ -7443,6 +7526,7 @@ impl fmt::Display for Assignment {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AssignmentTarget {
     /// A single column
     ColumnName(ObjectName),
@@ -7463,6 +7547,7 @@ impl fmt::Display for AssignmentTarget {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Expression forms allowed as a function argument.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionArgExpr {
     /// A normal expression argument.
     Expr(Expr),
@@ -7496,6 +7581,7 @@ impl fmt::Display for FunctionArgExpr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Operator used to separate function arguments
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionArgOperator {
     /// function(arg1 = value1)
     Equals,
@@ -7525,6 +7611,7 @@ impl fmt::Display for FunctionArgOperator {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Forms of function arguments (named, expression-named, or positional).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionArg {
     /// `name` is identifier
     ///
@@ -7574,6 +7661,7 @@ impl fmt::Display for FunctionArg {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Which cursor(s) to close.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CloseCursor {
     /// Close all cursors.
     All,
@@ -7597,6 +7685,7 @@ impl fmt::Display for CloseCursor {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DropDomain {
     /// Whether to drop the domain if it exists
     pub if_exists: bool,
@@ -7612,6 +7701,7 @@ pub struct DropDomain {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TypedString {
     /// The data type of the typed string (e.g. DATE, TIME, TIMESTAMP).
     pub data_type: DataType,
@@ -7657,6 +7747,7 @@ impl fmt::Display for TypedString {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Function {
     /// The function name (may be qualified).
     pub name: ObjectName,
@@ -7746,6 +7837,7 @@ impl fmt::Display for Function {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionArguments {
     /// Used for special functions like `CURRENT_TIMESTAMP` that are invoked
     /// without parentheses.
@@ -7772,6 +7864,7 @@ impl fmt::Display for FunctionArguments {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FunctionArgumentList {
     /// `[ ALL | DISTINCT ]`
     pub duplicate_treatment: Option<DuplicateTreatment>,
@@ -7801,6 +7894,7 @@ impl fmt::Display for FunctionArgumentList {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Clauses that can appear inside a function argument list.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionArgumentClause {
     /// Indicates how `NULL`s should be handled in the calculation, e.g. in `FIRST_VALUE` on [BigQuery].
     ///
@@ -7871,6 +7965,7 @@ impl fmt::Display for FunctionArgumentClause {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Method {
     /// The expression on which the method is invoked.
     pub expr: Box<Expr>,
@@ -7894,6 +7989,7 @@ impl fmt::Display for Method {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// How duplicate values are treated inside function argument lists.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DuplicateTreatment {
     /// Consider only unique values.
     Distinct,
@@ -7914,6 +8010,7 @@ impl fmt::Display for DuplicateTreatment {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// How the `ANALYZE`/`EXPLAIN ANALYZE` format is specified.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AnalyzeFormatKind {
     /// Format provided as a keyword, e.g. `FORMAT JSON`.
     Keyword(AnalyzeFormat),
@@ -7934,6 +8031,7 @@ impl fmt::Display for AnalyzeFormatKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Output formats supported for `ANALYZE`/`EXPLAIN ANALYZE`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AnalyzeFormat {
     /// Plain text format.
     TEXT,
@@ -7963,6 +8061,7 @@ impl fmt::Display for AnalyzeFormat {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FileFormat {
     /// Text file format.
     TEXTFILE,
@@ -7999,6 +8098,7 @@ impl fmt::Display for FileFormat {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ListAggOnOverflow {
     /// `ON OVERFLOW ERROR`
     Error,
@@ -8037,6 +8137,7 @@ impl fmt::Display for ListAggOnOverflow {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct HavingBound(pub HavingBoundKind, pub Expr);
 
 impl fmt::Display for HavingBound {
@@ -8049,6 +8150,7 @@ impl fmt::Display for HavingBound {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Which bound is used in a HAVING clause for ANY_VALUE on BigQuery.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum HavingBoundKind {
     /// The minimum bound.
     Min,
@@ -8069,6 +8171,7 @@ impl fmt::Display for HavingBoundKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Types of database objects referenced by DDL statements.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ObjectType {
     /// A table.
     Table,
@@ -8119,6 +8222,7 @@ impl fmt::Display for ObjectType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Types supported by `KILL` statements.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum KillType {
     /// Kill a connection.
     Connection,
@@ -8144,6 +8248,7 @@ impl fmt::Display for KillType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Distribution style options for Hive tables.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum HiveDistributionStyle {
     /// Partitioned distribution with the given columns.
     PARTITIONED {
@@ -8167,6 +8272,7 @@ pub enum HiveDistributionStyle {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Row format specification for Hive tables (SERDE or DELIMITED).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum HiveRowFormat {
     /// SerDe class specification with the implementing class name.
     SERDE {
@@ -8184,6 +8290,7 @@ pub enum HiveRowFormat {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Format specification for `LOAD DATA` Hive operations.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct HiveLoadDataFormat {
     /// SerDe expression used for the table.
     pub serde: Expr,
@@ -8195,6 +8302,7 @@ pub struct HiveLoadDataFormat {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A single row delimiter specification for Hive `ROW FORMAT`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct HiveRowDelimiter {
     /// The delimiter kind (fields/lines/etc.).
     pub delimiter: HiveDelimiter,
@@ -8213,6 +8321,7 @@ impl fmt::Display for HiveRowDelimiter {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Kind of delimiter used in Hive `ROW FORMAT` definitions.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum HiveDelimiter {
     /// Fields terminated by a delimiter.
     FieldsTerminatedBy,
@@ -8246,6 +8355,7 @@ impl fmt::Display for HiveDelimiter {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Describe output format options for Hive `DESCRIBE`/`EXPLAIN`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum HiveDescribeFormat {
     /// Extended describe output.
     Extended,
@@ -8267,6 +8377,7 @@ impl fmt::Display for HiveDescribeFormat {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Aliases accepted for describe-style commands.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DescribeAlias {
     /// `DESCRIBE` alias.
     Describe,
@@ -8292,6 +8403,7 @@ impl fmt::Display for DescribeAlias {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[allow(clippy::large_enum_variant)]
 /// Hive input/output format specification used in `CREATE TABLE`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum HiveIOFormat {
     /// Generic IO format with separate input and output expressions.
     IOF {
@@ -8311,6 +8423,7 @@ pub enum HiveIOFormat {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Hive table format and storage-related options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct HiveFormat {
     /// Optional row format specification.
     pub row_format: Option<HiveRowFormat>,
@@ -8326,6 +8439,7 @@ pub struct HiveFormat {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A clustered index column specification.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ClusteredIndex {
     /// Column identifier for the clustered index entry.
     pub name: Ident,
@@ -8348,6 +8462,7 @@ impl fmt::Display for ClusteredIndex {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Clustered options used for `CREATE TABLE` clustered/indexed storage.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableOptionsClustered {
     /// Use a columnstore index.
     ColumnstoreIndex,
@@ -8381,6 +8496,7 @@ impl fmt::Display for TableOptionsClustered {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PartitionRangeDirection {
     /// LEFT range direction.
     Left,
@@ -8392,6 +8508,7 @@ pub enum PartitionRangeDirection {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// SQL option syntax used in table and server definitions.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SqlOption {
     /// Clustered represents the clustered version of table storage for MSSQL.
     ///
@@ -8501,6 +8618,7 @@ impl fmt::Display for SqlOption {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Storage type options for a tablespace.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum StorageType {
     /// Store on disk.
     Disk,
@@ -8513,6 +8631,7 @@ pub enum StorageType {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// MySql TableSpace option
 /// <https://dev.mysql.com/doc/refman/8.4/en/create-table.html>
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TablespaceOption {
     /// Name of the tablespace.
     pub name: String,
@@ -8524,6 +8643,7 @@ pub struct TablespaceOption {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A key/value identifier pair used for secret or key-based options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SecretOption {
     /// The option key identifier.
     pub key: Ident,
@@ -8543,6 +8663,7 @@ impl fmt::Display for SecretOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateServerStatement {
     /// The server name.
     pub name: ObjectName,
@@ -8597,6 +8718,7 @@ impl fmt::Display for CreateServerStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateServerOption {
     /// Option key identifier.
     pub key: Ident,
@@ -8614,6 +8736,7 @@ impl fmt::Display for CreateServerOption {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Options supported by DuckDB for `ATTACH DATABASE`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AttachDuckDBDatabaseOption {
     /// READ_ONLY option, optional boolean value.
     ReadOnly(Option<bool>),
@@ -8636,6 +8759,7 @@ impl fmt::Display for AttachDuckDBDatabaseOption {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Mode for transactions: access mode or isolation level.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TransactionMode {
     /// Access mode for a transaction (e.g. `READ ONLY` / `READ WRITE`).
     AccessMode(TransactionAccessMode),
@@ -8657,6 +8781,7 @@ impl fmt::Display for TransactionMode {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Transaction access mode (READ ONLY / READ WRITE).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TransactionAccessMode {
     /// READ ONLY access mode.
     ReadOnly,
@@ -8678,6 +8803,7 @@ impl fmt::Display for TransactionAccessMode {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Transaction isolation levels.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TransactionIsolationLevel {
     /// READ UNCOMMITTED isolation level.
     ReadUncommitted,
@@ -8711,6 +8837,7 @@ impl fmt::Display for TransactionIsolationLevel {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TransactionModifier {
     /// DEFERRED transaction modifier.
     Deferred,
@@ -8741,6 +8868,7 @@ impl fmt::Display for TransactionModifier {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Filter forms usable in SHOW statements.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ShowStatementFilter {
     /// Filter using LIKE pattern.
     Like(String),
@@ -8768,6 +8896,7 @@ impl fmt::Display for ShowStatementFilter {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Clause types used with SHOW ... IN/FROM.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ShowStatementInClause {
     /// Use the `IN` clause.
     IN,
@@ -8792,6 +8921,7 @@ impl fmt::Display for ShowStatementInClause {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SqliteOnConflict {
     /// Use ROLLBACK on conflict.
     Rollback,
@@ -8826,6 +8956,7 @@ impl fmt::Display for SqliteOnConflict {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MysqlInsertPriority {
     /// LOW_PRIORITY modifier for INSERT/REPLACE.
     LowPriority,
@@ -8850,6 +8981,7 @@ impl fmt::Display for crate::ast::MysqlInsertPriority {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Source for the `COPY` command: a table or a query.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CopySource {
     /// Copy from a table with optional column list.
     Table {
@@ -8867,6 +8999,7 @@ pub enum CopySource {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Target for the `COPY` command: STDIN, STDOUT, a file, or a program.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CopyTarget {
     /// Use standard input as the source.
     Stdin,
@@ -8904,6 +9037,7 @@ impl fmt::Display for CopyTarget {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Action to take `ON COMMIT` for temporary tables.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OnCommit {
     /// Delete rows on commit.
     DeleteRows,
@@ -8919,6 +9053,7 @@ pub enum OnCommit {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CopyOption {
     /// FORMAT format_name
     Format(Ident),
@@ -8974,6 +9109,7 @@ impl fmt::Display for CopyOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CopyLegacyOption {
     /// ACCEPTANYDATE
     AcceptAnyDate,
@@ -9176,6 +9312,7 @@ impl fmt::Display for CopyLegacyOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FileSize {
     /// Numeric size value.
     pub size: Value,
@@ -9197,6 +9334,7 @@ impl fmt::Display for FileSize {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FileSizeUnit {
     /// Megabytes.
     MB,
@@ -9221,6 +9359,7 @@ impl fmt::Display for FileSizeUnit {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct UnloadPartitionBy {
     /// Columns used to partition the unload output.
     pub columns: Vec<Ident>,
@@ -9245,6 +9384,7 @@ impl fmt::Display for UnloadPartitionBy {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum IamRoleKind {
     /// Default role
     Default,
@@ -9267,6 +9407,7 @@ impl fmt::Display for IamRoleKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CopyLegacyCsvOption {
     /// HEADER
     Header,
@@ -9299,6 +9440,7 @@ impl fmt::Display for CopyLegacyCsvOption {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DiscardObject {
     /// Discard all session state.
     ALL,
@@ -9325,6 +9467,7 @@ impl fmt::Display for DiscardObject {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FlushType {
     /// Flush binary logs.
     BinaryLogs,
@@ -9378,6 +9521,7 @@ impl fmt::Display for FlushType {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FlushLocation {
     /// Do not write changes to the binary log.
     NoWriteToBinlog,
@@ -9398,6 +9542,7 @@ impl fmt::Display for FlushLocation {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ContextModifier {
     /// `LOCAL` identifier, usually related to transactional states.
     Local,
@@ -9426,6 +9571,7 @@ impl fmt::Display for ContextModifier {
 /// Function describe in DROP FUNCTION.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DropFunctionOption {
     /// `RESTRICT` option for DROP FUNCTION.
     Restrict,
@@ -9446,6 +9592,7 @@ impl fmt::Display for DropFunctionOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FunctionDesc {
     /// The function name.
     pub name: ObjectName,
@@ -9467,6 +9614,7 @@ impl fmt::Display for FunctionDesc {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OperateFunctionArg {
     /// Optional argument mode (`IN`, `OUT`, `INOUT`).
     pub mode: Option<ArgMode>,
@@ -9520,6 +9668,7 @@ impl fmt::Display for OperateFunctionArg {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ArgMode {
     /// `IN` mode.
     In,
@@ -9543,6 +9692,7 @@ impl fmt::Display for ArgMode {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionBehavior {
     /// Function is immutable.
     Immutable,
@@ -9568,6 +9718,7 @@ impl fmt::Display for FunctionBehavior {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionSecurity {
     /// Execute the function with the privileges of the user who defined it.
     Definer,
@@ -9590,6 +9741,7 @@ impl fmt::Display for FunctionSecurity {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionSetValue {
     /// SET param = value1, value2, ...
     Values(Vec<Expr>),
@@ -9603,6 +9755,7 @@ pub enum FunctionSetValue {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FunctionDefinitionSetParam {
     /// The name of the configuration parameter.
     pub name: Ident,
@@ -9626,6 +9779,7 @@ impl fmt::Display for FunctionDefinitionSetParam {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionCalledOnNull {
     /// Function is called even when inputs are null.
     CalledOnNullInput,
@@ -9649,6 +9803,7 @@ impl fmt::Display for FunctionCalledOnNull {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionParallel {
     /// The function is not safe to run in parallel.
     Unsafe,
@@ -9674,6 +9829,7 @@ impl fmt::Display for FunctionParallel {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FunctionDeterminismSpecifier {
     /// Function is deterministic.
     Deterministic,
@@ -9703,6 +9859,7 @@ impl fmt::Display for FunctionDeterminismSpecifier {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CreateFunctionBody {
     /// A function body expression using the 'AS' keyword and shows up
     /// before any `OPTIONS` clause.
@@ -9798,6 +9955,7 @@ pub enum CreateFunctionBody {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `USING` clause options for `CREATE FUNCTION` (e.g., JAR, FILE, ARCHIVE).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CreateFunctionUsing {
     /// Use a JAR file located at the given URI.
     Jar(String),
@@ -9825,6 +9983,7 @@ impl fmt::Display for CreateFunctionUsing {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MacroArg {
     /// The argument name.
     pub name: Ident,
@@ -9856,6 +10015,7 @@ impl fmt::Display for MacroArg {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Definition for a DuckDB macro: either an expression or a table-producing query.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MacroDefinition {
     /// The macro is defined as an expression.
     Expr(Expr),
@@ -9879,6 +10039,7 @@ impl fmt::Display for MacroDefinition {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SchemaName {
     /// Only schema name specified: `<schema name>`.
     Simple(ObjectName),
@@ -9910,6 +10071,7 @@ impl fmt::Display for SchemaName {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SearchModifier {
     /// `IN NATURAL LANGUAGE MODE`.
     InNaturalLanguageMode,
@@ -9946,6 +10108,7 @@ impl fmt::Display for SearchModifier {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct LockTable {
     /// The table identifier to lock.
     pub table: Ident,
@@ -9976,6 +10139,7 @@ impl fmt::Display for LockTable {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// The type of lock used in `LOCK TABLE` statements.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum LockTableType {
     /// Shared/read lock. If `local` is true, it's a local read lock.
     Read {
@@ -10014,6 +10178,7 @@ impl fmt::Display for LockTableType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Hive-specific `SET LOCATION` helper used in some `LOAD DATA` statements.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct HiveSetLocation {
     /// Whether the `SET` keyword was present.
     pub has_set: bool,
@@ -10036,6 +10201,7 @@ impl fmt::Display for HiveSetLocation {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// MySQL `ALTER TABLE` column position specifier: `FIRST` or `AFTER <column>`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MySQLColumnPosition {
     /// Place the column first in the table.
     First,
@@ -10060,6 +10226,7 @@ impl Display for MySQLColumnPosition {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// MySQL `CREATE VIEW` algorithm options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CreateViewAlgorithm {
     /// `UNDEFINED` algorithm.
     Undefined,
@@ -10083,6 +10250,7 @@ impl Display for CreateViewAlgorithm {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// MySQL `CREATE VIEW` SQL SECURITY options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CreateViewSecurity {
     /// The view runs with the privileges of the definer.
     Definer,
@@ -10105,6 +10273,7 @@ impl Display for CreateViewSecurity {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateViewParams {
     /// Optional view algorithm (e.g., MERGE, TEMPTABLE).
     pub algorithm: Option<CreateViewAlgorithm>,
@@ -10144,6 +10313,7 @@ impl Display for CreateViewParams {
 /// ENGINE = ReplicatedMergeTree('/table_name','{replica}', ver)
 /// ENGINE = SummingMergeTree([columns])
 /// ```
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NamedParenthesizedList {
     /// The option key (identifier) for this named list.
     pub key: Ident,
@@ -10160,6 +10330,7 @@ pub struct NamedParenthesizedList {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RowAccessPolicy {
     /// The fully-qualified policy object name.
     pub policy: ObjectName,
@@ -10191,6 +10362,7 @@ impl Display for RowAccessPolicy {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Tag {
     /// The tag key (can be qualified).
     pub key: ObjectName,
@@ -10217,6 +10389,7 @@ impl Display for Tag {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ContactEntry {
     /// The purpose label for the contact entry.
     pub purpose: String,
@@ -10234,6 +10407,7 @@ impl Display for ContactEntry {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CommentDef {
     /// Includes `=` when printing the comment, as `COMMENT = 'comment'`
     /// Does not include `=` when printing the comment, as `COMMENT 'comment'`
@@ -10267,6 +10441,7 @@ impl Display for CommentDef {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum WrappedCollection<T> {
     /// Print the collection without wrapping symbols, as `item, item, item`
     NoWrapping(T),
@@ -10316,6 +10491,7 @@ where
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct UtilityOption {
     /// The option name (identifier).
     pub name: Ident,
@@ -10339,6 +10515,7 @@ impl Display for UtilityOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ShowStatementOptions {
     /// Optional scope to show in (for example: TABLE, SCHEMA).
     pub show_in: Option<ShowStatementIn>,
@@ -10391,6 +10568,7 @@ impl Display for ShowStatementOptions {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Where a `SHOW` filter appears relative to the main clause.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ShowStatementFilterPosition {
     /// Put the filter in an infix position (e.g. `SHOW COLUMNS LIKE '%name%' IN TABLE tbl`).
     Infix(ShowStatementFilter), // For example: SHOW COLUMNS LIKE '%name%' IN TABLE tbl
@@ -10402,6 +10580,7 @@ pub enum ShowStatementFilterPosition {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Parent object types usable with `SHOW ... IN <parent>` clauses.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ShowStatementInParentType {
     /// ACCOUNT parent type for SHOW statements.
     Account,
@@ -10431,6 +10610,7 @@ impl fmt::Display for ShowStatementInParentType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Represents a `SHOW ... IN` clause with optional parent qualifier and name.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ShowStatementIn {
     /// The clause that specifies what to show (e.g. COLUMNS, TABLES).
     pub clause: ShowStatementInClause,
@@ -10458,6 +10638,7 @@ impl fmt::Display for ShowStatementIn {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ShowCharset {
     /// The statement can be written as `SHOW CHARSET` or `SHOW CHARACTER SET`
     /// true means CHARSET was used and false means CHARACTER SET was used
@@ -10485,6 +10666,7 @@ impl fmt::Display for ShowCharset {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Options for a `SHOW OBJECTS` statement.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ShowObjects {
     /// Whether to show terse output.
     pub terse: bool,
@@ -10504,6 +10686,7 @@ pub struct ShowObjects {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum JsonNullClause {
     /// `NULL ON NULL` behavior for JSON functions.
     NullOnNull,
@@ -10529,6 +10712,7 @@ impl Display for JsonNullClause {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct JsonReturningClause {
     /// The data type to return from the JSON function (e.g. JSON/JSONB).
     pub data_type: DataType,
@@ -10544,6 +10728,7 @@ impl Display for JsonReturningClause {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RenameTable {
     /// The current name of the object to rename.
     pub old_name: ObjectName,
@@ -10562,6 +10747,7 @@ impl fmt::Display for RenameTable {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableObject {
     /// Table specified by name.
     /// Example:
@@ -10592,6 +10778,7 @@ impl fmt::Display for TableObject {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SetSessionAuthorizationParam {
     /// The scope for the `SET SESSION AUTHORIZATION` (e.g., GLOBAL/SESSION).
     pub scope: ContextModifier,
@@ -10609,6 +10796,7 @@ impl fmt::Display for SetSessionAuthorizationParam {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SetSessionAuthorizationParamKind {
     /// Default authorization
     Default,
@@ -10630,6 +10818,7 @@ impl fmt::Display for SetSessionAuthorizationParamKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Kind of session parameter being set by `SET SESSION`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SetSessionParamKind {
     /// Generic session parameter (name/value pair).
     Generic(SetSessionParamGeneric),
@@ -10656,6 +10845,7 @@ impl fmt::Display for SetSessionParamKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Generic `SET SESSION` parameter represented as name(s) and value.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SetSessionParamGeneric {
     /// Names of the session parameters being set.
     pub names: Vec<String>,
@@ -10673,6 +10863,7 @@ impl fmt::Display for SetSessionParamGeneric {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `IDENTITY_INSERT` session parameter for a specific object.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SetSessionParamIdentityInsert {
     /// Object name targeted by `IDENTITY_INSERT`.
     pub obj: ObjectName,
@@ -10690,6 +10881,7 @@ impl fmt::Display for SetSessionParamIdentityInsert {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Offsets-related session parameter with keywords and a value.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SetSessionParamOffsets {
     /// Keywords specifying which offsets to modify.
     pub keywords: Vec<String>,
@@ -10712,6 +10904,7 @@ impl fmt::Display for SetSessionParamOffsets {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Statistics-related session parameter specifying topic and value.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SetSessionParamStatistics {
     /// Statistics topic to set (IO/PROFILE/TIME/XML).
     pub topic: SessionParamStatsTopic,
@@ -10729,6 +10922,7 @@ impl fmt::Display for SetSessionParamStatistics {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Topics available for session statistics configuration.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SessionParamStatsTopic {
     /// Input/output statistics.
     IO,
@@ -10755,6 +10949,7 @@ impl fmt::Display for SessionParamStatsTopic {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Value for a session boolean-like parameter (ON/OFF).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SessionParamValue {
     /// Session parameter enabled.
     On,
@@ -10780,6 +10975,7 @@ impl fmt::Display for SessionParamValue {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum StorageSerializationPolicy {
     /// Use compatible serialization mode.
     Compatible,
@@ -10805,6 +11001,7 @@ impl Display for StorageSerializationPolicy {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CatalogSyncNamespaceMode {
     /// Nest namespaces when syncing catalog.
     Nest,
@@ -10825,6 +11022,7 @@ impl Display for CatalogSyncNamespaceMode {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CopyIntoSnowflakeKind {
     /// Loads data from files to a table
     /// See: <https://docs.snowflake.com/en/sql-reference/sql/copy-into-table>
@@ -10838,6 +11036,7 @@ pub enum CopyIntoSnowflakeKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `PRINT` statement for producing debug/output messages.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PrintStatement {
     /// The expression producing the message to print.
     pub message: Box<Expr>,
@@ -10856,6 +11055,7 @@ impl fmt::Display for PrintStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ReturnStatement {
     /// Optional return value expression.
     pub value: Option<ReturnStatementValue>,
@@ -10874,6 +11074,7 @@ impl fmt::Display for ReturnStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ReturnStatementValue {
     /// Return an expression from a function or trigger.
     Expr(Expr),
@@ -10883,6 +11084,7 @@ pub enum ReturnStatementValue {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OpenStatement {
     /// Cursor name
     pub cursor_name: Ident,
@@ -10900,6 +11102,7 @@ impl fmt::Display for OpenStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum NullInclusion {
     /// Include NULL values in the UNPIVOT output.
     IncludeNulls,
@@ -10926,6 +11129,7 @@ impl fmt::Display for NullInclusion {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct MemberOf {
     /// The value to check for membership.
     pub value: Box<Expr>,
@@ -10943,6 +11147,7 @@ impl fmt::Display for MemberOf {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Represents an `EXPORT DATA` statement.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ExportData {
     /// Options for the export operation.
     pub options: Vec<SqlOption>,
@@ -10982,6 +11187,7 @@ impl fmt::Display for ExportData {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateUser {
     /// Replace existing user if present.
     pub or_replace: bool,
@@ -11035,6 +11241,7 @@ impl fmt::Display for CreateUser {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterUser {
     /// Whether to only alter the user if it exists.
     pub if_exists: bool,
@@ -11083,6 +11290,7 @@ pub struct AlterUser {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterUserAddRoleDelegation {
     /// Role name to delegate.
     pub role: Ident,
@@ -11096,6 +11304,7 @@ pub struct AlterUserAddRoleDelegation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterUserRemoveRoleDelegation {
     /// Optional role name to remove delegation for.
     pub role: Option<Ident>,
@@ -11109,6 +11318,7 @@ pub struct AlterUserRemoveRoleDelegation {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterUserAddMfaMethodOtp {
     /// Optional OTP count parameter.
     pub count: Option<Value>,
@@ -11120,6 +11330,7 @@ pub struct AlterUserAddMfaMethodOtp {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterUserModifyMfaMethod {
     /// The MFA method being modified.
     pub method: MfaMethodKind,
@@ -11131,6 +11342,7 @@ pub struct AlterUserModifyMfaMethod {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MfaMethodKind {
     /// PassKey (hardware or platform passkey) MFA method.
     PassKey,
@@ -11156,6 +11368,7 @@ impl fmt::Display for MfaMethodKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterUserSetPolicy {
     /// The kind of user policy being set (authentication/password/session).
     pub policy_kind: UserPolicyKind,
@@ -11167,6 +11380,7 @@ pub struct AlterUserSetPolicy {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UserPolicyKind {
     /// Authentication policy.
     Authentication,
@@ -11279,6 +11493,7 @@ impl fmt::Display for AlterUser {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AlterUserPassword {
     /// Whether the password is encrypted.
     pub encrypted: bool,
@@ -11307,6 +11522,7 @@ impl Display for AlterUserPassword {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CreateTableLikeKind {
     /// '''sql
     /// CREATE TABLE new (LIKE old ...)
@@ -11325,6 +11541,7 @@ pub enum CreateTableLikeKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Controls whether defaults are included when creating a table FROM/LILE another.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CreateTableLikeDefaults {
     /// Include default values from the source table.
     Including,
@@ -11345,6 +11562,7 @@ impl fmt::Display for CreateTableLikeDefaults {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Represents the `LIKE` clause of a `CREATE TABLE` statement.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CreateTableLike {
     /// The source table name to copy the schema from.
     pub name: ObjectName,
@@ -11368,6 +11586,7 @@ impl fmt::Display for CreateTableLike {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum RefreshModeKind {
     /// Automatic refresh mode (`AUTO`).
     Auto,
@@ -11393,6 +11612,7 @@ impl fmt::Display for RefreshModeKind {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum InitializeKind {
     /// Initialize on creation (`ON CREATE`).
     OnCreate,
@@ -11418,6 +11638,7 @@ impl fmt::Display for InitializeKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct VacuumStatement {
     /// Whether `FULL` was specified.
     pub full: bool,
@@ -11465,6 +11686,7 @@ impl fmt::Display for VacuumStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Reset {
     /// Resets all session parameters to their default values.
     ALL,
@@ -11480,6 +11702,7 @@ pub enum Reset {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ResetStatement {
     /// The reset action to perform (either `ALL` or a specific configuration parameter).
     pub reset: Reset,
@@ -11493,6 +11716,7 @@ pub struct ResetStatement {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OptimizerHint {
     /// the raw test of the optimizer hint without its markers
     pub text: String,
@@ -11507,6 +11731,7 @@ pub struct OptimizerHint {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OptimizerHintStyle {
     /// A hint corresponding to a single line comment,
     /// e.g. `--+ LEADING(v.e v.d t)`

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -32,6 +32,7 @@ use super::display_separated;
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UnaryOperator {
     /// `@-@` Length or circumference (PostgreSQL/Redshift geometric operator)
     /// see <https://www.postgresql.org/docs/9.5/functions-geometry.html>
@@ -96,6 +97,7 @@ impl fmt::Display for UnaryOperator {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum BinaryOperator {
     /// Plus, e.g. `a + b`
     Plus,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -37,6 +37,7 @@ use crate::{
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "visitor", visit(with = "visit_query"))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Query {
     /// WITH (common table expressions, or CTEs)
     pub with: Option<With>,
@@ -119,6 +120,7 @@ impl fmt::Display for Query {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ProjectionSelect {
     /// The list of projected select items.
     pub projection: Vec<SelectItem>,
@@ -147,6 +149,7 @@ impl fmt::Display for ProjectionSelect {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SetExpr {
     /// Restricted SELECT .. FROM .. HAVING (no ORDER BY or set operations)
     Select(Box<Select>),
@@ -237,6 +240,7 @@ impl fmt::Display for SetExpr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A set operator for combining two `SetExpr`s.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SetOperator {
     /// `UNION` set operator
     Union,
@@ -265,6 +269,7 @@ impl fmt::Display for SetOperator {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SetQuantifier {
     /// `ALL` quantifier
     All,
@@ -298,6 +303,7 @@ impl fmt::Display for SetQuantifier {
 /// A [`TABLE` command]( https://www.postgresql.org/docs/current/sql-select.html#SQL-TABLE)
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A (possibly schema-qualified) table reference used in `FROM` clauses.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Table {
     /// Optional table name (absent for e.g. `TABLE` command without argument).
     pub table_name: Option<String>,
@@ -325,6 +331,7 @@ impl fmt::Display for Table {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SelectFlavor {
     /// `SELECT *`
     Standard,
@@ -340,6 +347,7 @@ pub enum SelectFlavor {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Select {
     /// Token for the `SELECT` keyword
     pub select_token: AttachedToken,
@@ -550,6 +558,7 @@ impl fmt::Display for Select {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct LateralView {
     /// LATERAL VIEW
     pub lateral_view: Expr,
@@ -589,6 +598,7 @@ impl fmt::Display for LateralView {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum NamedWindowExpr {
     /// A direct reference to another named window definition.
     /// [BigQuery]
@@ -627,6 +637,7 @@ impl fmt::Display for NamedWindowExpr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A named window definition: `<name> AS <window specification>`
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NamedWindowDefinition(pub Ident, pub NamedWindowExpr);
 
 impl fmt::Display for NamedWindowDefinition {
@@ -639,6 +650,7 @@ impl fmt::Display for NamedWindowDefinition {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A `WITH` clause, introducing common table expressions (CTEs).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct With {
     /// Token for the `WITH` keyword
     pub with_token: AttachedToken,
@@ -663,6 +675,7 @@ impl fmt::Display for With {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Indicates whether a CTE is materialized or not.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CteAsMaterialized {
     /// The `WITH` statement specifies `AS MATERIALIZED` behavior
     Materialized,
@@ -691,6 +704,7 @@ impl fmt::Display for CteAsMaterialized {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Cte {
     /// The CTE alias (name introduced before the `AS` keyword).
     pub alias: TableAlias,
@@ -738,6 +752,7 @@ impl fmt::Display for Cte {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SelectItemQualifiedWildcardKind {
     /// Expression is an object name.
     /// e.g. `alias.*` or even `schema.table.*`
@@ -751,6 +766,7 @@ pub enum SelectItemQualifiedWildcardKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum SelectItem {
     /// Any expression, not followed by `[ AS ] alias`
     UnnamedExpr(Expr),
@@ -788,6 +804,7 @@ impl fmt::Display for SelectItemQualifiedWildcardKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct IdentWithAlias {
     /// The identifier being aliased.
     pub ident: Ident,
@@ -805,6 +822,7 @@ impl fmt::Display for IdentWithAlias {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct WildcardAdditionalOptions {
     /// The wildcard token `*`
     pub wildcard_token: AttachedToken,
@@ -868,6 +886,7 @@ impl fmt::Display for WildcardAdditionalOptions {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct IlikeSelectItem {
     /// The pattern expression used with `ILIKE`.
     pub pattern: String,
@@ -893,6 +912,7 @@ impl fmt::Display for IlikeSelectItem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ExcludeSelectItem {
     /// Single column name without parenthesis.
     ///
@@ -934,6 +954,7 @@ impl fmt::Display for ExcludeSelectItem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum RenameSelectItem {
     /// Single column name with alias without parenthesis.
     ///
@@ -974,6 +995,7 @@ impl fmt::Display for RenameSelectItem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ExceptSelectItem {
     /// First guaranteed column.
     pub first_element: Ident,
@@ -1008,6 +1030,7 @@ impl fmt::Display for ExceptSelectItem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ReplaceSelectItem {
     /// List of replacement elements contained in the `REPLACE(...)` clause.
     pub items: Vec<Box<ReplaceSelectElement>>,
@@ -1028,6 +1051,7 @@ impl fmt::Display for ReplaceSelectItem {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ReplaceSelectElement {
     /// Expression producing the replacement value.
     pub expr: Expr,
@@ -1073,6 +1097,7 @@ impl fmt::Display for SelectItem {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A left table followed by zero or more joins.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TableWithJoins {
     /// The starting table factor (left side) of the join chain.
     pub relation: TableFactor,
@@ -1097,6 +1122,7 @@ impl fmt::Display for TableWithJoins {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ConnectBy {
     /// START WITH
     pub condition: Expr,
@@ -1119,6 +1145,7 @@ impl fmt::Display for ConnectBy {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A single setting key-value pair.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Setting {
     /// Setting name/key.
     pub key: Ident,
@@ -1141,6 +1168,7 @@ impl fmt::Display for Setting {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ExprWithAlias {
     /// The expression.
     pub expr: Expr,
@@ -1168,6 +1196,7 @@ impl fmt::Display for ExprWithAlias {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ExprWithAliasAndOrderBy {
     /// Expression with optional alias.
     pub expr: ExprWithAlias,
@@ -1185,6 +1214,7 @@ impl fmt::Display for ExprWithAliasAndOrderBy {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TableFunctionArgs {
     /// The list of arguments passed to the table-valued function.
     pub args: Vec<FunctionArg>,
@@ -1199,6 +1229,7 @@ pub struct TableFunctionArgs {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Type of index hint (e.g., `USE`, `IGNORE`, `FORCE`).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableIndexHintType {
     /// `USE` hint.
     Use,
@@ -1222,6 +1253,7 @@ impl fmt::Display for TableIndexHintType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// The kind of index referenced by an index hint (e.g. `USE INDEX`).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableIndexType {
     /// The `INDEX` kind.
     Index,
@@ -1242,6 +1274,7 @@ impl fmt::Display for TableIndexType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Which clause the table index hint applies to.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableIndexHintForClause {
     /// Apply the hint to JOIN clauses.
     Join,
@@ -1265,6 +1298,7 @@ impl fmt::Display for TableIndexHintForClause {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// MySQL-style index hints attached to a table (e.g., `USE INDEX(...)`).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TableIndexHints {
     /// Type of hint (e.g., `USE`, `FORCE`, or `IGNORE`).
     pub hint_type: TableIndexHintType,
@@ -1291,6 +1325,7 @@ impl fmt::Display for TableIndexHints {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "visitor", visit(with = "visit_table_factor"))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableFactor {
     /// A named table or relation, possibly with arguments, hints, or sampling.
     Table {
@@ -1565,6 +1600,7 @@ pub enum TableFactor {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableSampleKind {
     /// Table sample located before the table alias option
     BeforeTableAlias(Box<TableSample>),
@@ -1576,6 +1612,7 @@ pub enum TableSampleKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Represents a `TABLESAMPLE` clause and its options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TableSample {
     /// Modifier (e.g. `SAMPLE` or `TABLESAMPLE`).
     pub modifier: TableSampleModifier,
@@ -1595,6 +1632,7 @@ pub struct TableSample {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Modifier specifying whether `SAMPLE` or `TABLESAMPLE` keyword was used.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableSampleModifier {
     /// `SAMPLE` modifier.
     Sample,
@@ -1616,6 +1654,7 @@ impl fmt::Display for TableSampleModifier {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Quantity for a `TABLESAMPLE` clause (e.g. `10 PERCENT` or `(10)`).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TableSampleQuantity {
     /// Whether the quantity was wrapped in parentheses.
     pub parenthesized: bool,
@@ -1646,6 +1685,7 @@ impl fmt::Display for TableSampleQuantity {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Sampling method used by `TABLESAMPLE`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableSampleMethod {
     /// `ROW` sampling method.
     Row,
@@ -1672,6 +1712,7 @@ impl fmt::Display for TableSampleMethod {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `SEED` or `REPEATABLE` clause used with sampling.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TableSampleSeed {
     /// Seed modifier (e.g. `REPEATABLE` or `SEED`).
     pub modifier: TableSampleSeedModifier,
@@ -1690,6 +1731,7 @@ impl fmt::Display for TableSampleSeed {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Modifier specifying how the sample seed is applied.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableSampleSeedModifier {
     /// `REPEATABLE` modifier.
     Repeatable,
@@ -1710,6 +1752,7 @@ impl fmt::Display for TableSampleSeedModifier {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Unit used with a `TABLESAMPLE` quantity (rows or percent).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableSampleUnit {
     /// `ROWS` unit.
     Rows,
@@ -1730,6 +1773,7 @@ impl fmt::Display for TableSampleUnit {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Bucket-based sampling clause: `BUCKET <bucket> OUT OF <total> [ON <expr>]`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TableSampleBucket {
     /// The bucket index expression.
     pub bucket: Value,
@@ -1774,6 +1818,7 @@ impl fmt::Display for TableSample {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PivotValueSource {
     /// Pivot on a static list of values.
     ///
@@ -1812,6 +1857,7 @@ impl fmt::Display for PivotValueSource {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// An item in the `MEASURES` clause of `MATCH_RECOGNIZE`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Measure {
     /// Expression producing the measure value.
     pub expr: Expr,
@@ -1831,6 +1877,7 @@ impl fmt::Display for Measure {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum RowsPerMatch {
     /// `ONE ROW PER MATCH`
     OneRow,
@@ -1859,6 +1906,7 @@ impl fmt::Display for RowsPerMatch {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum AfterMatchSkip {
     /// `PAST LAST ROW`
     PastLastRow,
@@ -1886,6 +1934,7 @@ impl fmt::Display for AfterMatchSkip {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// The mode for handling empty matches in a `MATCH_RECOGNIZE` operation.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum EmptyMatchesMode {
     /// `SHOW EMPTY MATCHES`
     Show,
@@ -1912,6 +1961,7 @@ impl fmt::Display for EmptyMatchesMode {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A symbol defined in a `MATCH_RECOGNIZE` operation.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SymbolDefinition {
     /// The symbol identifier.
     pub symbol: Ident,
@@ -1929,6 +1979,7 @@ impl fmt::Display for SymbolDefinition {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MatchRecognizeSymbol {
     /// A named symbol, e.g. `S1`.
     Named(Ident),
@@ -1954,6 +2005,7 @@ impl fmt::Display for MatchRecognizeSymbol {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum MatchRecognizePattern {
     /// A named symbol such as `S1` or a virtual symbol such as `^`.
     Symbol(MatchRecognizeSymbol),
@@ -1991,6 +2043,7 @@ impl fmt::Display for MatchRecognizePattern {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum RepetitionQuantifier {
     /// `*`
     ZeroOrMore,
@@ -2346,6 +2399,7 @@ impl fmt::Display for TableFactor {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// An alias for a table reference, optionally including an explicit `AS` and column names.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TableAlias {
     /// Tells whether the alias was introduced with an explicit, preceding "AS"
     /// keyword, e.g. `AS name`. Typically, the keyword is preceding the name
@@ -2375,6 +2429,7 @@ impl fmt::Display for TableAlias {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TableAliasColumnDef {
     /// Column name alias
     pub name: Ident,
@@ -2406,6 +2461,7 @@ impl fmt::Display for TableAliasColumnDef {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Specifies a table version selection, e.g. `FOR SYSTEM_TIME AS OF` or `AT(...)`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableVersion {
     /// When the table version is defined using `FOR SYSTEM_TIME AS OF`.
     /// For example: `SELECT * FROM tbl FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)`
@@ -2439,6 +2495,7 @@ impl Display for TableVersion {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A single `JOIN` clause including relation and join operator/options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Join {
     /// The joined table factor (table reference or derived table).
     pub relation: TableFactor,
@@ -2583,6 +2640,7 @@ impl fmt::Display for Join {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// The operator used for joining two tables, e.g. `INNER`, `LEFT`, `CROSS`, `ASOF`, etc.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum JoinOperator {
     /// Generic `JOIN` with an optional constraint.
     Join(JoinConstraint),
@@ -2635,6 +2693,7 @@ pub enum JoinOperator {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Represents how two tables are constrained in a join: `ON`, `USING`, `NATURAL`, or none.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum JoinConstraint {
     /// `ON <expr>` join condition.
     On(Expr),
@@ -2650,6 +2709,7 @@ pub enum JoinConstraint {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// The kind of `ORDER BY` clause: either `ALL` with modifiers or a list of expressions.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OrderByKind {
     /// `GROUP BY ALL`/`ORDER BY ALL` syntax with optional modifiers.
     ///
@@ -2665,6 +2725,7 @@ pub enum OrderByKind {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Represents an `ORDER BY` clause with its kind and optional `INTERPOLATE`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OrderBy {
     /// The kind of ordering (expressions or `ALL`).
     pub kind: OrderByKind,
@@ -2700,6 +2761,7 @@ impl fmt::Display for OrderBy {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OrderByExpr {
     /// The expression to order by.
     pub expr: Expr,
@@ -2737,6 +2799,7 @@ impl fmt::Display for OrderByExpr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `WITH FILL` options for ClickHouse `ORDER BY` expressions.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct WithFill {
     /// Optional lower bound expression for the fill range (`FROM <expr>`).
     pub from: Option<Expr>,
@@ -2770,6 +2833,7 @@ impl fmt::Display for WithFill {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// An expression used by `WITH FILL`/`INTERPOLATE` to specify interpolation for a column.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InterpolateExpr {
     /// The column to interpolate.
     pub column: Ident,
@@ -2781,6 +2845,7 @@ pub struct InterpolateExpr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `INTERPOLATE` clause used with ClickHouse `WITH FILL` to compute missing values.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Interpolate {
     /// Optional list of interpolation expressions.
     pub exprs: Option<Vec<InterpolateExpr>>,
@@ -2800,6 +2865,7 @@ impl fmt::Display for InterpolateExpr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Options for an `ORDER BY` expression (ASC/DESC and NULLS FIRST/LAST).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OrderByOptions {
     /// Optional `ASC` (`Some(true)`) or `DESC` (`Some(false)`).
     pub asc: Option<bool>,
@@ -2827,6 +2893,7 @@ impl fmt::Display for OrderByOptions {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Represents the different syntactic forms of `LIMIT` clauses.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum LimitClause {
     /// Standard SQL `LIMIT` syntax (optionally `BY` and `OFFSET`).
     ///
@@ -2879,6 +2946,7 @@ impl fmt::Display for LimitClause {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `OFFSET` clause consisting of a value and a rows specifier.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Offset {
     /// The numeric expression following `OFFSET`.
     pub value: Expr,
@@ -2896,6 +2964,7 @@ impl fmt::Display for Offset {
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum OffsetRows {
     /// Omitting `ROW`/`ROWS` entirely (non-standard MySQL quirk).
     None,
@@ -2929,6 +2998,7 @@ impl fmt::Display for OffsetRows {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PipeOperator {
     /// Limits the number of rows to return in a query, with an optional OFFSET clause to skip over rows.
     ///
@@ -3259,6 +3329,7 @@ impl PipeOperator {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `FETCH` clause options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Fetch {
     /// `WITH TIES` option is present.
     pub with_ties: bool,
@@ -3284,6 +3355,7 @@ impl fmt::Display for Fetch {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `FOR ...` locking clause.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct LockClause {
     /// The kind of lock requested (e.g. `SHARE`, `UPDATE`).
     pub lock_type: LockType,
@@ -3310,6 +3382,7 @@ impl fmt::Display for LockClause {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// The lock type used in `FOR <lock>` clauses (e.g. `FOR SHARE`, `FOR UPDATE`).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum LockType {
     /// `SHARE` lock (shared lock).
     Share,
@@ -3331,6 +3404,7 @@ impl fmt::Display for LockType {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Non-blocking lock options for `FOR ...` clauses.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum NonBlock {
     /// `NOWAIT` — do not wait for the lock.
     Nowait,
@@ -3352,6 +3426,7 @@ impl fmt::Display for NonBlock {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `DISTINCT` or `DISTINCT ON (...)` modifiers for `SELECT` lists.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Distinct {
     /// `DISTINCT` (remove duplicate rows)
     Distinct,
@@ -3376,6 +3451,7 @@ impl fmt::Display for Distinct {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// MSSQL `TOP` clause options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Top {
     /// SQL semantic equivalent of LIMIT but with same structure as FETCH.
     /// MSSQL only.
@@ -3390,6 +3466,7 @@ pub struct Top {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Quantity used in a `TOP` clause: either an expression or a constant.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TopQuantity {
     /// A parenthesized expression (MSSQL syntax: `TOP (expr)`).
     Expr(Expr),
@@ -3418,6 +3495,7 @@ impl fmt::Display for Top {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// An explicit `VALUES` clause and its rows.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Values {
     /// Was there an explicit `ROW` keyword (MySQL)?
     /// <https://dev.mysql.com/doc/refman/8.0/en/values.html>
@@ -3451,6 +3529,7 @@ impl fmt::Display for Values {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// `SELECT INTO` clause options.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SelectInto {
     /// `TEMPORARY` modifier.
     pub temporary: bool,
@@ -3480,6 +3559,7 @@ impl fmt::Display for SelectInto {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Modifiers used with `GROUP BY` such as `WITH ROLLUP` or `WITH CUBE`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GroupByWithModifier {
     /// `WITH ROLLUP` modifier.
     Rollup,
@@ -3511,6 +3591,7 @@ impl fmt::Display for GroupByWithModifier {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Represents the two syntactic forms that `GROUP BY` can take, including
 /// `GROUP BY ALL` with optional modifiers and ordinary `GROUP BY <exprs>`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GroupByExpr {
     /// ALL syntax of [Snowflake], [DuckDB] and [ClickHouse].
     ///
@@ -3555,6 +3636,7 @@ impl fmt::Display for GroupByExpr {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FormatClause {
     /// The format identifier.
     Identifier(Ident),
@@ -3577,6 +3659,7 @@ impl fmt::Display for FormatClause {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InputFormatClause {
     /// The format identifier.
     pub ident: Ident,
@@ -3600,6 +3683,7 @@ impl fmt::Display for InputFormatClause {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ForClause {
     /// `FOR BROWSE` clause.
     Browse,
@@ -3683,6 +3767,7 @@ impl fmt::Display for ForClause {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Modes for `FOR XML` clause.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ForXml {
     /// `RAW` mode with optional root name: `RAW('root')`.
     Raw(Option<String>),
@@ -3721,6 +3806,7 @@ impl fmt::Display for ForXml {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Modes for `FOR JSON` clause.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ForJson {
     /// `AUTO` mode.
     Auto,
@@ -3760,6 +3846,7 @@ impl fmt::Display for ForJson {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum JsonTableColumn {
     /// A named column with a JSON path
     Named(JsonTableNamedColumn),
@@ -3790,6 +3877,7 @@ impl fmt::Display for JsonTableColumn {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// A nested column in a `JSON_TABLE` column list.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct JsonTableNestedColumn {
     /// JSON path expression (must be a literal `Value`).
     pub path: Value,
@@ -3818,6 +3906,7 @@ impl fmt::Display for JsonTableNestedColumn {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct JsonTableNamedColumn {
     /// The name of the column to be extracted.
     pub name: Ident,
@@ -3859,6 +3948,7 @@ impl fmt::Display for JsonTableNamedColumn {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Error/empty-value handling for `JSON_TABLE` columns.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum JsonTableColumnErrorHandling {
     /// `NULL` — return NULL when the path does not match.
     Null,
@@ -3890,6 +3980,7 @@ impl fmt::Display for JsonTableColumnErrorHandling {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct OpenJsonTableColumn {
     /// The name of the column to be extracted.
     pub name: Ident,
@@ -3924,6 +4015,7 @@ impl fmt::Display for OpenJsonTableColumn {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Mode of BigQuery value tables, e.g. `AS STRUCT` or `AS VALUE`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ValueTableMode {
     /// `AS STRUCT`
     AsStruct,
@@ -3950,6 +4042,7 @@ impl fmt::Display for ValueTableMode {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UpdateTableFromKind {
     /// Update Statement where the 'FROM' clause is before the 'SET' keyword (Supported by Snowflake)
     /// For Example: `UPDATE FROM t1 SET t1.name='aaa'`
@@ -3963,6 +4056,7 @@ pub enum UpdateTableFromKind {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum XmlTableColumnOption {
     /// A named column with a type, optional path, and default value.
     NamedInfo {
@@ -3994,6 +4088,7 @@ pub enum XmlTableColumnOption {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct XmlTableColumn {
     /// The name of the column.
     pub name: Ident,
@@ -4035,6 +4130,7 @@ impl fmt::Display for XmlTableColumn {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Argument passed in the `XMLTABLE PASSING` clause.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct XmlPassingArgument {
     /// Expression to pass to the XML table.
     pub expr: Expr,
@@ -4062,6 +4158,7 @@ impl fmt::Display for XmlPassingArgument {
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// The PASSING clause for `XMLTABLE`.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct XmlPassingClause {
     /// The list of passed arguments.
     pub arguments: Vec<XmlPassingArgument>,
@@ -4082,6 +4179,7 @@ impl fmt::Display for XmlPassingClause {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct XmlNamespaceDefinition {
     /// The namespace URI (a text expression).
     pub uri: Expr,

--- a/src/ast/table_constraints.rs
+++ b/src/ast/table_constraints.rs
@@ -39,6 +39,7 @@ use sqlparser_derive::{Visit, VisitMut};
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TableConstraint {
     /// MySQL [definition][1] for `UNIQUE` constraints statements:\
     /// * `[CONSTRAINT [<name>]] UNIQUE <index_type_display> [<index_name>] [index_type] (<columns>) <index_options>`
@@ -156,6 +157,7 @@ impl fmt::Display for TableConstraint {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// A `CHECK` constraint (`[ CONSTRAINT <name> ] CHECK (<expr>) [[NOT] ENFORCED]`).
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct CheckConstraint {
     /// Optional constraint name.
     pub name: Option<Ident>,
@@ -199,6 +201,7 @@ impl crate::ast::Spanned for CheckConstraint {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ForeignKeyConstraint {
     /// Optional constraint name.
     pub name: Option<Ident>,
@@ -288,6 +291,7 @@ impl crate::ast::Spanned for ForeignKeyConstraint {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct FullTextOrSpatialConstraint {
     /// Whether this is a `FULLTEXT` (true) or `SPATIAL` (false) definition.
     pub fulltext: bool,
@@ -343,6 +347,7 @@ impl crate::ast::Spanned for FullTextOrSpatialConstraint {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct IndexConstraint {
     /// Whether this index starts with KEY (true) or INDEX (false), to maintain the same syntax.
     pub display_as_key: bool,
@@ -412,6 +417,7 @@ impl crate::ast::Spanned for IndexConstraint {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PrimaryKeyConstraint {
     /// Constraint name.
     ///
@@ -473,6 +479,7 @@ impl crate::ast::Spanned for PrimaryKeyConstraint {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// Unique constraint definition.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct UniqueConstraint {
     /// Constraint name.
     ///

--- a/src/ast/trigger.rs
+++ b/src/ast/trigger.rs
@@ -22,6 +22,7 @@ use super::*;
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TriggerObject {
     /// The trigger fires once for each row affected by the triggering event
     Row,
@@ -42,6 +43,7 @@ impl fmt::Display for TriggerObject {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
 /// This clause indicates whether the following relation name is for the before-image transition relation or the after-image transition relation
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TriggerReferencingType {
     /// The transition relation containing the old rows affected by the triggering statement
     OldTable,
@@ -62,6 +64,7 @@ impl fmt::Display for TriggerReferencingType {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TriggerReferencing {
     /// The referencing type (`OLD TABLE` or `NEW TABLE`).
     pub refer_type: TriggerReferencingType,
@@ -87,6 +90,7 @@ impl fmt::Display for TriggerReferencing {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TriggerEvent {
     /// Trigger on INSERT event
     Insert,
@@ -120,6 +124,7 @@ impl fmt::Display for TriggerEvent {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TriggerPeriod {
     /// The trigger fires once for each row affected by the triggering event
     For,
@@ -146,6 +151,7 @@ impl fmt::Display for TriggerPeriod {
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TriggerExecBodyType {
     /// Execute a function
     Function,
@@ -165,6 +171,7 @@ impl fmt::Display for TriggerExecBodyType {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TriggerExecBody {
     /// Whether the body is a `FUNCTION` or `PROCEDURE` invocation.
     pub exec_type: TriggerExecBodyType,

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -68,6 +68,7 @@ use sqlparser_derive::{Visit, VisitMut};
 #[derive(Debug, Clone, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ValueWithSpan {
     /// The wrapped `Value`.
     pub value: Value,
@@ -119,6 +120,7 @@ impl From<ValueWithSpan> for Value {
     derive(Visit, VisitMut),
     visit(with = "visit_value")
 )]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Value {
     /// Numeric literal
     #[cfg(not(feature = "bigdecimal"))]
@@ -279,6 +281,7 @@ impl fmt::Display for Value {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DollarQuotedString {
     /// Inner string contents.
     pub value: String,
@@ -306,6 +309,7 @@ impl fmt::Display for DollarQuotedString {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct QuoteDelimitedString {
     /// the quote start character; i.e. the character _after_ the opening `Q'`
     pub start_quote: char,
@@ -329,6 +333,7 @@ impl fmt::Display for QuoteDelimitedString {
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DateTimeField {
     /// `YEAR`
     Year,
@@ -491,6 +496,7 @@ impl fmt::Display for DateTimeField {
 /// certain distinctions between visually or functionally identical characters.
 ///
 /// See [Unicode Normalization Forms](https://unicode.org/reports/tr15/) for details.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum NormalizationForm {
     /// Canonical Decomposition, followed by Canonical Composition.
     NFC,
@@ -513,6 +519,7 @@ impl fmt::Display for NormalizationForm {
     }
 }
 
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct EscapeQuotedString<'a> {
     string: &'a str,
     quote: char,
@@ -592,6 +599,7 @@ pub fn escape_double_quote_string(s: &str) -> EscapeQuotedString<'_> {
     escape_quoted_string(s, '\"')
 }
 
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct EscapeEscapedStringLiteral<'a>(&'a str);
 
 impl fmt::Display for EscapeEscapedStringLiteral<'_> {
@@ -628,6 +636,7 @@ pub fn escape_escaped_string(s: &str) -> EscapeEscapedStringLiteral<'_> {
     EscapeEscapedStringLiteral(s)
 }
 
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct EscapeUnicodeStringLiteral<'a>(&'a str);
 
 impl fmt::Display for EscapeUnicodeStringLiteral<'_> {
@@ -671,6 +680,7 @@ pub fn escape_unicode_string(s: &str) -> EscapeUnicodeStringLiteral<'_> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TrimWhereField {
     /// `BOTH` (trim from both ends)
     Both,

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -54,6 +54,7 @@ macro_rules! define_keywords {
         #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
         #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
         #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
         #[allow(non_camel_case_types)]
         /// An enumeration of SQL keywords recognized by the parser.
         pub enum Keyword {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -55,6 +55,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Token {
     /// An end-of-file marker, not a real token
     EOF,
@@ -437,6 +438,7 @@ impl Token {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Word {
     /// The value of the token, without the enclosing quotes, and with the
     /// escape sequences (if any) processed (TODO: escapes are not handled)
@@ -477,6 +479,7 @@ impl Word {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Whitespace {
     /// A single space character.
     Space,
@@ -531,6 +534,7 @@ impl fmt::Display for Whitespace {
 #[derive(Eq, PartialEq, Hash, Clone, Copy, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Location {
     /// Line number, starting from 1.
     ///
@@ -594,6 +598,7 @@ impl From<(u64, u64)> for Location {
 #[derive(Eq, PartialEq, Hash, Clone, PartialOrd, Ord, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Span {
     /// Start `Location` (inclusive).
     pub start: Location,
@@ -719,6 +724,7 @@ pub type TokenWithLocation = TokenWithSpan;
 #[derive(Debug, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// A `Token` together with its `Span` (location in the source).
 pub struct TokenWithSpan {
     /// The token value.


### PR DESCRIPTION
Adds `Arbitrary` derives to all AST structs and enums for property-based testing and fuzzing.

## Changes

- Added `arbitrary` as optional dependency with feature gating
- Derived `Arbitrary` on all public AST types in ast
- Added `Arbitrary` to core types (`Token`, `Span`, `Location`, etc.)
- Excluded display helpers and iterators

**Note**: `BigDecimal` (used in `Value::Number`) lacks `Arbitrary` support. PR submitted: https://github.com/akubera/bigdecimal-rs/pull/163