### PR TITLE
Print a space between adjacent prefix unary operators

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1963,7 +1963,8 @@ impl fmt::Display for Expr {
                         | UnaryOperator::DoubleAt
                         | UnaryOperator::QuestionDash
                         | UnaryOperator::QuestionPipe
-                ) {
+                ) || matches!(expr.as_ref(), Expr::UnaryOp { .. })
+                {
                     write!(f, "{op} {expr}")
                 } else {
                     write!(f, "{op}{expr}")

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -196,6 +196,36 @@ where
     DisplaySeparated { slice, sep: ", " }
 }
 
+/// Returns true when the prefix operator `op` written directly before `operand`
+/// would be tokenized as a single operator rather than as two.
+fn lexes_as_one_operator(op: &UnaryOperator, operand: &Expr) -> bool {
+    let Expr::UnaryOp { op: leading, .. } = operand else {
+        return false;
+    };
+    match op {
+        UnaryOperator::Minus
+        | UnaryOperator::BitwiseNot
+        | UnaryOperator::PGSquareRoot
+        | UnaryOperator::PGCubeRoot => !matches!(
+            leading,
+            UnaryOperator::Not | UnaryOperator::PGPostfixFactorial
+        ),
+        UnaryOperator::BangNot => {
+            matches!(leading, UnaryOperator::BangNot | UnaryOperator::BitwiseNot)
+        }
+        UnaryOperator::PGAbs => matches!(
+            leading,
+            UnaryOperator::AtDashAt
+                | UnaryOperator::DoubleAt
+                | UnaryOperator::Minus
+                | UnaryOperator::PGAbs
+                | UnaryOperator::QuestionDash
+                | UnaryOperator::QuestionPipe
+        ),
+        _ => false,
+    }
+}
+
 /// Writes the given statements to the formatter, each ending with
 /// a semicolon and space separated.
 fn format_statement_list(f: &mut fmt::Formatter, statements: &[Statement]) -> fmt::Result {
@@ -1963,7 +1993,7 @@ impl fmt::Display for Expr {
                         | UnaryOperator::DoubleAt
                         | UnaryOperator::QuestionDash
                         | UnaryOperator::QuestionPipe
-                ) || matches!(expr.as_ref(), Expr::UnaryOp { .. })
+                ) || lexes_as_one_operator(op, expr)
                 {
                     write!(f, "{op} {expr}")
                 } else {

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -19687,3 +19687,11 @@ fn parse_nested_unary_ops() {
     all_dialects().verified_stmt("SELECT NOT NOT a");
     all_dialects().one_statement_parses_to("SELECT ~ ~ 1", "SELECT ~ ~1");
 }
+
+#[test]
+fn parse_adjacent_unary_ops_that_do_not_combine() {
+    all_dialects().verified_stmt("SELECT ++a");
+    all_dialects().verified_stmt("SELECT +~a");
+    all_dialects().verified_stmt("SELECT -NOT a");
+    all_dialects().verified_stmt("SELECT ~NOT a");
+}

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -19679,3 +19679,11 @@ fn parse_function_arg_call_chain_no_exponential_blowup() {
     rx.recv_timeout(Duration::from_secs(5))
         .expect("parser should reject this quickly, not loop exponentially");
 }
+
+#[test]
+fn parse_nested_unary_ops() {
+    all_dialects().verified_stmt("SELECT - -1");
+    all_dialects().verified_stmt("SELECT ~ ~1");
+    all_dialects().verified_stmt("SELECT NOT NOT a");
+    all_dialects().one_statement_parses_to("SELECT ~ ~ 1", "SELECT ~ ~1");
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -9663,3 +9663,29 @@ fn parse_right_deep_join_chain() {
     // NATURAL JOIN followed by a constrained join must stay left-associative.
     pg().verified_stmt("SELECT * FROM t0 NATURAL JOIN t1 INNER JOIN t2 ON true");
 }
+
+#[test]
+fn parse_nested_pg_unary_ops() {
+    let select = pg().verified_only_select("SELECT @ @1");
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::UnaryOp {
+            op: UnaryOperator::PGAbs,
+            expr: Box::new(Expr::UnaryOp {
+                op: UnaryOperator::PGAbs,
+                expr: Box::new(Expr::value(number("1"))),
+            }),
+        }),
+        select.projection[0]
+    );
+
+    let select = pg().verified_only_select("SELECT @@ 1");
+    assert_eq!(
+        SelectItem::UnnamedExpr(Expr::UnaryOp {
+            op: UnaryOperator::DoubleAt,
+            expr: Box::new(Expr::value(number("1"))),
+        }),
+        select.projection[0]
+    );
+
+    pg().verified_stmt("SELECT |/ |/1");
+}

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -9689,3 +9689,11 @@ fn parse_nested_pg_unary_ops() {
 
     pg().verified_stmt("SELECT |/ |/1");
 }
+
+#[test]
+fn parse_adjacent_pg_unary_ops_that_do_not_combine() {
+    pg().verified_stmt("SELECT +@a");
+    pg().verified_stmt("SELECT !!~a");
+    pg().verified_stmt("SELECT @~a");
+    pg().verified_stmt("SELECT !!|/a");
+}


### PR DESCRIPTION
`Expr::UnaryOp`'s `Display` writes `{op}{expr}` with no separator, so a nested unary operand is printed glued to the operator:

```sql
SELECT ~ ~ 1
```

prints as `SELECT ~~1`, which no longer reparses on any dialect (`Expected: an expression, found: ~~`). `SELECT - -1` prints as `SELECT --1` the same way; that one only breaks where `--` opens a line comment, so MySQL is unaffected.

On PostgreSQL it changes meaning rather than failing, because `@@` is its own operator: `SELECT @ @ 1` (abs of abs) prints as `SELECT @@1`, which reparses as `UnaryOperator::DoubleAt` applied to `1`.

The fix inserts a space only where the operator's glyph and the operand's leading glyph would tokenize as a single token. Pairs that cannot merge are left alone, so `++a`, `+@a`, `!!~a` and `-NOT a` print unchanged.

Tests are `parse_nested_unary_ops` and `parse_nested_pg_unary_ops`, which fail without the source change, plus `parse_adjacent_unary_ops_that_do_not_combine` and `parse_adjacent_pg_unary_ops_that_do_not_combine` pinning the pairs that must stay glued. The `AGENTS.md` pre-commit checks are clean locally.
