### PR TITLE
MSSQL: Support PROC as CREATE PROCEDURE abbreviation

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1251,6 +1251,12 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if this dialect supports `PROC` as an abbreviation for
+    /// `PROCEDURE` in a `CREATE` statement.
+    fn supports_create_proc_syntax(&self) -> bool {
+        false
+    }
+
     /// Returns true if the dialect accepts a comma-separated list of table-level
     /// options placed between the table name and the column-list parenthesis, e.g.
     ///

--- a/src/dialect/mssql.rs
+++ b/src/dialect/mssql.rs
@@ -71,6 +71,10 @@ impl Dialect for MsSqlDialect {
         true
     }
 
+    fn supports_create_proc_syntax(&self) -> bool {
+        true
+    }
+
     fn supports_connect_by(&self) -> bool {
         true
     }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -819,6 +819,7 @@ define_keywords!(
     PRINT,
     PRIOR,
     PRIVILEGES,
+    PROC,
     PROCEDURE,
     PROCESSLIST,
     PROFILE,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5334,7 +5334,9 @@ impl<'a> Parser<'a> {
             self.parse_create_collation().map(Into::into)
         } else if self.parse_keyword(Keyword::TYPE) {
             self.parse_create_type()
-        } else if self.parse_keyword(Keyword::PROCEDURE) {
+        } else if self.parse_keyword(Keyword::PROCEDURE)
+            || self.dialect.supports_create_proc_syntax() && self.parse_keyword(Keyword::PROC)
+        {
             self.parse_create_procedure(or_alter)
         } else if self.parse_keyword(Keyword::CONNECTOR) {
             self.parse_create_connector().map(Into::into)

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -2925,3 +2925,20 @@ fn parse_mssql_money_constants() {
         expr_from_projection(only(&select.projection)),
     );
 }
+
+#[test]
+fn parse_create_proc() {
+    ms().one_statement_parses_to(
+        "CREATE PROC test AS BEGIN SELECT 1; END",
+        "CREATE PROCEDURE test AS BEGIN SELECT 1; END",
+    );
+    ms().one_statement_parses_to(
+        "CREATE OR ALTER PROC test AS BEGIN SELECT 1; END",
+        "CREATE OR ALTER PROCEDURE test AS BEGIN SELECT 1; END",
+    );
+
+    TestedDialects::new(vec![Box::new(GenericDialect {})])
+        .parse_sql_statements("CREATE PROC test AS BEGIN SELECT 1; END")
+        .expect_err("PROC should remain MSSQL-specific");
+    ms_and_generic().verified_stmt("SELECT proc FROM jobs");
+}


### PR DESCRIPTION
Adds support for the T-SQL `PROC` abbreviation in both `CREATE PROC` and `CREATE OR ALTER PROC`.

The parser gates the syntax through a dialect capability and normalizes the AST display to `PROCEDURE`. Tests also verify that `CREATE PROC` remains MSSQL-specific and that `proc` can still be used as an identifier.

Reference: https://learn.microsoft.com/en-us/sql/t-sql/statements/create-procedure-transact-sql
