### PR TITLE
PostgreSQL `UNLOGGED` Table Support and `ALTER TABLE ... SET LOGGED|UNLOGGED`

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -442,6 +442,14 @@ pub enum AlterTableOperation {
         /// Table properties specified as SQL options.
         table_properties: Vec<SqlOption>,
     },
+    /// `SET LOGGED`
+    ///
+    /// Note: this is PostgreSQL-specific.
+    SetLogged,
+    /// `SET UNLOGGED`
+    ///
+    /// Note: this is PostgreSQL-specific.
+    SetUnlogged,
     /// `OWNER TO { <new_owner> | CURRENT_ROLE | CURRENT_USER | SESSION_USER }`
     ///
     /// Note: this is PostgreSQL-specific <https://www.postgresql.org/docs/current/sql-altertable.html>
@@ -970,6 +978,12 @@ impl fmt::Display for AlterTableOperation {
                     "SET TBLPROPERTIES({})",
                     display_comma_separated(table_properties)
                 )
+            }
+            AlterTableOperation::SetLogged => {
+                write!(f, "SET LOGGED")
+            }
+            AlterTableOperation::SetUnlogged => {
+                write!(f, "SET UNLOGGED")
             }
             AlterTableOperation::FreezePartition {
                 partition,
@@ -2903,6 +2917,8 @@ pub struct CreateTable {
     pub or_replace: bool,
     /// `TEMP` or `TEMPORARY` clause
     pub temporary: bool,
+    /// `UNLOGGED` clause
+    pub unlogged: bool,
     /// `EXTERNAL` clause
     pub external: bool,
     /// `DYNAMIC` clause
@@ -3094,7 +3110,7 @@ impl fmt::Display for CreateTable {
         //   `CREATE TABLE t (a INT) AS SELECT a from t2`
         write!(
             f,
-            "CREATE {or_replace}{external}{global}{multiset}{temporary}{transient}{volatile}{dynamic}{iceberg}{snapshot}TABLE {if_not_exists}{name}",
+            "CREATE {or_replace}{external}{global}{multiset}{temporary}{unlogged}{transient}{volatile}{dynamic}{iceberg}{snapshot}TABLE {if_not_exists}{name}",
             or_replace = if self.or_replace { "OR REPLACE " } else { "" },
             external = if self.external { "EXTERNAL " } else { "" },
             snapshot = if self.snapshot { "SNAPSHOT " } else { "" },
@@ -3113,6 +3129,7 @@ impl fmt::Display for CreateTable {
                 .map(|m| if m { "MULTISET " } else { "SET " })
                 .unwrap_or(""),
             temporary = if self.temporary { "TEMPORARY " } else { "" },
+            unlogged = if self.unlogged { "UNLOGGED " } else { "" },
             transient = if self.transient { "TRANSIENT " } else { "" },
             volatile = if self.volatile { "VOLATILE " } else { "" },
             iceberg = if self.iceberg { "ICEBERG " } else { "" },

--- a/src/ast/helpers/stmt_create_table.rs
+++ b/src/ast/helpers/stmt_create_table.rs
@@ -69,6 +69,8 @@ pub struct CreateTableBuilder {
     pub or_replace: bool,
     /// Whether the table is `TEMPORARY`.
     pub temporary: bool,
+    /// Whether the table is `UNLOGGED`.
+    pub unlogged: bool,
     /// Whether the table is `EXTERNAL`.
     pub external: bool,
     /// Optional `GLOBAL` flag for dialects that support it.
@@ -200,6 +202,7 @@ impl CreateTableBuilder {
         Self {
             or_replace: false,
             temporary: false,
+            unlogged: false,
             external: false,
             global: None,
             if_not_exists: false,
@@ -271,6 +274,11 @@ impl CreateTableBuilder {
     /// Mark the table as `TEMPORARY`.
     pub fn temporary(mut self, temporary: bool) -> Self {
         self.temporary = temporary;
+        self
+    }
+    /// Mark the table as `UNLOGGED`.
+    pub fn unlogged(mut self, unlogged: bool) -> Self {
+        self.unlogged = unlogged;
         self
     }
     /// Mark the table as `EXTERNAL`.
@@ -595,6 +603,7 @@ impl CreateTableBuilder {
         CreateTable {
             or_replace: self.or_replace,
             temporary: self.temporary,
+            unlogged: self.unlogged,
             external: self.external,
             global: self.global,
             if_not_exists: self.if_not_exists,
@@ -680,6 +689,7 @@ impl From<CreateTable> for CreateTableBuilder {
         Self {
             or_replace: table.or_replace,
             temporary: table.temporary,
+            unlogged: table.unlogged,
             external: table.external,
             global: table.global,
             if_not_exists: table.if_not_exists,

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -551,6 +551,7 @@ impl Spanned for CreateTable {
         let CreateTable {
             or_replace: _,    // bool
             temporary: _,     // bool
+            unlogged: _,      // bool
             external: _,      // bool
             global: _,        // bool
             dynamic: _,       // bool
@@ -1228,6 +1229,8 @@ impl Spanned for AlterTableOperation {
             AlterTableOperation::SetTblProperties { table_properties } => {
                 union_spans(table_properties.iter().map(|i| i.span()))
             }
+            AlterTableOperation::SetLogged => Span::empty(),
+            AlterTableOperation::SetUnlogged => Span::empty(),
             AlterTableOperation::OwnerTo { .. } => Span::empty(),
             AlterTableOperation::ClusterBy { exprs } => union_spans(exprs.iter().map(|e| e.span())),
             AlterTableOperation::DropClusteringKey => Span::empty(),

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -601,6 +601,7 @@ define_keywords!(
     LOCK,
     LOCKED,
     LOG,
+    LOGGED,
     LOGIN,
     LOGS,
     LONG,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5231,6 +5231,10 @@ impl<'a> Parser<'a> {
             .parse_one_of_keywords(&[Keyword::TEMP, Keyword::TEMPORARY])
             .is_some();
         let volatile = self.parse_keyword(Keyword::VOLATILE);
+        let unlogged = self.peek_keywords(&[Keyword::UNLOGGED, Keyword::TABLE]);
+        if unlogged {
+            self.expect_keyword(Keyword::UNLOGGED)?;
+        }
         let persistent = dialect_of!(self is DuckDbDialect)
             && self.parse_one_of_keywords(&[Keyword::PERSISTENT]).is_some();
         let create_view_params = self.parse_create_view_params()?;
@@ -5238,15 +5242,11 @@ impl<'a> Parser<'a> {
             self.parse_create_snapshot_table().map(Into::into)
         } else if self.peek_keywords(&[Keyword::TEXT, Keyword::SEARCH]) {
             self.parse_create_text_search().map(Into::into)
-        } else if self.peek_keywords(&[Keyword::UNLOGGED, Keyword::TABLE]) {
-            self.expect_keywords(&[Keyword::UNLOGGED, Keyword::TABLE])?;
-            let mut create_table = self
-                .parse_create_table(or_replace, temporary, global, transient, volatile, multiset)?;
-            create_table.unlogged = true;
-            Ok(create_table.into())
         } else if self.parse_keyword(Keyword::TABLE) {
-            self.parse_create_table(or_replace, temporary, global, transient, volatile, multiset)
-                .map(Into::into)
+            self.parse_create_table(
+                or_replace, temporary, unlogged, global, transient, volatile, multiset,
+            )
+            .map(Into::into)
         } else if self.peek_keyword(Keyword::MATERIALIZED)
             || self.peek_keyword(Keyword::VIEW)
             || self.peek_keywords(&[Keyword::SECURE, Keyword::MATERIALIZED, Keyword::VIEW])
@@ -8655,10 +8655,12 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse `CREATE TABLE` statement.
+    #[allow(clippy::too_many_arguments)]
     pub fn parse_create_table(
         &mut self,
         or_replace: bool,
         temporary: bool,
+        unlogged: bool,
         global: Option<bool>,
         transient: bool,
         volatile: bool,
@@ -8840,7 +8842,7 @@ impl<'a> Parser<'a> {
 
         Ok(CreateTableBuilder::new(table_name)
             .temporary(temporary)
-            .unlogged(false)
+            .unlogged(unlogged)
             .columns(columns)
             .constraints(constraints)
             .or_replace(or_replace)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5231,8 +5231,6 @@ impl<'a> Parser<'a> {
             .parse_one_of_keywords(&[Keyword::TEMP, Keyword::TEMPORARY])
             .is_some();
         let volatile = self.parse_keyword(Keyword::VOLATILE);
-        let unlogged = dialect_of!(self is PostgreSqlDialect | GenericDialect)
-            && self.parse_keyword(Keyword::UNLOGGED);
         let persistent = dialect_of!(self is DuckDbDialect)
             && self.parse_one_of_keywords(&[Keyword::PERSISTENT]).is_some();
         let create_view_params = self.parse_create_view_params()?;
@@ -5240,13 +5238,17 @@ impl<'a> Parser<'a> {
             self.parse_create_snapshot_table().map(Into::into)
         } else if self.peek_keywords(&[Keyword::TEXT, Keyword::SEARCH]) {
             self.parse_create_text_search().map(Into::into)
+        } else if self.peek_keywords(&[Keyword::UNLOGGED, Keyword::TABLE]) {
+            self.expect_keywords(&[Keyword::UNLOGGED, Keyword::TABLE])?;
+            self.parse_create_table(
+                or_replace, temporary, true, global, transient, volatile, multiset,
+            )
+            .map(Into::into)
         } else if self.parse_keyword(Keyword::TABLE) {
             self.parse_create_table(
-                or_replace, temporary, unlogged, global, transient, volatile, multiset,
+                or_replace, temporary, false, global, transient, volatile, multiset,
             )
-                .map(Into::into)
-        } else if unlogged {
-            self.expected_ref("TABLE after UNLOGGED", self.peek_token_ref())
+            .map(Into::into)
         } else if self.peek_keyword(Keyword::MATERIALIZED)
             || self.peek_keyword(Keyword::VIEW)
             || self.peek_keywords(&[Keyword::SECURE, Keyword::MATERIALIZED, Keyword::VIEW])
@@ -11032,13 +11034,9 @@ impl<'a> Parser<'a> {
         } else if self.parse_keywords(&[Keyword::VALIDATE, Keyword::CONSTRAINT]) {
             let name = self.parse_identifier()?;
             AlterTableOperation::ValidateConstraint { name }
-        } else if dialect_of!(self is PostgreSqlDialect | GenericDialect)
-            && self.parse_keywords(&[Keyword::SET, Keyword::LOGGED])
-        {
+        } else if self.parse_keywords(&[Keyword::SET, Keyword::LOGGED]) {
             AlterTableOperation::SetLogged
-        } else if dialect_of!(self is PostgreSqlDialect | GenericDialect)
-            && self.parse_keywords(&[Keyword::SET, Keyword::UNLOGGED])
-        {
+        } else if self.parse_keywords(&[Keyword::SET, Keyword::UNLOGGED]) {
             AlterTableOperation::SetUnlogged
         } else {
             let mut options =

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5240,15 +5240,13 @@ impl<'a> Parser<'a> {
             self.parse_create_text_search().map(Into::into)
         } else if self.peek_keywords(&[Keyword::UNLOGGED, Keyword::TABLE]) {
             self.expect_keywords(&[Keyword::UNLOGGED, Keyword::TABLE])?;
-            self.parse_create_table(
-                or_replace, temporary, true, global, transient, volatile, multiset,
-            )
-            .map(Into::into)
+            let mut create_table = self
+                .parse_create_table(or_replace, temporary, global, transient, volatile, multiset)?;
+            create_table.unlogged = true;
+            Ok(create_table.into())
         } else if self.parse_keyword(Keyword::TABLE) {
-            self.parse_create_table(
-                or_replace, temporary, false, global, transient, volatile, multiset,
-            )
-            .map(Into::into)
+            self.parse_create_table(or_replace, temporary, global, transient, volatile, multiset)
+                .map(Into::into)
         } else if self.peek_keyword(Keyword::MATERIALIZED)
             || self.peek_keyword(Keyword::VIEW)
             || self.peek_keywords(&[Keyword::SECURE, Keyword::MATERIALIZED, Keyword::VIEW])
@@ -8661,7 +8659,6 @@ impl<'a> Parser<'a> {
         &mut self,
         or_replace: bool,
         temporary: bool,
-        unlogged: bool,
         global: Option<bool>,
         transient: bool,
         volatile: bool,
@@ -8843,7 +8840,7 @@ impl<'a> Parser<'a> {
 
         Ok(CreateTableBuilder::new(table_name)
             .temporary(temporary)
-            .unlogged(unlogged)
+            .unlogged(false)
             .columns(columns)
             .constraints(constraints)
             .or_replace(or_replace)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5231,6 +5231,8 @@ impl<'a> Parser<'a> {
             .parse_one_of_keywords(&[Keyword::TEMP, Keyword::TEMPORARY])
             .is_some();
         let volatile = self.parse_keyword(Keyword::VOLATILE);
+        let unlogged = dialect_of!(self is PostgreSqlDialect | GenericDialect)
+            && self.parse_keyword(Keyword::UNLOGGED);
         let persistent = dialect_of!(self is DuckDbDialect)
             && self.parse_one_of_keywords(&[Keyword::PERSISTENT]).is_some();
         let create_view_params = self.parse_create_view_params()?;
@@ -5239,8 +5241,12 @@ impl<'a> Parser<'a> {
         } else if self.peek_keywords(&[Keyword::TEXT, Keyword::SEARCH]) {
             self.parse_create_text_search().map(Into::into)
         } else if self.parse_keyword(Keyword::TABLE) {
-            self.parse_create_table(or_replace, temporary, global, transient, volatile, multiset)
+            self.parse_create_table(
+                or_replace, temporary, unlogged, global, transient, volatile, multiset,
+            )
                 .map(Into::into)
+        } else if unlogged {
+            self.expected_ref("TABLE after UNLOGGED", self.peek_token_ref())
         } else if self.peek_keyword(Keyword::MATERIALIZED)
             || self.peek_keyword(Keyword::VIEW)
             || self.peek_keywords(&[Keyword::SECURE, Keyword::MATERIALIZED, Keyword::VIEW])
@@ -8653,6 +8659,7 @@ impl<'a> Parser<'a> {
         &mut self,
         or_replace: bool,
         temporary: bool,
+        unlogged: bool,
         global: Option<bool>,
         transient: bool,
         volatile: bool,
@@ -8834,6 +8841,7 @@ impl<'a> Parser<'a> {
 
         Ok(CreateTableBuilder::new(table_name)
             .temporary(temporary)
+            .unlogged(unlogged)
             .columns(columns)
             .constraints(constraints)
             .or_replace(or_replace)
@@ -11024,6 +11032,14 @@ impl<'a> Parser<'a> {
         } else if self.parse_keywords(&[Keyword::VALIDATE, Keyword::CONSTRAINT]) {
             let name = self.parse_identifier()?;
             AlterTableOperation::ValidateConstraint { name }
+        } else if dialect_of!(self is PostgreSqlDialect | GenericDialect)
+            && self.parse_keywords(&[Keyword::SET, Keyword::LOGGED])
+        {
+            AlterTableOperation::SetLogged
+        } else if dialect_of!(self is PostgreSqlDialect | GenericDialect)
+            && self.parse_keywords(&[Keyword::SET, Keyword::UNLOGGED])
+        {
+            AlterTableOperation::SetUnlogged
         } else {
             let mut options =
                 self.parse_options_with_keywords(&[Keyword::SET, Keyword::TBLPROPERTIES])?;

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -19515,3 +19515,27 @@ fn parse_table_factor_paren_chain_no_exponential_blowup() {
     rx.recv_timeout(Duration::from_secs(5))
         .expect("parser should reject this quickly, not loop exponentially");
 }
+
+#[test]
+fn parse_unlogged_table_logging_controls_in_all_dialects() {
+    match all_dialects().verified_stmt("CREATE UNLOGGED TABLE t (a INT)") {
+        Statement::CreateTable(CreateTable { unlogged, .. }) => {
+            assert!(unlogged);
+        }
+        _ => unreachable!("Expected CREATE TABLE"),
+    }
+
+    match all_dialects().verified_stmt("ALTER TABLE t SET LOGGED") {
+        Statement::AlterTable(AlterTable { operations, .. }) => {
+            assert_eq!(vec![AlterTableOperation::SetLogged], operations);
+        }
+        _ => unreachable!("Expected ALTER TABLE"),
+    }
+
+    match all_dialects().verified_stmt("ALTER TABLE t SET UNLOGGED") {
+        Statement::AlterTable(AlterTable { operations, .. }) => {
+            assert_eq!(vec![AlterTableOperation::SetUnlogged], operations);
+        }
+        _ => unreachable!("Expected ALTER TABLE"),
+    }
+}

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -703,6 +703,7 @@ fn test_duckdb_union_datatype() {
         Statement::CreateTable(CreateTable {
             or_replace: Default::default(),
             temporary: Default::default(),
+            unlogged: Default::default(),
             external: Default::default(),
             global: Default::default(),
             if_not_exists: Default::default(),

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1924,6 +1924,7 @@ fn parse_create_table_with_valid_options() {
             Statement::CreateTable(CreateTable {
                 or_replace: false,
                 temporary: false,
+                unlogged: false,
                 external: false,
                 global: None,
                 dynamic: false,
@@ -2121,6 +2122,7 @@ fn parse_create_table_with_identity_column() {
             Statement::CreateTable(CreateTable {
                 or_replace: false,
                 temporary: false,
+                unlogged: false,
                 external: false,
                 global: None,
                 dynamic: false,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5944,11 +5944,10 @@ fn parse_create_unlogged_table() {
         _ => unreachable!(),
     }
 
-    // Negative test: UNLOGGED without TABLE should error
     let res = pg().parse_sql_statements("CREATE UNLOGGED VIEW v AS SELECT 1");
-    assert!(
-        res.is_err(),
-        "CREATE UNLOGGED should only be followed by TABLE"
+    assert_eq!(
+        ParserError::ParserError("Expected: an object type after CREATE, found: UNLOGGED".into()),
+        res.unwrap_err()
     );
 }
 

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -1279,6 +1279,33 @@ fn parse_alter_table_owner_to() {
 }
 
 #[test]
+fn parse_alter_table_set_logged_unlogged() {
+    let sql = "ALTER TABLE unlogged1 SET LOGGED";
+    match pg_and_generic().verified_stmt(sql) {
+        Statement::AlterTable(AlterTable {
+            name, operations, ..
+        }) => {
+            assert_eq!("unlogged1", name.to_string());
+            assert_eq!(vec![AlterTableOperation::SetLogged], operations);
+        }
+        _ => unreachable!(),
+    }
+    pg_and_generic().one_statement_parses_to(sql, sql);
+
+    let sql = "ALTER TABLE unlogged1 SET UNLOGGED";
+    match pg_and_generic().verified_stmt(sql) {
+        Statement::AlterTable(AlterTable {
+            name, operations, ..
+        }) => {
+            assert_eq!("unlogged1", name.to_string());
+            assert_eq!(vec![AlterTableOperation::SetUnlogged], operations);
+        }
+        _ => unreachable!(),
+    }
+    pg_and_generic().one_statement_parses_to(sql, sql);
+}
+
+#[test]
 fn parse_create_table_if_not_exists() {
     let sql = "CREATE TABLE IF NOT EXISTS uk_cities ()";
     let ast = pg_and_generic().verified_stmt(sql);
@@ -5874,6 +5901,51 @@ fn parse_create_table_with_partition_by() {
 }
 
 #[test]
+fn parse_create_unlogged_table() {
+    let sql = "CREATE UNLOGGED TABLE public.unlogged2 (a int primary key)";
+    match pg_and_generic().one_statement_parses_to(
+        sql,
+        "CREATE UNLOGGED TABLE public.unlogged2 (a INT PRIMARY KEY)",
+    ) {
+        Statement::CreateTable(CreateTable { name, unlogged, .. }) => {
+            assert!(unlogged);
+            assert_eq!("public.unlogged2", name.to_string());
+        }
+        _ => unreachable!(),
+    }
+
+    let sql = "CREATE UNLOGGED TABLE pg_temp.unlogged3 (a int primary key)";
+    match pg_and_generic().one_statement_parses_to(
+        sql,
+        "CREATE UNLOGGED TABLE pg_temp.unlogged3 (a INT PRIMARY KEY)",
+    ) {
+        Statement::CreateTable(CreateTable { name, unlogged, .. }) => {
+            assert!(unlogged);
+            assert_eq!("pg_temp.unlogged3", name.to_string());
+        }
+        _ => unreachable!(),
+    }
+
+    let sql = "CREATE UNLOGGED TABLE unlogged1 (a int) PARTITION BY RANGE (a)";
+    match pg_and_generic().one_statement_parses_to(
+        sql,
+        "CREATE UNLOGGED TABLE unlogged1 (a INT) PARTITION BY RANGE(a)",
+    ) {
+        Statement::CreateTable(CreateTable {
+            name,
+            unlogged,
+            partition_by,
+            ..
+        }) => {
+            assert!(unlogged);
+            assert_eq!("unlogged1", name.to_string());
+            assert!(partition_by.is_some());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_join_constraint_unnest_alias() {
     assert_eq!(
         only(
@@ -6819,6 +6891,7 @@ fn parse_trigger_related_functions() {
         CreateTable {
             or_replace: false,
             temporary: false,
+            unlogged: false,
             external: false,
             global: None,
             dynamic: false,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5943,6 +5943,13 @@ fn parse_create_unlogged_table() {
         }
         _ => unreachable!(),
     }
+
+    // Negative test: UNLOGGED without TABLE should error
+    let res = pg().parse_sql_statements("CREATE UNLOGGED VIEW v AS SELECT 1");
+    assert!(
+        res.is_err(),
+        "CREATE UNLOGGED should only be followed by TABLE"
+    );
 }
 
 #[test]


### PR DESCRIPTION
This change adds parser and AST support for PostgreSQL table logging controls:

1. `CREATE UNLOGGED TABLE ...`
2. `ALTER TABLE ... SET LOGGED`
3. `ALTER TABLE ... SET UNLOGGED`

It also adds regression tests and updates cross-dialect test fixtures impacted by the AST shape change.