### PR TITLE
Escape closing brackets in bracket-quoted identifiers

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -385,7 +385,19 @@ impl fmt::Display for Ident {
                 let escaped = value::escape_quoted_string(&self.value, q);
                 write!(f, "{q}{escaped}{q}")
             }
-            Some('[') => write!(f, "[{}]", self.value),
+            Some('[') => {
+                // Redshift nested quoted identifiers (e.g. `["a]b"]`) store the
+                // value as a complete double-quoted string whose inner `]` is
+                // literal, so leave those unchanged. Otherwise double each `]`,
+                // mirroring the tokenizer folding `]]` into `]`, so the
+                // identifier round-trips (#2409).
+                let v = &self.value;
+                if v.len() >= 2 && v.starts_with('"') && v.ends_with('"') {
+                    write!(f, "[{v}]")
+                } else {
+                    write!(f, "[{}]", v.replace(']', "]]"))
+                }
+            }
             None => f.write_str(&self.value),
             _ => panic!("unexpected quote style"),
         }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -388,23 +388,21 @@ impl fmt::Display for Ident {
             Some('[') => {
                 let v = &self.value;
                 if v.len() >= 2 && v.starts_with('"') && v.ends_with('"') {
-                    // A nested double-quoted identifier (e.g. Redshift `["a]b"]`)
-                    // keeps its inner quotes in the value and its `]` is already
-                    // literal, so emit it unchanged.
+                    // Redshift's nested quoted identifier form (`["a b"]`) keeps
+                    // the inner quotes in the value, where `]` is literal.
                     write!(f, "[{v}]")
                 } else {
-                    // Double a lone `]` so the identifier round-trips, but leave
-                    // an already-doubled `]]` intact: in the tokenizer's no-escape
-                    // mode the value still holds the raw `]]`, and re-doubling it
-                    // would corrupt the identifier.
-                    write!(f, "[")?;
-                    let mut rest = v.as_str();
-                    while let Some(pos) = rest.find(']') {
-                        write!(f, "{}]]", &rest[..pos])?;
-                        let after = &rest[pos + 1..];
-                        rest = after.strip_prefix(']').unwrap_or(after);
+                    // Each `]` is doubled. `escape_quoted_string` can't be reused:
+                    // it skips a quote that is already doubled, which corrupts a
+                    // value containing `]]`.
+                    f.write_str("[")?;
+                    for (i, part) in v.split(']').enumerate() {
+                        if i > 0 {
+                            f.write_str("]]")?;
+                        }
+                        f.write_str(part)?;
                     }
-                    write!(f, "{rest}]")
+                    f.write_str("]")
                 }
             }
             None => f.write_str(&self.value),

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -386,16 +386,25 @@ impl fmt::Display for Ident {
                 write!(f, "{q}{escaped}{q}")
             }
             Some('[') => {
-                // Redshift nested quoted identifiers (e.g. `["a]b"]`) store the
-                // value as a complete double-quoted string whose inner `]` is
-                // literal, so leave those unchanged. Otherwise double each `]`,
-                // mirroring the tokenizer folding `]]` into `]`, so the
-                // identifier round-trips (#2409).
                 let v = &self.value;
                 if v.len() >= 2 && v.starts_with('"') && v.ends_with('"') {
+                    // A nested double-quoted identifier (e.g. Redshift `["a]b"]`)
+                    // keeps its inner quotes in the value and its `]` is already
+                    // literal, so emit it unchanged.
                     write!(f, "[{v}]")
                 } else {
-                    write!(f, "[{}]", v.replace(']', "]]"))
+                    // Double a lone `]` so the identifier round-trips, but leave
+                    // an already-doubled `]]` intact: in the tokenizer's no-escape
+                    // mode the value still holds the raw `]]`, and re-doubling it
+                    // would corrupt the identifier.
+                    write!(f, "[")?;
+                    let mut rest = v.as_str();
+                    while let Some(pos) = rest.find(']') {
+                        write!(f, "{}]]", &rest[..pos])?;
+                        let after = &rest[pos + 1..];
+                        rest = after.strip_prefix(']').unwrap_or(after);
+                    }
+                    write!(f, "{rest}]")
                 }
             }
             None => f.write_str(&self.value),

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -939,14 +939,28 @@ fn parse_table_name_in_square_brackets() {
 
 #[test]
 fn parse_bracket_identifier_with_escaped_closing_bracket() {
-    // A bracket-quoted identifier whose value contains `]` must serialize
-    // with the bracket doubled so it round-trips. See #2409.
+    // A `]` inside a bracket-quoted identifier is escaped by doubling it, so
+    // `[a]]b]` denotes the identifier `a]b`.
     let select = ms().verified_only_select("SELECT [a]]b]");
     assert_eq!(
         &Expr::Identifier(Ident::with_quote('[', "a]b")),
         expr_from_projection(&select.projection[0]),
     );
-    ms().verified_stmt("SELECT [a]]b] FROM [c]]d]");
+
+    // Round-trips regardless of where the escaped `]` sits.
+    for sql in [
+        "SELECT [a]]b] FROM [c]]d]",
+        "SELECT []]]",      // the identifier is a single `]`
+        "SELECT [a]]]",     // trailing `]`
+        "SELECT []]b]",     // leading `]`
+        "SELECT [a]]b]]c]", // several escaped `]`
+    ] {
+        ms().verified_stmt(sql);
+    }
+
+    // In no-escape mode the parsed value keeps the raw `]]`, so serializing it
+    // must not double the brackets again.
+    ms_no_unescape().verified_stmt("SELECT [a]]b]");
 }
 
 #[test]
@@ -2445,6 +2459,13 @@ fn parse_mssql_table_identifier_with_default_schema() {
 
 fn ms() -> TestedDialects {
     TestedDialects::new(vec![Box::new(MsSqlDialect {})])
+}
+
+fn ms_no_unescape() -> TestedDialects {
+    TestedDialects::new_with_options(
+        vec![Box::new(MsSqlDialect {})],
+        ParserOptions::new().with_unescape(false),
+    )
 }
 
 // MS SQL dialect with support for optional semi-colon statement delimiters

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -938,6 +938,18 @@ fn parse_table_name_in_square_brackets() {
 }
 
 #[test]
+fn parse_bracket_identifier_with_escaped_closing_bracket() {
+    // A bracket-quoted identifier whose value contains `]` must serialize
+    // with the bracket doubled so it round-trips. See #2409.
+    let select = ms().verified_only_select("SELECT [a]]b]");
+    assert_eq!(
+        &Expr::Identifier(Ident::with_quote('[', "a]b")),
+        expr_from_projection(&select.projection[0]),
+    );
+    ms().verified_stmt("SELECT [a]]b] FROM [c]]d]");
+}
+
+#[test]
 fn parse_for_clause() {
     ms_and_generic().verified_stmt("SELECT a FROM t FOR JSON PATH");
     ms_and_generic().verified_stmt("SELECT b FROM t FOR JSON AUTO");

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -31,7 +31,7 @@ use sqlparser::ast::DataType::{Int, Text, Varbinary};
 use sqlparser::ast::DeclareAssignment::MsSqlAssignment;
 use sqlparser::ast::Value::SingleQuotedString;
 use sqlparser::ast::*;
-use sqlparser::dialect::{GenericDialect, MsSqlDialect};
+use sqlparser::dialect::{GenericDialect, MsSqlDialect, SQLiteDialect};
 use sqlparser::parser::{Parser, ParserError, ParserOptions};
 
 #[test]
@@ -947,20 +947,41 @@ fn parse_bracket_identifier_with_escaped_closing_bracket() {
         expr_from_projection(&select.projection[0]),
     );
 
-    // Round-trips regardless of where the escaped `]` sits.
-    for sql in [
-        "SELECT [a]]b] FROM [c]]d]",
-        "SELECT []]]",      // the identifier is a single `]`
-        "SELECT [a]]]",     // trailing `]`
-        "SELECT []]b]",     // leading `]`
-        "SELECT [a]]b]]c]", // several escaped `]`
-    ] {
-        ms().verified_stmt(sql);
-    }
+    // Consecutive `]` in the value are each escaped, so `a]]b` stays `a]]b`.
+    let select = ms().verified_only_select("SELECT [a]]]]b]");
+    assert_eq!(
+        &Expr::Identifier(Ident::with_quote('[', "a]]b")),
+        expr_from_projection(&select.projection[0]),
+    );
+}
 
-    // In no-escape mode the parsed value keeps the raw `]]`, so serializing it
-    // must not double the brackets again.
-    ms_no_unescape().verified_stmt("SELECT [a]]b]");
+#[test]
+fn bracket_identifier_display_round_trips() {
+    // Serializing an identifier must produce SQL that parses back to the same
+    // identifier. Checked exhaustively over every value of length 1..=5 built
+    // from `]`, `"`, an ordinary character and a multi-byte one.
+    let mut values = vec![String::new()];
+    for _ in 0..5 {
+        values = values
+            .iter()
+            .flat_map(|v| [']', '"', 'a', 'é'].map(|c| format!("{v}{c}")))
+            .collect();
+        for value in &values {
+            // A value wrapped in `"` is Redshift's nested quoted identifier form,
+            // which is emitted verbatim, so a `]` in it cannot be escaped.
+            if value.starts_with('"') && value.ends_with('"') && value.contains(']') {
+                continue;
+            }
+            let ident = Ident::with_quote('[', value.as_str());
+            let sql = format!("SELECT {ident}");
+            let select = ms_and_sqlite().verified_only_select(&sql);
+            assert_eq!(
+                &Expr::Identifier(ident),
+                expr_from_projection(&select.projection[0]),
+                "{sql} did not round trip",
+            );
+        }
+    }
 }
 
 #[test]
@@ -2461,11 +2482,8 @@ fn ms() -> TestedDialects {
     TestedDialects::new(vec![Box::new(MsSqlDialect {})])
 }
 
-fn ms_no_unescape() -> TestedDialects {
-    TestedDialects::new_with_options(
-        vec![Box::new(MsSqlDialect {})],
-        ParserOptions::new().with_unescape(false),
-    )
+fn ms_and_sqlite() -> TestedDialects {
+    TestedDialects::new(vec![Box::new(MsSqlDialect {}), Box::new(SQLiteDialect {})])
 }
 
 // MS SQL dialect with support for optional semi-colon statement delimiters


### PR DESCRIPTION
Fixes #2409.

A bracket-quoted identifier whose value contains `]` (e.g. `[a]]b]`, value `a]b`) serialized back to `[a]b]`, which no longer re-parses. This doubles each `]` on display, mirroring the tokenizer which folds `]]` into `]`.

Redshift also parses nested quoted identifiers like `["a]b"]`, whose value is stored as a complete double-quoted string (`"a]b"`) with a literal inner `]`. The AST doesn't distinguish that from a plain bracket ident, so a value that is a complete `"..."` string is left unchanged; otherwise the `]` are doubled.

Added a round-trip test; the existing Redshift nested-identifier test covers the verbatim case.

Used AI assistance on this; I reviewed and tested it.
