### PR TITLE
MySQL: print a space before PARTITION when displaying a table factor

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2216,7 +2216,7 @@ impl fmt::Display for TableFactor {
                     json_path.fmt(f)?;
                 }
                 if !partitions.is_empty() {
-                    write!(f, "PARTITION ({})", display_comma_separated(partitions))?;
+                    write!(f, " PARTITION ({})", display_comma_separated(partitions))?;
                 }
                 if let Some(args) = args {
                     write!(f, "(")?;

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -4946,3 +4946,19 @@ fn parse_adjacent_string_literal_concatenation() {
 fn parse_group_by_with_rollup() {
     mysql().verified_stmt("SELECT * FROM tbl GROUP BY col1, col2 WITH ROLLUP");
 }
+
+#[test]
+fn parse_table_partition_selection() {
+    mysql_and_generic().verified_stmt("SELECT * FROM employees PARTITION (p0, p2)");
+    mysql_and_generic().verified_stmt("SELECT * FROM employees PARTITION (p0) AS e");
+    mysql_and_generic().verified_stmt(
+        "SELECT * FROM employees PARTITION (p0) JOIN departments PARTITION (p1) ON employees.dept_id = departments.id",
+    );
+    mysql_and_generic().verified_stmt("UPDATE employees PARTITION (p0) SET salary = 1");
+    mysql_and_generic().verified_stmt("DELETE FROM employees PARTITION (p0) WHERE id = 1");
+
+    let err = mysql_and_generic()
+        .parse_sql_statements("SELECT * FROM employees PARTITION")
+        .expect_err("expected an error");
+    assert_matches!(err, ParserError::ParserError(_));
+}


### PR DESCRIPTION
```sql
SELECT * FROM employees PARTITION (p0, p2)
```

round-trips to `SELECT * FROM employeesPARTITION (p0, p2)`, which re-parses as a table *function* named `employeesPARTITION` taking arguments `p0` and `p2` — a different AST, not just different whitespace.

`Display for TableFactor::Table` writes `PARTITION (...)` with no leading space, unlike the sibling clauses in the same arm (` WITH ORDINALITY`, ` {alias}`, ` WITH (...)`). The fix adds the space.

Test is `parse_table_partition_selection` in `tests/sqlparser_mysql.rs`, covering `SELECT`/`UPDATE`/`DELETE`, an alias, a join and the missing-parenthesis error path; it fails without the change. Table-level `PARTITION` selection had no test coverage before.
