### PR TITLE
Add support for INTERVAL keyword as unquoted identifier in PostgreSQL

### DIFF
--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -33,6 +33,8 @@ use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
 use crate::tokenizer::Token;
 
+use super::keywords::RESERVED_FOR_IDENTIFIER;
+
 /// A [`Dialect`] for [PostgreSQL](https://www.postgresql.org/)
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -79,6 +81,14 @@ impl Dialect for PostgreSqlDialect {
 
     fn supports_unicode_string_literal(&self) -> bool {
         true
+    }
+
+    fn is_reserved_for_identifier(&self, kw: Keyword) -> bool {
+        if matches!(kw, Keyword::INTERVAL) {
+            false
+        } else {
+            RESERVED_FOR_IDENTIFIER.contains(&kw)
+        }
     }
 
     /// See <https://www.postgresql.org/docs/current/sql-createoperator.html>

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5778,6 +5778,12 @@ fn parse_interval_data_type() {
 }
 
 #[test]
+fn parse_interval_keyword_as_unquoted_identifier() {
+    pg().verified_stmt("SELECT MAX(interval) FROM tbl");
+    pg().verified_expr("INTERVAL '1 day'");
+}
+
+#[test]
 fn parse_create_table_with_options() {
     let sql = "CREATE TABLE t (c INT) WITH (foo = 'bar', a = 123)";
     match pg().verified_stmt(sql) {


### PR DESCRIPTION
This PR fixes a PostgreSQL dialect parsing bug where `INTERVAL` was always treated as a reserved identifier keyword, causing valid queries such as:

```sql
SELECT MAX(interval) FROM tbl
```

to fail with `Expected: an expression, found: )`.

## Problem

In PostgreSQL, interval can be used as an unquoted identifier in unambiguous expression positions (for example function arguments). Our parser attempted INTERVAL-literal parsing first, and on failure it only fell back to identifier parsing when the keyword is not reserved. Because INTERVAL was reserved for `PostgreSqlDialect`, fallback was blocked.

## Fix

- Added a PostgreSQL-specific override of `is_reserved_for_identifier` so `Keyword::INTERVAL` is not treated as reserved in this dialect.
- Kept default reserved behavior for all other keywords unchanged.

## Tests

Added regression test in PostgreSQL-specific suite:

- `SELECT MAX(interval) FROM tbl` now parses successfully in PostgreSqlDialect.
- `INTERVAL '1 day'` still parses as an interval expression (guarding against regressions).

## Impact

- Improves compatibility with real-world PostgreSQL schemas where columns/args may be named interval.
- No public API changes.
- No cross-dialect behavior changes intended beyond PostgreSQL’s INTERVAL identifier handling.