### PR TITLE
Redshift: allow INTERVAL as a column name

### DIFF
--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -16,9 +16,11 @@
 // under the License.
 
 use crate::dialect::Dialect;
+use crate::keywords::Keyword;
 use core::iter::Peekable;
 use core::str::Chars;
 
+use super::keywords::RESERVED_FOR_IDENTIFIER;
 use super::PostgreSqlDialect;
 
 /// A [`Dialect`] for [RedShift](https://aws.amazon.com/redshift/)
@@ -174,5 +176,15 @@ impl Dialect for RedshiftSqlDialect {
 
     fn supports_window_function_null_treatment_arg(&self) -> bool {
         true
+    }
+
+    /// `INTERVAL` is listed as reserved in Redshift docs but the actual parser allows it as an
+    /// identifier, consistent with pgsql.
+    fn is_reserved_for_identifier(&self, kw: Keyword) -> bool {
+        if matches!(kw, Keyword::INTERVAL) {
+            false
+        } else {
+            RESERVED_FOR_IDENTIFIER.contains(&kw)
+        }
     }
 }

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -552,3 +552,8 @@ fn parse_unpivot_expression() {
     );
     dialects.verified_stmt("SELECT t.id, k, v FROM test_colors AS t, UNPIVOT t AS v AT k");
 }
+
+#[test]
+fn test_interval_as_column_name() {
+    redshift().verified_stmt("SELECT * FROM table_name WHERE interval = 78");
+}


### PR DESCRIPTION
Redshift's actual parser allows `INTERVAL` as an unquoted identifier (consistent with its PostgreSQL base), despite the docs listing it as reserved. This mirrors the existing PostgreSQL dialect override.

Example that now parses:
```sql
SELECT * FROM table_name WHERE interval = 78
```