### PR TITLE
Inline Word::to_ident

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21214,6 +21214,7 @@ impl Word {
     /// Use this method when you need to keep the original `Word` around.
     /// If you can consume the `Word`, prefer [`into_ident`](Self::into_ident) instead
     /// to avoid cloning.
+    #[inline]
     pub fn to_ident(&self, span: Span) -> Ident {
         Ident {
             value: self.value.clone(),


### PR DESCRIPTION
## Summary

This marks `Word::to_ident` as inline.

`Word::to_ident` is a small helper used while building identifier-heavy AST nodes. It clones the word value, copies the quote style and attaches the caller-provided span. Letting the compiler inline it removes the call boundary from parser hot paths without changing behavior.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test`
- `cargo bench --manifest-path sqlparser_bench/Cargo.toml --bench sqlparser_bench -- --baseline upstream-main`

## Benchmark

I ran the repository benchmark suite on the same machine, first saving an `upstream-main` baseline from the current `main` branch and then comparing this branch against it.

| Benchmark | Criterion change estimate |
| --- | ---: |
| `word_to_ident/to_ident_100x` | 14.44% faster |
| `parse_identifiers/select_100_columns` | 2.58% faster |
| `parse_identifiers/select_100_qualified_columns` | 2.56% faster |
| `parse_compound_keyword_chain/chain_5` | 2.78% faster |
| `parse_prefix_keyword_call_chain/chain_10` | 3.11% faster |

The broader parsing benchmarks were also neutral to positive in this run, with the largest median regression at 1.51%.
