### PR TITLE
Make `visitor` feature `no_std`-compatible

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           targets: 'thumbv6m-none-eabi'
       - run: cargo check --no-default-features --target thumbv6m-none-eabi
+      - run: cargo check --no-default-features --features visitor --target thumbv6m-none-eabi
 
   test:
     strategy:

--- a/derive/src/visit.rs
+++ b/derive/src/visit.rs
@@ -62,11 +62,11 @@ pub(crate) fn derive_visit(
             fn visit<V: sqlparser::ast::#visitor_trait>(
                 &#modifier self,
                 visitor: &mut V
-            ) -> ::std::ops::ControlFlow<V::Break> {
+            ) -> ::core::ops::ControlFlow<V::Break> {
                 #pre_visit
                 #children
                 #post_visit
-                ::std::ops::ControlFlow::Continue(())
+                ::core::ops::ControlFlow::Continue(())
             }
         }
     };

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -17,8 +17,11 @@
 
 //! Recursive visitors for ast Nodes. See [`Visitor`] for more details.
 
-use crate::ast::{Expr, ObjectName, Query, Select, Statement, TableFactor, ValueWithSpan};
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::ops::ControlFlow;
+
+use crate::ast::{Expr, ObjectName, Query, Select, Statement, TableFactor, ValueWithSpan};
 
 /// A type that can be visited by a [`Visitor`]. See [`Visitor`] for
 /// recursively visiting parsed SQL statements.


### PR DESCRIPTION
Enabling the `visitor` feature without `std` (e.g. `default-features = false, features = ["visitor"]` on `wasm32-unknown-unknown`) currently fails with ~3200 errors. The `Visit` / `VisitMut` derive in `sqlparser_derive` hard-codes `::std::ops::ControlFlow` in the generated impls, and `src/ast/visitor.rs` references `String` / `Vec` / `Box` without importing them from `alloc`, so neither path resolves once the crate root evaluates `#![no_std]`.

The existing `compile-no-std` CI job is extended with a `--features visitor` cargo check on `thumbv6m-none-eabi` so this regression cannot land silently again.