### PR TITLE
Forbid unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ edition = "2021"
 name = "sqlparser"
 path = "src/lib.rs"
 
+[lints.rust]
+unsafe_code = "forbid"
+
 [features]
 default = ["std", "recursive-protection"]
 std = []

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -35,6 +35,9 @@ edition = "2021"
 [lib]
 proc-macro = true
 
+[lints.rust]
+unsafe_code = "forbid"
+
 [dependencies]
 syn = { version = "2.0", default-features = false, features = ["full", "printing", "parsing", "derive", "proc-macro", "clone-impls"] }
 proc-macro2 = "1.0"


### PR DESCRIPTION
Neither the parser nor the derive crate contains any unsafe code. This adds `unsafe_code = "forbid"` via the `[lints.rust]` table in both manifests so any future unsafe is rejected at compile time. The lint is set per crate because this repo is not a Cargo workspace, so there is no `[workspace.lints]` table to inherit from.