### PR TITLE
Doris SQL: add Doris Dialect

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -52,6 +52,7 @@ $ cargo run --example cli - [--dialectname]
         "--postgres" => Box::new(PostgreSqlDialect {}),
         "--ms" => Box::new(MsSqlDialect {}),
         "--mysql" => Box::new(MySqlDialect {}),
+        "--doris" => Box::new(DorisDialect {}),
         "--snowflake" => Box::new(SnowflakeDialect {}),
         "--hive" => Box::new(HiveDialect {}),
         "--redshift" => Box::new(RedshiftSqlDialect {}),

--- a/src/dialect/doris.rs
+++ b/src/dialect/doris.rs
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::dialect::Dialect;
+
+/// A [`Dialect`] for [Apache Doris](https://doris.apache.org/).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DorisDialect {}
+
+impl Dialect for DorisDialect {
+    fn is_delimited_identifier_start(&self, ch: char) -> bool {
+        ch == '`'
+    }
+
+    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        Some('`')
+    }
+
+    fn is_identifier_start(&self, ch: char) -> bool {
+        ch.is_ascii_alphabetic() || ch == '_' || !ch.is_ascii()
+    }
+
+    fn is_identifier_part(&self, ch: char) -> bool {
+        self.is_identifier_start(ch) || ch.is_ascii_digit()
+    }
+
+    fn supports_string_literal_backslash_escape(&self) -> bool {
+        true
+    }
+
+    fn ignores_wildcard_escapes(&self) -> bool {
+        true
+    }
+
+    fn supports_numeric_prefix(&self) -> bool {
+        true
+    }
+}

--- a/src/dialect/doris.rs
+++ b/src/dialect/doris.rs
@@ -15,7 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::dialect::Dialect;
+use crate::{
+    ast::Expr,
+    dialect::{Dialect, MySqlDialect},
+    parser::{Parser, ParserError},
+};
 
 /// A [`Dialect`] for [Apache Doris](https://doris.apache.org/).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -24,30 +28,47 @@ pub struct DorisDialect {}
 
 impl Dialect for DorisDialect {
     fn is_delimited_identifier_start(&self, ch: char) -> bool {
-        ch == '`'
+        MySqlDialect {}.is_delimited_identifier_start(ch)
     }
 
-    fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
-        Some('`')
+    fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
+        MySqlDialect {}.identifier_quote_style(identifier)
     }
 
     fn is_identifier_start(&self, ch: char) -> bool {
-        ch.is_ascii_alphabetic() || ch == '_' || !ch.is_ascii()
+        MySqlDialect {}.is_identifier_start(ch)
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        self.is_identifier_start(ch) || ch.is_ascii_digit()
+        MySqlDialect {}.is_identifier_part(ch)
     }
 
     fn supports_string_literal_backslash_escape(&self) -> bool {
-        true
+        MySqlDialect {}.supports_string_literal_backslash_escape()
     }
 
     fn ignores_wildcard_escapes(&self) -> bool {
-        true
+        MySqlDialect {}.ignores_wildcard_escapes()
     }
 
     fn supports_numeric_prefix(&self) -> bool {
-        true
+        MySqlDialect {}.supports_numeric_prefix()
+    }
+
+    fn supports_limit_comma(&self) -> bool {
+        MySqlDialect {}.supports_limit_comma()
+    }
+
+    fn parse_infix(
+        &self,
+        parser: &mut Parser,
+        expr: &Expr,
+        precedence: u8,
+    ) -> Option<Result<Expr, ParserError>> {
+        MySqlDialect {}.parse_infix(parser, expr, precedence)
+    }
+
+    fn supports_group_by_with_modifier(&self) -> bool {
+        MySqlDialect {}.supports_group_by_with_modifier()
     }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -19,6 +19,7 @@ mod ansi;
 mod bigquery;
 mod clickhouse;
 mod databricks;
+mod doris;
 mod duckdb;
 mod generic;
 mod hive;
@@ -43,6 +44,7 @@ pub use self::ansi::AnsiDialect;
 pub use self::bigquery::BigQueryDialect;
 pub use self::clickhouse::ClickHouseDialect;
 pub use self::databricks::DatabricksDialect;
+pub use self::doris::DorisDialect;
 pub use self::duckdb::DuckDbDialect;
 pub use self::generic::GenericDialect;
 pub use self::hive::HiveDialect;
@@ -1908,6 +1910,7 @@ pub fn dialect_from_str(dialect_name: impl AsRef<str>) -> Option<Box<dyn Dialect
         "bigquery" => Some(Box::new(BigQueryDialect)),
         "ansi" => Some(Box::new(AnsiDialect {})),
         "duckdb" => Some(Box::new(DuckDbDialect {})),
+        "doris" => Some(Box::new(DorisDialect {})),
         "databricks" => Some(Box::new(DatabricksDialect {})),
         "spark" | "sparksql" => Some(Box::new(SparkSqlDialect {})),
         "oracle" => Some(Box::new(OracleDialect {})),
@@ -1963,6 +1966,8 @@ mod tests {
         assert!(parse_dialect("ANSI").is::<AnsiDialect>());
         assert!(parse_dialect("duckdb").is::<DuckDbDialect>());
         assert!(parse_dialect("DuckDb").is::<DuckDbDialect>());
+        assert!(parse_dialect("doris").is::<DorisDialect>());
+        assert!(parse_dialect("Doris").is::<DorisDialect>());
         assert!(parse_dialect("DataBricks").is::<DatabricksDialect>());
         assert!(parse_dialect("databricks").is::<DatabricksDialect>());
         assert!(parse_dialect("teradata").is::<TeradataDialect>());

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -286,6 +286,7 @@ pub fn all_dialects() -> TestedDialects {
         Box::new(HiveDialect {}),
         Box::new(RedshiftSqlDialect {}),
         Box::new(MySqlDialect {}),
+        Box::new(DorisDialect {}),
         Box::new(BigQueryDialect {}),
         Box::new(SQLiteDialect {}),
         Box::new(DuckDbDialect {}),

--- a/tests/sqlparser_doris.rs
+++ b/tests/sqlparser_doris.rs
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![warn(clippy::all)]
+//! Test SQL syntax specific to Apache Doris.
+
+#[macro_use]
+mod test_utils;
+
+use sqlparser::dialect::{Dialect, DorisDialect, GenericDialect};
+use test_utils::*;
+
+fn doris() -> TestedDialects {
+    TestedDialects::new(vec![Box::new(DorisDialect {})])
+}
+
+fn doris_and_generic() -> TestedDialects {
+    TestedDialects::new(vec![Box::new(DorisDialect {}), Box::new(GenericDialect {})])
+}
+
+#[test]
+fn doris_identifier_and_string_literal_gates() {
+    let dialect = DorisDialect {};
+    assert_eq!(dialect.identifier_quote_style("identifier"), Some('`'));
+    assert!(dialect.is_delimited_identifier_start('`'));
+    assert!(dialect.supports_string_literal_backslash_escape());
+    assert!(dialect.ignores_wildcard_escapes());
+    assert!(dialect.supports_numeric_prefix());
+}
+
+#[test]
+fn parse_doris_strings_and_identifiers() {
+    doris().verified_stmt(
+        r#"SELECT "double quoted string", 'single quoted string', `select` FROM `db`.`table`"#,
+    );
+}
+
+#[test]
+fn doris_and_generic_parse_common_sql_identically() {
+    doris_and_generic().verified_stmt("SELECT 1 AS properties FROM t");
+}

--- a/tests/sqlparser_doris.rs
+++ b/tests/sqlparser_doris.rs
@@ -21,25 +21,11 @@
 #[macro_use]
 mod test_utils;
 
-use sqlparser::dialect::{Dialect, DorisDialect, GenericDialect};
+use sqlparser::dialect::DorisDialect;
 use test_utils::*;
 
 fn doris() -> TestedDialects {
     TestedDialects::new(vec![Box::new(DorisDialect {})])
-}
-
-fn doris_and_generic() -> TestedDialects {
-    TestedDialects::new(vec![Box::new(DorisDialect {}), Box::new(GenericDialect {})])
-}
-
-#[test]
-fn doris_identifier_and_string_literal_gates() {
-    let dialect = DorisDialect {};
-    assert_eq!(dialect.identifier_quote_style("identifier"), Some('`'));
-    assert!(dialect.is_delimited_identifier_start('`'));
-    assert!(dialect.supports_string_literal_backslash_escape());
-    assert!(dialect.ignores_wildcard_escapes());
-    assert!(dialect.supports_numeric_prefix());
 }
 
 #[test]
@@ -47,11 +33,6 @@ fn parse_doris_strings_and_identifiers() {
     doris().verified_only_select(
         r#"SELECT "double quoted string", 'single quoted string', `select` FROM `db`.`table`"#,
     );
-}
-
-#[test]
-fn doris_and_generic_parse_common_sql_identically() {
-    doris_and_generic().verified_stmt("SELECT 1 AS properties FROM t");
 }
 
 #[test]

--- a/tests/sqlparser_doris.rs
+++ b/tests/sqlparser_doris.rs
@@ -44,7 +44,7 @@ fn doris_identifier_and_string_literal_gates() {
 
 #[test]
 fn parse_doris_strings_and_identifiers() {
-    doris().verified_stmt(
+    doris().verified_only_select(
         r#"SELECT "double quoted string", 'single quoted string', `select` FROM `db`.`table`"#,
     );
 }
@@ -52,4 +52,19 @@ fn parse_doris_strings_and_identifiers() {
 #[test]
 fn doris_and_generic_parse_common_sql_identically() {
     doris_and_generic().verified_stmt("SELECT 1 AS properties FROM t");
+}
+
+#[test]
+fn parse_doris_limit_comma() {
+    doris().verified_only_select("SELECT * FROM t LIMIT 5, 10");
+}
+
+#[test]
+fn parse_doris_div_infix() {
+    doris().verified_only_select("SELECT 5 DIV 2");
+}
+
+#[test]
+fn parse_doris_group_by_with_rollup() {
+    doris().verified_only_select("SELECT * FROM t GROUP BY col1, col2 WITH ROLLUP");
 }


### PR DESCRIPTION
## Summary

Adds Doris SQL dialect support to close #2379 

> This is PR 1 of a stacked Doris SQL support series. It contains only the shared AUTO_INCREMENT AST cleanup and the Doris dialect skeleton. Follow-up draft PRs add CREATE TABLE table models, LOAD DATA INFILE, and CREATE ROUTINE LOAD support.

This PR introduces `DorisDialect` and parser/AST support for common Doris SQL syntax, especially Doris `CREATE TABLE` clauses, partition/distribution definitions, table properties, Doris column options, and Doris load statements.

## Changes



- Add `DorisDialect`
  - backtick-delimited identifiers
  - Doris-style identifiers
  - backslash string escapes
  - Doris-specific parser capability gates

- Add Doris `CREATE TABLE` support
  - `ENGINE = OLAP`
  - `DUPLICATE KEY`, `UNIQUE KEY`, `AGGREGATE KEY`
  - table-level `COMMENT`
  - `PARTITION BY RANGE/LIST`
  - `AUTO PARTITION`
  - partition values including `MAXVALUE` / `MAX_VALUE`
  - fixed and batch range partitions
  - `DISTRIBUTED BY HASH/RANDOM`
  - `BUCKETS <n>` and `BUCKETS AUTO`
  - `PROPERTIES (...)`

- Add Doris AST structures
  - key model
  - partition model
  - distribution model
  - bucket declarations
  - Doris load statements

- Add Doris-specific statement parsing
  - `LOAD DATA INFILE`
  - `CREATE ROUTINE LOAD`

- Extend tests
  - Doris round-trip parser tests
  - structured AST assertions
  - generic/ANSI rejection cases for Doris-only syntax
  - table comment escaping
  - compatibility checks for surrounding dialect behavior


## Testing

```bash
cargo fmt --check
cargo test --test sqlparser_doris