### PR TITLE
Honour operator precedence in SQLite `REGEXP`, `MATCH` and `GLOB`

### DIFF
--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -79,7 +79,7 @@ impl Dialect for SQLiteDialect {
         &self,
         parser: &mut crate::parser::Parser,
         expr: &crate::ast::Expr,
-        _precedence: u8,
+        precedence: u8,
     ) -> Option<Result<crate::ast::Expr, ParserError>> {
         // Parse MATCH, REGEXP and GLOB as operators
         // See <https://www.sqlite.org/lang_expr.html#the_like_glob_regexp_match_and_extract_operators>
@@ -90,7 +90,7 @@ impl Dialect for SQLiteDialect {
         ] {
             if parser.parse_keyword(keyword) {
                 let left = Box::new(expr.clone());
-                let right = Box::new(match parser.parse_expr() {
+                let right = Box::new(match parser.parse_subexpr(precedence) {
                     Ok(expr) => expr,
                     Err(e) => return Some(Err(e)),
                 });

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -926,6 +926,37 @@ fn test_drop_trigger() {
     }
 }
 
+#[test]
+fn parse_pattern_operators_bind_at_like_precedence() {
+    fn where_operator(sql: &str) -> BinaryOperator {
+        let Statement::Query(query) = sqlite().verified_stmt(sql) else {
+            panic!("expected a query");
+        };
+        let SetExpr::Select(select) = *query.body else {
+            panic!("expected a select");
+        };
+        let Some(Expr::BinaryOp { op, .. }) = select.selection else {
+            panic!("expected a WHERE binary operator");
+        };
+        op
+    }
+
+    // Above AND, so the pattern does not swallow the rest of the expression.
+    for operator in ["REGEXP", "MATCH", "GLOB", "LIKE"] {
+        let sql = format!("SELECT 1 FROM t WHERE a {operator} 'p' AND b = 1");
+        assert_eq!(where_operator(&sql), BinaryOperator::And, "{operator}");
+    }
+    // Below string concatenation, so the pattern is not cut short either.
+    for (operator, expected) in [
+        ("REGEXP", BinaryOperator::Regexp),
+        ("MATCH", BinaryOperator::Match),
+        ("GLOB", BinaryOperator::Glob),
+    ] {
+        let sql = format!("SELECT 1 FROM t WHERE a {operator} 'p' || 'q'");
+        assert_eq!(where_operator(&sql), expected, "{operator}");
+    }
+}
+
 fn sqlite() -> TestedDialects {
     TestedDialects::new(vec![Box::new(SQLiteDialect {})])
 }


### PR DESCRIPTION
`SQLiteDialect::parse_infix` parsed the right operand of `REGEXP`, `MATCH`, and `GLOB` with `parse_expr`, and previously lead to mutating the meaning of boolean operations constructed with it.

For instance, `a REGEXP 'p' AND b = 1` parsed as a `REGEXP ('p' AND b = 1)` instead of `(a REGEXP 'p') AND (b = 1)`.

The hook was ignoring the precedence its caller passed, so using it fixes all three. Nothing errored before, and Display adds no parentheses, so the wrong tree reprinted as the original text. That is why a text round trip never caught it and the new test asserts on the tree instead.