### PR TITLE
Add ordered bind placeholder dialect metadata

### DIFF
--- a/derive/src/dialect.rs
+++ b/derive/src/dialect.rs
@@ -23,15 +23,15 @@ use std::collections::HashSet;
 use syn::{
     braced,
     parse::{Parse, ParseStream},
-    Error, File, FnArg, Ident, Item, LitBool, LitChar, Pat, ReceiverKind, ReturnType, Signature,
-    Token, TraitItem, Type,
+    Error, Expr, File, FnArg, Ident, Item, LitBool, LitChar, Pat, ReceiverKind, ReturnType,
+    Signature, Token, TraitItem, Type,
 };
 
 /// Override value types supported by the macro
 pub(crate) enum Override {
     Bool(LitBool),
     Char(LitChar),
-    None,
+    Expr(Expr),
 }
 
 /// Parsed input for the `derive_dialect!` macro
@@ -80,20 +80,8 @@ impl Parse for DeriveDialectInput {
                                 Override::Bool(content.parse()?)
                             } else if content.peek(LitChar) {
                                 Override::Char(content.parse()?)
-                            } else if content.peek(Ident) {
-                                let ident: Ident = content.parse()?;
-                                if ident == "None" {
-                                    Override::None
-                                } else {
-                                    return Err(Error::new(
-                                        ident.span(),
-                                        format!("Expected `true`, `false`, a char, or `None`, found `{ident}`"),
-                                    ));
-                                }
                             } else {
-                                return Err(
-                                    content.error("Expected `true`, `false`, a char, or `None`")
-                                );
+                                Override::Expr(content.parse()?)
                             };
                             overrides.push((key, value));
                             if content.peek(Token![,]) {
@@ -136,6 +124,7 @@ fn derive_dialect_inner(input: DeriveDialectInput) -> syn::Result<TokenStream> {
     let methods = extract_dialect_methods(&file)?;
 
     // Validate overrides
+    let method_names: HashSet<_> = methods.iter().map(|m| m.name.to_string()).collect();
     let bool_names: HashSet<_> = methods
         .iter()
         .filter(|m| is_bool_method(&m.signature))
@@ -143,6 +132,12 @@ fn derive_dialect_inner(input: DeriveDialectInput) -> syn::Result<TokenStream> {
         .collect();
     for (key, value) in &input.overrides {
         let key_str = key.to_string();
+        if !method_names.contains(&key_str) {
+            return Err(Error::new(
+                key.span(),
+                format!("Unknown method `{key_str}`"),
+            ));
+        }
         match value {
             Override::Bool(_) if !bool_names.contains(&key_str) => {
                 return Err(Error::new(
@@ -150,10 +145,10 @@ fn derive_dialect_inner(input: DeriveDialectInput) -> syn::Result<TokenStream> {
                     format!("Unknown boolean method `{key_str}`"),
                 ));
             }
-            Override::Char(_) | Override::None if key_str != "identifier_quote_style" => {
+            Override::Char(_) if key_str != "identifier_quote_style" => {
                 return Err(Error::new(
                     key.span(),
-                    format!("Char/None only valid for `identifier_quote_style`, not `{key_str}`"),
+                    format!("Char only valid for `identifier_quote_style`, not `{key_str}`"),
                 ));
             }
             _ => {}
@@ -214,10 +209,9 @@ fn generate_derived_dialect(input: &DeriveDialectInput, methods: &[DialectMethod
                     fn identifier_quote_style(&self, _: &str) -> Option<char> { Some(#c) }
                 }
             }
-            Some(Override::None) => {
-                quote_spanned! { method_name.span() =>
-                    fn identifier_quote_style(&self, _: &str) -> Option<char> { None }
-                }
+            Some(Override::Expr(expr)) => {
+                let sig = &method.signature;
+                quote_spanned! { method_name.span() => #sig { #expr } }
             }
             None => delegate(method),
         }
@@ -230,7 +224,7 @@ fn generate_derived_dialect(input: &DeriveDialectInput, methods: &[DialectMethod
             use ::core::iter::Peekable;
             use ::core::str::Chars;
             use sqlparser::ast::{ColumnOption, Expr, GranteesType, Ident, ObjectNamePart, Statement};
-            use sqlparser::dialect::{Dialect, Precedence};
+            use sqlparser::dialect::{BindPlaceholderStyle, Dialect, Precedence};
             use sqlparser::keywords::Keyword;
             use sqlparser::parser::{Parser, ParserError};
 

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -167,6 +167,17 @@ macro_rules! dialect_is {
     }
 }
 
+/// Placeholder spelling for ordered unnamed bind parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum BindPlaceholderStyle {
+    /// `?`
+    QuestionMark,
+    /// `$1`, `$2`, ...
+    DollarNumbered,
+}
+
 /// Encapsulates the differences between SQL implementations.
 ///
 /// # SQL Dialects
@@ -251,6 +262,15 @@ pub trait Dialect: Debug + Any {
 
     /// Return the character used to quote identifiers.
     fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
+        None
+    }
+
+    /// Return the placeholder syntax this server accepts for ordered unnamed bind parameters.
+    ///
+    /// This describes the server contract rather than every placeholder the parser can tokenize.
+    /// `None` means this dialect does not specify an ordered bind syntax.
+    /// See [`Dialect::supports_dollar_placeholder`] for SQLite-style named `$name` placeholders.
+    fn ordered_bind_placeholder_style(&self) -> Option<BindPlaceholderStyle> {
         None
     }
 
@@ -1112,8 +1132,11 @@ pub trait Dialect: Debug + Any {
         false
     }
 
-    /// Returns true if this dialect allows dollar placeholders
-    /// e.g. `SELECT $var` (SQLite)
+    /// Returns true if this dialect allows SQLite-style named dollar placeholders,
+    /// for example `SELECT $name`.
+    ///
+    /// This does not describe PostgreSQL-style ordered binds such as `SELECT $1`.
+    /// See [`Dialect::ordered_bind_placeholder_style`].
     fn supports_dollar_placeholder(&self) -> bool {
         false
     }
@@ -2001,6 +2024,7 @@ mod tests {
                 supports_order_by_all = true,
                 supports_nested_comments = true,
                 supports_triple_quoted_string = true,
+                ordered_bind_placeholder_style = Some(BindPlaceholderStyle::DollarNumbered),
             },
         );
         let dialect = EnhancedGenericDialect::new();
@@ -2008,6 +2032,10 @@ mod tests {
         assert!(dialect.supports_order_by_all());
         assert!(dialect.supports_nested_comments());
         assert!(dialect.supports_triple_quoted_string());
+        assert_eq!(
+            dialect.ordered_bind_placeholder_style(),
+            Some(BindPlaceholderStyle::DollarNumbered)
+        );
 
         let d: &dyn Dialect = &dialect;
         assert!(d.is::<GenericDialect>());
@@ -2038,6 +2066,23 @@ mod tests {
             let actual = dialect.identifier_quote_style(ident);
 
             assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn ordered_bind_placeholder_style() {
+        let tests: Vec<(&dyn Dialect, Option<BindPlaceholderStyle>)> = vec![
+            (&GenericDialect {}, None),
+            (&MySqlDialect {}, Some(BindPlaceholderStyle::QuestionMark)),
+            (
+                &PostgreSqlDialect {},
+                Some(BindPlaceholderStyle::DollarNumbered),
+            ),
+            (&SQLiteDialect {}, Some(BindPlaceholderStyle::QuestionMark)),
+        ];
+
+        for (dialect, expected) in tests {
+            assert_eq!(dialect.ordered_bind_placeholder_style(), expected);
         }
     }
 
@@ -2075,6 +2120,10 @@ mod tests {
 
             fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
                 self.0.identifier_quote_style(identifier)
+            }
+
+            fn ordered_bind_placeholder_style(&self) -> Option<BindPlaceholderStyle> {
+                self.0.ordered_bind_placeholder_style()
             }
 
             fn supports_string_literal_backslash_escape(&self) -> bool {
@@ -2144,6 +2193,10 @@ mod tests {
         let statement = r#"SELECT 'Wayne\'s World'"#;
         let res1 = Parser::parse_sql(&MySqlDialect {}, statement);
         let res2 = Parser::parse_sql(&WrappedDialect(MySqlDialect {}), statement);
+        assert_eq!(
+            WrappedDialect(MySqlDialect {}).ordered_bind_placeholder_style(),
+            Some(BindPlaceholderStyle::QuestionMark)
+        );
         assert!(res1.is_ok());
         assert_eq!(res1, res2);
     }

--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -20,7 +20,7 @@ use alloc::boxed::Box;
 
 use crate::{
     ast::{BinaryOperator, Expr, LockTable, LockTableType, Statement},
-    dialect::Dialect,
+    dialect::{BindPlaceholderStyle, Dialect},
     keywords::Keyword,
     parser::{Parser, ParserError},
 };
@@ -65,6 +65,10 @@ impl Dialect for MySqlDialect {
 
     fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
         Some('`')
+    }
+
+    fn ordered_bind_placeholder_style(&self) -> Option<BindPlaceholderStyle> {
+        Some(BindPlaceholderStyle::QuestionMark)
     }
 
     // See https://dev.mysql.com/doc/refman/8.0/en/string-literals.html#character-escape-sequences

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -28,7 +28,7 @@
 // limitations under the License.
 use log::debug;
 
-use crate::dialect::{Dialect, Precedence};
+use crate::dialect::{BindPlaceholderStyle, Dialect, Precedence};
 use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
 use crate::tokenizer::Token;
@@ -75,6 +75,10 @@ const OR_PREC: u8 = 10;
 impl Dialect for PostgreSqlDialect {
     fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
         Some('"')
+    }
+
+    fn ordered_bind_placeholder_style(&self) -> Option<BindPlaceholderStyle> {
+        Some(BindPlaceholderStyle::DollarNumbered)
     }
 
     fn is_delimited_identifier_start(&self, ch: char) -> bool {

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -20,7 +20,7 @@ use alloc::boxed::Box;
 
 use crate::ast::BinaryOperator;
 use crate::ast::{Expr, Statement};
-use crate::dialect::Dialect;
+use crate::dialect::{BindPlaceholderStyle, Dialect};
 use crate::keywords::Keyword;
 use crate::parser::{Parser, ParserError};
 
@@ -44,6 +44,10 @@ impl Dialect for SQLiteDialect {
 
     fn identifier_quote_style(&self, _identifier: &str) -> Option<char> {
         Some('`')
+    }
+
+    fn ordered_bind_placeholder_style(&self) -> Option<BindPlaceholderStyle> {
+        Some(BindPlaceholderStyle::QuestionMark)
     }
 
     fn is_identifier_start(&self, ch: char) -> bool {


### PR DESCRIPTION
This PR adds `Dialect::ordered_bind_placeholder_style()` to provide the information of whether a Dialect's ordered bind placeholders should be written as `?` or `$1`.