### PR TITLE
CI: bump rust-cache, stale, setup-python, Python

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -33,8 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.8
+          python-version: 3.14
       - name: Audit licenses
         run: ./dev/release/run-rat.sh .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,7 +96,7 @@ jobs:
       uses: ./.github/actions/setup-builder
       with:
         rust-version: ${{ matrix.rust }}
-    - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
     - name: Install Tarpaulin
       run: cargo install cargo-tarpaulin
     - name: Test

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-pr-message: "Thank you for your contribution. Unfortunately, this pull request is stale because it has been open 60 days with no activity. Please remove the stale label or comment or this will be closed in 7 days."
           days-before-pr-stale: 60


### PR DESCRIPTION
  rust-cache: v2.7.8 → v2.9.1
    released on 12/03/2026
    https://github.com/Swatinem/rust-cache/releases/tag/v2.9.1

  stale: v9 → v10.3.0
    released on 20/05/2026
    https://github.com/actions/stale/releases/tag/v10.3.0

  setup-python: v5 → v6
    released on 03/06/2026
    https://github.com/actions/setup-python/releases/tag/v6.3.0

  Python: 3.8 → 3.14
    released on 07/10/2025
    https://python.org/downloads/release/python-3140/