### PR TITLE
Support `NO INHERIT` modifier on `CHECK` constraints

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1939,7 +1939,7 @@ pub enum ColumnOption {
     /// [<constraint_characteristics>]
     /// `).
     ForeignKey(ForeignKeyConstraint),
-    /// `CHECK (<expr>)`
+    /// `CHECK (<expr>) [NO INHERIT] [[NOT] ENFORCED]`
     Check(CheckConstraint),
     /// Dialect-specific options, such as:
     /// - MySQL's `AUTO_INCREMENT` or SQLite's `AUTOINCREMENT`

--- a/src/ast/table_constraints.rs
+++ b/src/ast/table_constraints.rs
@@ -78,7 +78,7 @@ pub enum TableConstraint {
     ///   [ON UPDATE <referential_action>] [ON DELETE <referential_action>]
     /// }`).
     ForeignKey(ForeignKeyConstraint),
-    /// `[ CONSTRAINT <name> ] CHECK (<expr>) [[NOT] ENFORCED]`
+    /// `[ CONSTRAINT <name> ] CHECK (<expr>) [NO INHERIT] [[NOT] ENFORCED]`
     Check(CheckConstraint),
     /// MySQLs [index definition][1] for index creation. Not present on ANSI so, for now, the usage
     /// is restricted to MySQL, as no other dialects that support this syntax were found.
@@ -186,12 +186,15 @@ impl fmt::Display for TableConstraint {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
-/// A `CHECK` constraint (`[ CONSTRAINT <name> ] CHECK (<expr>) [[NOT] ENFORCED]`).
+/// A `CHECK` constraint (`[ CONSTRAINT <name> ] CHECK (<expr>) [NO INHERIT] [[NOT] ENFORCED]`).
 pub struct CheckConstraint {
     /// Optional constraint name.
     pub name: Option<Ident>,
     /// The boolean expression the CHECK constraint enforces.
     pub expr: Box<Expr>,
+    /// PostgreSQL-specific `NO INHERIT` flag: child tables do not inherit the constraint.
+    /// <https://www.postgresql.org/docs/current/sql-createtable.html>
+    pub no_inherit: bool,
     /// MySQL-specific `ENFORCED` / `NOT ENFORCED` flag.
     /// <https://dev.mysql.com/doc/refman/8.4/en/create-table.html>
     pub enforced: Option<bool>,
@@ -206,11 +209,13 @@ impl fmt::Display for CheckConstraint {
             display_constraint_name(&self.name),
             self.expr
         )?;
-        if let Some(b) = self.enforced {
-            write!(f, " {}", if b { "ENFORCED" } else { "NOT ENFORCED" })
-        } else {
-            Ok(())
+        if self.no_inherit {
+            write!(f, " NO INHERIT")?;
         }
+        if let Some(b) = self.enforced {
+            write!(f, " {}", if b { "ENFORCED" } else { "NOT ENFORCED" })?;
+        }
+        Ok(())
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9695,6 +9695,7 @@ impl<'a> Parser<'a> {
             // since `CHECK` requires parentheses, we can parse the inner expression in ParserState::Normal
             let expr: Expr = self.with_state(ParserState::Normal, |p| p.parse_expr())?;
             self.expect_token(&Token::RParen)?;
+            let no_inherit = self.parse_keywords(&[Keyword::NO, Keyword::INHERIT]);
 
             let enforced = if self.parse_keyword(Keyword::ENFORCED) {
                 Some(true)
@@ -9708,6 +9709,7 @@ impl<'a> Parser<'a> {
                 CheckConstraint {
                     name: None, // Column-level check constraints don't have names
                     expr: Box::new(expr),
+                    no_inherit,
                     enforced,
                 }
                 .into(),
@@ -10171,6 +10173,7 @@ impl<'a> Parser<'a> {
                 self.expect_token(&Token::LParen)?;
                 let expr = Box::new(self.parse_expr()?);
                 self.expect_token(&Token::RParen)?;
+                let no_inherit = self.parse_keywords(&[Keyword::NO, Keyword::INHERIT]);
 
                 let enforced = if self.parse_keyword(Keyword::ENFORCED) {
                     Some(true)
@@ -10184,6 +10187,7 @@ impl<'a> Parser<'a> {
                     CheckConstraint {
                         name,
                         expr,
+                        no_inherit,
                         enforced,
                     }
                     .into(),

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -3998,6 +3998,7 @@ fn parse_create_table() {
                                 option: ColumnOption::Check(CheckConstraint {
                                     name: None,
                                     expr: Box::new(verified_expr("constrained > 0")),
+                                    no_inherit: false,
                                     enforced: None,
                                 }),
                             },
@@ -17592,6 +17593,19 @@ fn column_check_enforced() {
     all_dialects().verified_stmt(
         "CREATE TABLE t (a INT CHECK (a > 0) NOT ENFORCED, b INT CHECK (b > 0) ENFORCED, c INT CHECK (c > 0))",
     );
+}
+
+#[test]
+fn table_check_no_inherit() {
+    all_dialects().verified_stmt("CREATE TABLE t (a INT, CONSTRAINT c CHECK (a > 0) NO INHERIT)");
+    all_dialects().verified_stmt("CREATE TABLE t (a INT, CHECK (a > 0) NO INHERIT)");
+    all_dialects().verified_stmt("CREATE TABLE t (a INT, CHECK (a > 0) NO INHERIT NOT ENFORCED)");
+}
+
+#[test]
+fn column_check_no_inherit() {
+    all_dialects().verified_stmt("CREATE TABLE t (x INT CHECK (x > 1) NO INHERIT)");
+    all_dialects().verified_stmt("CREATE TABLE t (x INT CHECK (x > 1) NO INHERIT NOT ENFORCED)");
 }
 
 #[test]

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -6546,6 +6546,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            no_inherit: false,
             enforced: None,
         }
         .into()],
@@ -6566,6 +6567,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            no_inherit: false,
             enforced: None,
         }
         .into()],
@@ -6586,6 +6588,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            no_inherit: false,
             enforced: None,
         }
         .into()],
@@ -6606,6 +6609,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            no_inherit: false,
             enforced: None,
         }
         .into()],
@@ -6626,6 +6630,7 @@ fn parse_create_domain() {
                 op: BinaryOperator::Gt,
                 right: Box::new(Expr::Value(test_utils::number("0").into())),
             }),
+            no_inherit: false,
             enforced: None,
         }
         .into()],
@@ -9817,4 +9822,33 @@ fn parse_quoted_argument_names_in_function_signatures() {
             default_expr: None,
         }])
     );
+}
+
+#[test]
+fn parse_alter_table_constraint_check_no_inherit() {
+    match pg_and_generic()
+        .verified_stmt("ALTER TABLE docs ADD CONSTRAINT c CHECK (id > 0) NO INHERIT NOT VALID")
+    {
+        Statement::AlterTable(AlterTable { operations, .. }) => {
+            assert_eq!(
+                operations,
+                vec![AlterTableOperation::AddConstraint {
+                    constraint: CheckConstraint {
+                        name: Some("c".into()),
+                        expr: Box::new(Expr::BinaryOp {
+                            left: Box::new(Expr::Identifier(Ident::new("id"))),
+                            op: BinaryOperator::Gt,
+                            right: Box::new(Expr::Value(test_utils::number("0").into())),
+                        }),
+                        no_inherit: true,
+                        enforced: None,
+                    }
+                    .into(),
+                    not_valid: true,
+                }]
+            );
+        }
+        _ => unreachable!(),
+    }
+    pg_and_generic().verified_stmt("ALTER TABLE docs ADD CONSTRAINT c CHECK (id > 0) NO INHERIT");
 }


### PR DESCRIPTION
PostgreSQL marks constraints that child tables should not inherit with `NO INHERIT`, and `pg_dump` emits it for any schema using table inheritance. The parser rejected it in every position:

```sql
ALTER TABLE docs ADD CONSTRAINT c CHECK (id > 0) NO INHERIT;
-- Expected: end of statement, found: NO

CREATE TABLE t (a INT, CONSTRAINT c CHECK (a > 0) NO INHERIT);
-- Expected: ',' or ')' after column definition, found: NO
 ```
 
 Relevant doc: https://www.postgresql.org/docs/current/sql-createtable.html