### PR TITLE
Visit CreateView name as a relation

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -4386,6 +4386,7 @@ pub struct CreateView {
     /// <https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax>
     pub secure: bool,
     /// View name
+    #[cfg_attr(feature = "visitor", visit(with = "visit_relation"))]
     pub name: ObjectName,
     /// If `if_not_exists` is true, this flag is set to true if the view name comes before the `IF NOT EXISTS` clause.
     /// Example:

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -1242,6 +1242,27 @@ mod tests {
         do_visit("SELECT a, b FROM t", &mut visitor);
         assert_eq!(visitor.idents, vec!["a", "b", "t"]);
     }
+
+    #[derive(Default)]
+    struct RelationVisitor {
+        relations: Vec<String>,
+    }
+
+    impl Visitor for RelationVisitor {
+        type Break = ();
+
+        fn pre_visit_relation(&mut self, relation: &ObjectName) -> ControlFlow<Self::Break> {
+            self.relations.push(relation.to_string());
+            ControlFlow::Continue(())
+        }
+    }
+
+    #[test]
+    fn test_visit_create_view_name_as_relation() {
+        let mut visitor = RelationVisitor::default();
+        do_visit("CREATE VIEW db1.v AS SELECT * FROM t", &mut visitor);
+        assert_eq!(visitor.relations, vec!["db1.v", "t"]);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`visit_relations` / `visit_relations_mut` did not visit the view name in `CREATE VIEW` statements:

```rust
let statements = Parser::parse_sql(&GenericDialect {}, "CREATE VIEW db1.v AS SELECT * FROM t")?;
// visit_relations yielded only `t`, not `db1.v`
```

`CreateTable`, `CreateIndex`, `Msck`, and `AlterTable` already annotate their object names with `visit(with = "visit_relation")` — `CreateView.name` was missing the annotation. This PR adds it, so tools that inspect or rewrite relation references (e.g. schema rewriters) see the view name too.
