### PR TITLE
Postgres: Accept generated columns with no mode keyword or VIRTUAL

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9827,18 +9827,15 @@ impl<'a> Parser<'a> {
                 let expr: Expr = self.with_state(ParserState::Normal, |p| p.parse_expr())?;
                 self.expect_token(&Token::RParen)?;
                 let (gen_as, expr_mode) = if self.parse_keywords(&[Keyword::STORED]) {
-                    Ok((
+                    (
                         GeneratedAs::ExpStored,
                         Some(GeneratedExpressionMode::Stored),
-                    ))
-                } else if dialect_of!(self is PostgreSqlDialect) {
-                    // Postgres' AS IDENTITY branches are above, this one needs STORED
-                    self.expected_ref("STORED", self.peek_token_ref())
+                    )
                 } else if self.parse_keywords(&[Keyword::VIRTUAL]) {
-                    Ok((GeneratedAs::Always, Some(GeneratedExpressionMode::Virtual)))
+                    (GeneratedAs::Always, Some(GeneratedExpressionMode::Virtual))
                 } else {
-                    Ok((GeneratedAs::Always, None))
-                }?;
+                    (GeneratedAs::Always, None)
+                };
 
                 Ok(Some(ColumnOption::Generated {
                     generated_as: gen_as,

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -9663,3 +9663,26 @@ fn parse_right_deep_join_chain() {
     // NATURAL JOIN followed by a constrained join must stay left-associative.
     pg().verified_stmt("SELECT * FROM t0 NATURAL JOIN t1 INNER JOIN t2 ON true");
 }
+
+#[test]
+fn parse_create_table_generated_column_modes() {
+    // PostgreSQL 18 generated columns are virtual by default, so the mode keyword is
+    // optional and VIRTUAL may also be written explicitly. All three forms round-trip
+    // without gaining or losing a mode keyword.
+    pg().verified_stmt("CREATE TABLE t (a TEXT, b TEXT GENERATED ALWAYS AS (a))");
+    pg().verified_stmt("CREATE TABLE t (a TEXT, b TEXT GENERATED ALWAYS AS (a) VIRTUAL)");
+    pg().verified_stmt("CREATE TABLE t (a TEXT, b TEXT GENERATED ALWAYS AS (a) STORED)");
+
+    // PostgreSQL 18 pg_dump emits generated virtual columns with no mode keyword.
+    pg().one_statement_parses_to(
+        r#"CREATE TABLE users (
+    first_name text NOT NULL,
+    last_name text NOT NULL,
+    name character varying(255) GENERATED ALWAYS AS (((first_name || ' '::text) || last_name)) NOT NULL
+)"#,
+        "CREATE TABLE users (\
+        first_name TEXT NOT NULL, \
+        last_name TEXT NOT NULL, \
+        name CHARACTER VARYING(255) GENERATED ALWAYS AS (((first_name || ' '::TEXT) || last_name)) NOT NULL)",
+    );
+}


### PR DESCRIPTION
Fixes #2407.

`PostgreSqlDialect` required `STORED` after `GENERATED ALWAYS AS (expr)`, so it rejected both the omitted mode and an explicit `VIRTUAL`:

```
CREATE TABLE users (..., name character varying(255)
    GENERATED ALWAYS AS (((first_name || ' '::text) || last_name)) NOT NULL);
-- Expected: STORED, found: NOT at Line: 6, Column: 9

CREATE TABLE users (a text, name text GENERATED ALWAYS AS (a) VIRTUAL);
-- Expected: STORED, found: VIRTUAL at Line: 1, Column: 63
```

PostgreSQL 18 documents the grammar as `GENERATED ALWAYS AS ( generation_expr ) [ STORED | VIRTUAL ]`, with `VIRTUAL` as the default when the keyword is omitted.

This removes the `PostgreSqlDialect` special case so the dialect falls back to the shared handling, which already parses both forms and round-trips them unchanged. `STORED` is unaffected.
