### PR TITLE
Support parenthesized `CREATE TABLE ... (LIKE ... INCLUDING/EXCLUDING DEFAULTS)` in `PostgreSQL`

### DIFF
--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -292,4 +292,8 @@ impl Dialect for PostgreSqlDialect {
     fn supports_insert_table_alias(&self) -> bool {
         true
     }
+
+    fn supports_create_table_like_parenthesized(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
This PR fixes PostgreSQL parsing for:

- `CREATE TABLE new (LIKE old INCLUDING DEFAULTS)`
- `CREATE TABLE new (LIKE old EXCLUDING DEFAULTS)`

These are valid PostgreSQL forms, but were previously rejected.

The parser already supports `INCLUDING/EXCLUDING DEFAULTS` in maybe_parse_create_table_like, but that code path is gated by `Dialect::supports_create_table_like_parenthesized()`. `PostgreSqlDialect` did not enable that capability.