### PR TITLE
Parse PostgreSQL MERGE DO NOTHING actions

### DIFF
--- a/src/ast/dml.rs
+++ b/src/ast/dml.rs
@@ -608,6 +608,13 @@ pub enum MergeAction {
         /// The `DELETE` token that starts the sub-expression.
         delete_token: AttachedToken,
     },
+    /// A `DO NOTHING` clause.
+    DoNothing {
+        /// The `DO` token that starts the sub-expression.
+        do_token: AttachedToken,
+        /// The `NOTHING` token that ends the sub-expression.
+        nothing_token: AttachedToken,
+    },
 }
 
 impl Display for MergeAction {
@@ -621,6 +628,9 @@ impl Display for MergeAction {
             }
             MergeAction::Delete { .. } => {
                 write!(f, "DELETE")
+            }
+            MergeAction::DoNothing { .. } => {
+                write!(f, "DO NOTHING")
             }
         }
     }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -2557,6 +2557,10 @@ impl Spanned for MergeAction {
             MergeAction::Insert(expr) => expr.span(),
             MergeAction::Update(expr) => expr.span(),
             MergeAction::Delete { delete_token } => delete_token.0.span,
+            MergeAction::DoNothing {
+                do_token,
+                nothing_token,
+            } => do_token.0.span.union(&nothing_token.0.span),
         }
     }
 }
@@ -2909,6 +2913,7 @@ WHERE id = 1
 
               WHEN MATCHED AND target_table.x != 'X' THEN   DELETE
         WHEN NOT MATCHED AND 1 THEN INSERT (product, quantity) ROW
+        WHEN MATCHED THEN DO NOTHING
         "#;
 
         let r = Parser::parse_sql(&crate::dialect::GenericDialect, sql).unwrap();
@@ -2917,7 +2922,7 @@ WHERE id = 1
         // ~ assert the span of the whole statement
         let stmt_span = r[0].span();
         assert_eq!(stmt_span.start, (4, 9).into());
-        assert_eq!(stmt_span.end, (16, 67).into());
+        assert_eq!(stmt_span.end, (17, 37).into());
 
         // ~ individual tokens within the statement
         let Statement::Merge(Merge {
@@ -2937,7 +2942,7 @@ WHERE id = 1
             merge_token.0.span,
             Span::new(Location::new(4, 9), Location::new(4, 14))
         );
-        assert_eq!(clauses.len(), 4);
+        assert_eq!(clauses.len(), 5);
 
         // ~ the INSERT clause's TOKENs
         assert_eq!(
@@ -3017,6 +3022,31 @@ WHERE id = 1
             );
         } else {
             panic!("not a MERGE INSERT clause");
+        }
+
+        assert_eq!(
+            clauses[4].when_token.0.span,
+            Span::new(Location::new(17, 9), Location::new(17, 13))
+        );
+        if let MergeAction::DoNothing {
+            do_token,
+            nothing_token,
+        } = &clauses[4].action
+        {
+            assert_eq!(
+                do_token.0.span,
+                Span::new(Location::new(17, 27), Location::new(17, 29))
+            );
+            assert_eq!(
+                nothing_token.0.span,
+                Span::new(Location::new(17, 30), Location::new(17, 37))
+            );
+            assert_eq!(
+                clauses[4].action.span(),
+                Span::new(Location::new(17, 27), Location::new(17, 37))
+            );
+        } else {
+            panic!("not a MERGE DO NOTHING clause");
         }
 
         assert!(output.is_none());

--- a/src/parser/merge.rs
+++ b/src/parser/merge.rs
@@ -107,7 +107,16 @@ impl Parser<'_> {
                 Keyword::UPDATE,
                 Keyword::INSERT,
                 Keyword::DELETE,
+                Keyword::DO,
             ]) {
+                Some(Keyword::DO) => {
+                    let do_token = self.get_current_token().clone();
+                    let nothing_token = self.expect_keyword(Keyword::NOTHING)?;
+                    MergeAction::DoNothing {
+                        do_token: do_token.into(),
+                        nothing_token: nothing_token.into(),
+                    }
+                }
                 Some(Keyword::UPDATE) => {
                     if matches!(
                         clause_kind,
@@ -212,7 +221,7 @@ impl Parser<'_> {
                 }
                 _ => {
                     return parser_err!(
-                        "expected UPDATE, DELETE or INSERT in merge clause",
+                        "expected UPDATE, DELETE, INSERT or DO NOTHING in merge clause",
                         self.peek_token_ref().span.start
                     );
                 }

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -9875,10 +9875,6 @@ fn parse_merge_do_nothing() {
             }
         ]
     ));
-}
-
-#[test]
-fn reject_merge_do_without_nothing() {
     assert_eq!(
         pg_and_generic().parse_sql_statements(
             "MERGE INTO target USING source ON target.id = source.id WHEN MATCHED THEN DO UPDATE"

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -9883,6 +9883,9 @@ fn parse_merge_do_nothing() {
             "Expected: NOTHING, found: UPDATE".into()
         ))
     );
+}
+
+#[test]
 fn parse_compound_field_access_numeric_display() {
     let sql = "SELECT * FROM t WHERE CASE WHEN a = 1 THEN b ELSE c END . 2";
     let mut statements = pg().parse_sql_statements(sql).unwrap();

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -9852,3 +9852,39 @@ fn parse_alter_table_constraint_check_no_inherit() {
     }
     pg_and_generic().verified_stmt("ALTER TABLE docs ADD CONSTRAINT c CHECK (id > 0) NO INHERIT");
 }
+
+#[test]
+fn parse_merge_do_nothing() {
+    let Statement::Merge(merge) = pg_and_generic().verified_stmt(
+        "MERGE INTO target USING source ON target.id = source.id WHEN MATCHED THEN DO NOTHING WHEN NOT MATCHED THEN DO NOTHING",
+    ) else {
+        panic!("expected MERGE statement");
+    };
+    assert!(matches!(
+        merge.clauses.as_slice(),
+        [
+            MergeClause {
+                clause_kind: MergeClauseKind::Matched,
+                action: MergeAction::DoNothing { .. },
+                ..
+            },
+            MergeClause {
+                clause_kind: MergeClauseKind::NotMatched,
+                action: MergeAction::DoNothing { .. },
+                ..
+            }
+        ]
+    ));
+}
+
+#[test]
+fn reject_merge_do_without_nothing() {
+    assert_eq!(
+        pg_and_generic().parse_sql_statements(
+            "MERGE INTO target USING source ON target.id = source.id WHEN MATCHED THEN DO UPDATE"
+        ),
+        Err(ParserError::ParserError(
+            "Expected: NOTHING, found: UPDATE".into()
+        ))
+    );
+}


### PR DESCRIPTION
`MERGE ... WHEN MATCHED THEN DO NOTHING` currently fails because merge action parsing only recognizes `UPDATE`, `DELETE`, and `INSERT`.

`DO NOTHING` has no payload, so it is represented as `MergeAction::DoNothing` while retaining both keyword spans.
