### PR TITLE
Honour operator precedence in MySQL and Spark `DIV`

### DIFF
--- a/src/dialect/mysql.rs
+++ b/src/dialect/mysql.rs
@@ -98,12 +98,12 @@ impl Dialect for MySqlDialect {
         &self,
         parser: &mut crate::parser::Parser,
         expr: &crate::ast::Expr,
-        _precedence: u8,
+        precedence: u8,
     ) -> Option<Result<crate::ast::Expr, ParserError>> {
         // Parse DIV as an operator
         if parser.parse_keyword(Keyword::DIV) {
             let left = Box::new(expr.clone());
-            let right = Box::new(match parser.parse_expr() {
+            let right = Box::new(match parser.parse_subexpr(precedence) {
                 Ok(expr) => expr,
                 Err(e) => return Some(Err(e)),
             });

--- a/src/dialect/spark.rs
+++ b/src/dialect/spark.rs
@@ -137,11 +137,11 @@ impl Dialect for SparkSqlDialect {
         &self,
         parser: &mut Parser,
         expr: &Expr,
-        _precedence: u8,
+        precedence: u8,
     ) -> Option<Result<Expr, ParserError>> {
         if parser.parse_keyword(Keyword::DIV) {
             let left = Box::new(expr.clone());
-            let right = Box::new(match parser.parse_expr() {
+            let right = Box::new(match parser.parse_subexpr(precedence) {
                 Ok(expr) => expr,
                 Err(e) => return Some(Err(e)),
             });

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3760,6 +3760,62 @@ fn parse_div_infix_propagates_parse_error() {
 }
 
 #[test]
+fn parse_div_precedence() {
+    let div = |left: Expr, right: Expr| Expr::BinaryOp {
+        left: Box::new(left),
+        op: BinaryOperator::MyIntegerDivide,
+        right: Box::new(right),
+    };
+    let num = |n: &str| Expr::value(number(n));
+
+    // `DIV` shares the precedence of `*` and `/`, so `+` must end up at the root.
+    assert_eq!(
+        Expr::BinaryOp {
+            left: Box::new(div(num("7"), num("2"))),
+            op: BinaryOperator::Plus,
+            right: Box::new(num("1")),
+        },
+        mysql().verified_expr("7 DIV 2 + 1")
+    );
+
+    // Equal precedence resolves left-associatively, both against `*` and against itself.
+    assert_eq!(
+        Expr::BinaryOp {
+            left: Box::new(div(num("9"), num("3"))),
+            op: BinaryOperator::Multiply,
+            right: Box::new(num("3")),
+        },
+        mysql().verified_expr("9 DIV 3 * 3")
+    );
+    assert_eq!(
+        div(div(num("10"), num("5")), num("2")),
+        mysql().verified_expr("10 DIV 5 DIV 2")
+    );
+
+    assert_eq!(
+        Expr::BinaryOp {
+            left: Box::new(div(Expr::Identifier(Ident::new("a")), num("2"))),
+            op: BinaryOperator::Eq,
+            right: Box::new(num("1")),
+        },
+        mysql().verified_expr("a DIV 2 = 1")
+    );
+
+    // Explicit parentheses still push the whole expression into the right operand.
+    assert_eq!(
+        div(
+            num("7"),
+            Expr::Nested(Box::new(Expr::BinaryOp {
+                left: Box::new(num("2")),
+                op: BinaryOperator::Plus,
+                right: Box::new(num("1")),
+            }))
+        ),
+        mysql().verified_expr("7 DIV (2 + 1)")
+    );
+}
+
+#[test]
 fn parse_drop_temporary_table() {
     let sql = "DROP TEMPORARY TABLE foo";
     match mysql().verified_stmt(sql) {

--- a/tests/sqlparser_spark.rs
+++ b/tests/sqlparser_spark.rs
@@ -171,6 +171,36 @@ fn test_div_literal() {
     spark().one_statement_parses_to("SELECT 10 div 3", "SELECT 10 DIV 3");
 }
 
+#[test]
+fn test_div_precedence() {
+    let div = |left: Expr, right: Expr| Expr::BinaryOp {
+        left: Box::new(left),
+        op: BinaryOperator::MyIntegerDivide,
+        right: Box::new(right),
+    };
+    let num = |n: &str| Expr::value(number(n));
+
+    // `DIV` shares the precedence of `*` and `/`, so `+` must end up at the root.
+    assert_eq!(
+        Expr::BinaryOp {
+            left: Box::new(div(num("7"), num("2"))),
+            op: BinaryOperator::Plus,
+            right: Box::new(num("1")),
+        },
+        spark().verified_expr("7 DIV 2 + 1")
+    );
+
+    // Equal precedence resolves left-associatively.
+    assert_eq!(
+        Expr::BinaryOp {
+            left: Box::new(div(num("9"), num("3"))),
+            op: BinaryOperator::Multiply,
+            right: Box::new(num("3")),
+        },
+        spark().verified_expr("9 DIV 3 * 3")
+    );
+}
+
 // --------------------------------
 // Struct support
 // --------------------------------


### PR DESCRIPTION
Fixes #2460.

`Dialect::get_next_precedence` announces `DIV` at `Precedence::MulDivModOp`, but `MySqlDialect::parse_infix`
and `SparkSqlDialect::parse_infix` both ignored their `precedence` argument and parsed the right
operand with `parse_expr()` (= `parse_subexpr(0)`), so the operand absorbed every following operator:

| SQL | Before | After / MySQL & Spark |
|---|---|---|
| `7 DIV 2 + 1` | `7 DIV (2 + 1)` = 2 | `(7 DIV 2) + 1` = 4 |
| `9 DIV 3 * 3` | `9 DIV (3 * 3)` = 1 | `(9 DIV 3) * 3` = 9 |
| `a DIV 2 = 1` | `a DIV (2 = 1)` | `(a DIV 2) = 1` |

Both engines place `DIV` with `*` and `/`: MySQL's
[operator precedence table](https://dev.mysql.com/doc/refman/8.4/en/operator-precedence.html) lists
`*, /, DIV, %, MOD` on one row, and Spark's `SqlBaseParser.g4` has
`operator=(ASTERISK | SLASH | PERCENT | DIV)` in a single left-recursive rule.

The fix threads the caller's precedence through to `parse_subexpr`, exactly as
`SqliteDialect::parse_infix` already does for `REGEXP` / `MATCH` / `GLOB` (#2419). Since
`parse_subexpr` passes the *upcoming* operator's precedence into the dialect hook, the right operand
is parsed at `MulDivModOp`, which stops it before `+` and makes `DIV` left-associative against `*`,
`/` and itself.

`Display` for `Expr::BinaryOp` emits no parentheses, so a mis-grouped tree round-trips back to the
original SQL — `verified_stmt` / `verified_expr` alone cannot catch this. The new tests therefore
assert on the tree: `tests/sqlparser_mysql.rs::parse_div_precedence` covers `+`, `*`, `DIV` against
itself, `=`, and explicit parentheses; `tests/sqlparser_spark.rs::test_div_precedence` mirrors the
first two for Spark. I confirmed both fail without the source change.

`GenericDialect` is deliberately not included — it has no `DIV` operator support, so it never
produces `MyIntegerDivide`.

Full suite green (1605 tests, up 2 from 1603), `cargo fmt --check` and
`cargo clippy --all-targets --all-features -- -D warnings` clean.

Thanks to @LucaCappelletti94, who spotted this while reviewing #2436 and wrote both the patch and the
headline test.
