### PR TITLE
Preserve numeric compound field access display

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1487,6 +1487,9 @@ pub enum AccessExpr {
 impl fmt::Display for AccessExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            AccessExpr::Dot(Expr::Value(value)) if matches!(value.value, Value::Number(_, _)) => {
+                write!(f, " . {value}")
+            }
             AccessExpr::Dot(expr) => write!(f, ".{expr}"),
             AccessExpr::Subscript(subscript) => write!(f, "[{subscript}]"),
         }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -9852,3 +9852,14 @@ fn parse_alter_table_constraint_check_no_inherit() {
     }
     pg_and_generic().verified_stmt("ALTER TABLE docs ADD CONSTRAINT c CHECK (id > 0) NO INHERIT");
 }
+
+#[test]
+fn parse_compound_field_access_numeric_display() {
+    let sql = "SELECT * FROM t WHERE CASE WHEN a = 1 THEN b ELSE c END . 2";
+    let mut statements = pg().parse_sql_statements(sql).unwrap();
+    assert_eq!(statements.len(), 1);
+    let statement = statements.pop().unwrap();
+    let displayed = statement.to_string();
+    let reparsed = pg().parse_sql_statements(&displayed).unwrap();
+    assert_eq!(vec![statement], reparsed);
+}


### PR DESCRIPTION
`CASE ... END . 2` parsed successfully, but its printed form became `CASE ... END.2`. That cannot be parsed again because `.2` is tokenized as a number.

This keeps a space around numeric dotted field access, so the printed statement reparses to the same tree.