### PR TITLE
BigQuery: enable FROM-first SELECT

### DIFF
--- a/src/dialect/bigquery.rs
+++ b/src/dialect/bigquery.rs
@@ -136,6 +136,14 @@ impl Dialect for BigQueryDialect {
         true
     }
 
+    /// BigQuery allows a query to start with `FROM` (e.g. `FROM t`, and the
+    /// entry form for pipe syntax, `FROM t |> ...`).
+    ///
+    /// See <https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#from_queries>
+    fn supports_from_first_select(&self) -> bool {
+        true
+    }
+
     /// See <https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#execute_immediate>
     fn supports_execute_immediate(&self) -> bool {
         true

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2956,5 +2956,4 @@ fn parse_from_first_select() {
     bigquery().verified_stmt("FROM t");
     bigquery().verified_stmt("FROM t SELECT a, b");
     bigquery().verified_stmt("FROM t |> WHERE a > 1 |> SELECT a");
-    }
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2953,8 +2953,6 @@ fn test_create_snapshot_table() {
 
 #[test]
 fn parse_from_first_select() {
-    // BigQuery allows a query to begin with `FROM`, both on its own and as the
-    // entry form for pipe syntax.
     bigquery().verified_stmt("FROM t");
     bigquery().verified_stmt("FROM t SELECT a, b");
     bigquery().verified_stmt("FROM t |> WHERE a > 1 |> SELECT a");

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2958,23 +2958,5 @@ fn parse_from_first_select() {
     bigquery().verified_stmt("FROM t");
     bigquery().verified_stmt("FROM t SELECT a, b");
     bigquery().verified_stmt("FROM t |> WHERE a > 1 |> SELECT a");
-
-    // The bare form has no explicit SELECT and parses as `FromFirstNoSelect`;
-    // adding a SELECT switches it to `FromFirst`.
-    match bigquery().verified_stmt("FROM t") {
-        Statement::Query(query) => match *query.body {
-            SetExpr::Select(select) => {
-                assert_eq!(select.flavor, SelectFlavor::FromFirstNoSelect)
-            }
-            other => panic!("expected a select, got {other:?}"),
-        },
-        other => panic!("expected a query, got {other:?}"),
-    }
-    match bigquery().verified_stmt("FROM t SELECT a, b") {
-        Statement::Query(query) => match *query.body {
-            SetExpr::Select(select) => assert_eq!(select.flavor, SelectFlavor::FromFirst),
-            other => panic!("expected a select, got {other:?}"),
-        },
-        other => panic!("expected a query, got {other:?}"),
     }
 }

--- a/tests/sqlparser_bigquery.rs
+++ b/tests/sqlparser_bigquery.rs
@@ -2950,3 +2950,31 @@ fn test_create_snapshot_table() {
         "CREATE SNAPSHOT TABLE IF NOT EXISTS dataset_id.table1 CLONE dataset_id.table2 FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR) OPTIONS(expiration_timestamp = TIMESTAMP '2025-01-01 00:00:00 UTC')",
     );
 }
+
+#[test]
+fn parse_from_first_select() {
+    // BigQuery allows a query to begin with `FROM`, both on its own and as the
+    // entry form for pipe syntax.
+    bigquery().verified_stmt("FROM t");
+    bigquery().verified_stmt("FROM t SELECT a, b");
+    bigquery().verified_stmt("FROM t |> WHERE a > 1 |> SELECT a");
+
+    // The bare form has no explicit SELECT and parses as `FromFirstNoSelect`;
+    // adding a SELECT switches it to `FromFirst`.
+    match bigquery().verified_stmt("FROM t") {
+        Statement::Query(query) => match *query.body {
+            SetExpr::Select(select) => {
+                assert_eq!(select.flavor, SelectFlavor::FromFirstNoSelect)
+            }
+            other => panic!("expected a select, got {other:?}"),
+        },
+        other => panic!("expected a query, got {other:?}"),
+    }
+    match bigquery().verified_stmt("FROM t SELECT a, b") {
+        Statement::Query(query) => match *query.body {
+            SetExpr::Select(select) => assert_eq!(select.flavor, SelectFlavor::FromFirst),
+            other => panic!("expected a select, got {other:?}"),
+        },
+        other => panic!("expected a query, got {other:?}"),
+    }
+}


### PR DESCRIPTION
BigQuery allows a query to start with `FROM`, e.g. `FROM t` and `FROM t SELECT *`,
which is also the entry form for pipe syntax (`FROM t |> ...`).

The parser already supports FROM-first `SELECT` behind
`Dialect::supports_from_first_select()` (enabled for ClickHouse, DuckDB and
Generic); this enables it for BigQuery as well. The existing
`test_select_from_first` / `test_select_from_first_with_cte`, parameterized over
`all_dialects_where(|d| d.supports_from_first_select())`, now cover BigQuery.

Docs: https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#from_queries