### PR TITLE
Snowflake: Add DESC[RIBE] EXTERNAL VOLUME

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4558,6 +4558,11 @@ pub enum Statement {
         comment: Option<String>,
     },
     /// ```sql
+    /// DESC[RIBE] EXTERNAL VOLUME <name>
+    /// ```
+    /// See <https://docs.snowflake.com/en/sql-reference/sql/desc-external-volume>
+    DescribeExternalVolume(DescribeExternalVolume),
+    /// ```sql
     /// CREATE [ OR REPLACE ] WAREHOUSE [ IF NOT EXISTS ] <name>
     ///   [ [ WITH ] <property> = <value> [ ... ] ]
     /// ```
@@ -6293,6 +6298,7 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
+            Statement::DescribeExternalVolume(s) => write!(f, "{s}"),
             Statement::CreateWarehouse(s) => write!(f, "{s}"),
             Statement::CopyIntoSnowflake {
                 kind,
@@ -11131,6 +11137,26 @@ pub struct ShowObjects {
     pub show_options: ShowStatementOptions,
 }
 
+/// ```sql
+/// DESC[RIBE] EXTERNAL VOLUME <name>
+/// ```
+/// See <https://docs.snowflake.com/en/sql-reference/sql/desc-external-volume>
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct DescribeExternalVolume {
+    /// The keyword used, `DESC` or `DESCRIBE`.
+    pub describe_alias: DescribeAlias,
+    /// External volume name.
+    pub name: ObjectName,
+}
+
+impl fmt::Display for DescribeExternalVolume {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} EXTERNAL VOLUME {}", self.describe_alias, self.name)
+    }
+}
+
 /// MSSQL's json null clause
 ///
 /// ```plaintext
@@ -12623,6 +12649,12 @@ impl From<ExportData> for Statement {
 impl From<CreateUser> for Statement {
     fn from(c: CreateUser) -> Self {
         Self::CreateUser(c)
+    }
+}
+
+impl From<DescribeExternalVolume> for Statement {
+    fn from(d: DescribeExternalVolume) -> Self {
+        Self::DescribeExternalVolume(d)
     }
 }
 

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -523,6 +523,7 @@ impl Spanned for Statement {
             Statement::Vacuum(..) => Span::empty(),
             Statement::AlterUser(..) => Span::empty(),
             Statement::Reset(..) => Span::empty(),
+            Statement::DescribeExternalVolume(..) => Span::empty(),
         }
     }
 }

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -29,12 +29,13 @@ use crate::ast::helpers::stmt_data_loading::{
 use crate::ast::{
     AlterTable, AlterTableOperation, AlterTableType, CatalogSyncNamespaceMode, ColumnOption,
     ColumnPolicy, ColumnPolicyProperty, ContactEntry, CopyIntoSnowflakeKind, CreateTable,
-    CreateTableLikeKind, DollarQuotedString, Ident, IdentityParameters, IdentityProperty,
-    IdentityPropertyFormatKind, IdentityPropertyKind, IdentityPropertyOrder, InitializeKind,
-    Insert, MultiTableInsertIntoClause, MultiTableInsertType, MultiTableInsertValue,
-    MultiTableInsertValues, MultiTableInsertWhenClause, ObjectName, ObjectNamePart,
-    RefreshModeKind, RowAccessPolicy, ShowObjects, SqlOption, Statement, StorageLifecyclePolicy,
-    StorageSerializationPolicy, TableObject, TagsColumnOption, Value, WrappedCollection,
+    CreateTableLikeKind, DescribeAlias, DescribeExternalVolume, DollarQuotedString, Ident,
+    IdentityParameters, IdentityProperty, IdentityPropertyFormatKind, IdentityPropertyKind,
+    IdentityPropertyOrder, InitializeKind, Insert, MultiTableInsertIntoClause,
+    MultiTableInsertType, MultiTableInsertValue, MultiTableInsertValues,
+    MultiTableInsertWhenClause, ObjectName, ObjectNamePart, RefreshModeKind, RowAccessPolicy,
+    ShowObjects, SqlOption, Statement, StorageLifecyclePolicy, StorageSerializationPolicy,
+    TableObject, TagsColumnOption, Value, WrappedCollection,
 };
 use crate::dialect::{Dialect, Precedence};
 use crate::keywords::Keyword;
@@ -284,6 +285,20 @@ impl Dialect for SnowflakeDialect {
                 _ => return Some(parser.expected_ref("SET or UNSET", parser.peek_token_ref())),
             };
             return Some(parse_alter_session(parser, set));
+        }
+
+        if let Some(kw) = parser.parse_one_of_keywords(&[Keyword::DESC, Keyword::DESCRIBE]) {
+            if parser.parse_keywords(&[Keyword::EXTERNAL, Keyword::VOLUME]) {
+                // DESC[RIBE] EXTERNAL VOLUME
+                let describe_alias = if kw == Keyword::DESC {
+                    DescribeAlias::Desc
+                } else {
+                    DescribeAlias::Describe
+                };
+                return Some(parse_describe_external_volume(describe_alias, parser));
+            }
+            // not EXTERNAL VOLUME — put back DESC/DESCRIBE
+            parser.prev_token();
         }
 
         if parser.parse_keyword(Keyword::CREATE) {
@@ -1987,4 +2002,17 @@ fn parse_multi_table_insert_when_clauses(
     }
 
     Ok((when_clauses, else_clause))
+}
+
+/// Parse `DESC[RIBE] EXTERNAL VOLUME <name>`
+fn parse_describe_external_volume(
+    describe_alias: DescribeAlias,
+    parser: &mut Parser,
+) -> Result<Statement, ParserError> {
+    let name = parser.parse_object_name(false)?;
+    Ok(DescribeExternalVolume {
+        describe_alias,
+        name,
+    }
+    .into())
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -4912,3 +4912,32 @@ fn test_select_dollar_column_from_stage() {
     // With table function args, without alias
     snowflake().verified_stmt("SELECT $1, $2 FROM @mystage1(file_format => 'myformat')");
 }
+
+#[test]
+fn test_describe_external_volume() {
+    match snowflake().verified_stmt("DESCRIBE EXTERNAL VOLUME my_vol") {
+        Statement::DescribeExternalVolume(DescribeExternalVolume {
+            describe_alias,
+            name,
+        }) => {
+            assert_eq!(DescribeAlias::Describe, describe_alias);
+            assert_eq!("my_vol", name.to_string());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_desc_external_volume() {
+    // The DESC spelling is preserved on round-trip.
+    match snowflake().verified_stmt("DESC EXTERNAL VOLUME my_vol") {
+        Statement::DescribeExternalVolume(DescribeExternalVolume {
+            describe_alias,
+            name,
+        }) => {
+            assert_eq!(DescribeAlias::Desc, describe_alias);
+            assert_eq!("my_vol", name.to_string());
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
Snowflake's `DESC[RIBE] EXTERNAL VOLUME` did not parse:

```sql
DESCRIBE EXTERNAL VOLUME my_vol;
```

This adds a `DescribeExternalVolume` statement to the Snowflake dialect. The `DESC` vs `DESCRIBE` spelling is preserved on round-trip via the existing `DescribeAlias`.

See the [Snowflake `DESC EXTERNAL VOLUME` docs](https://docs.snowflake.com/en/sql-reference/sql/desc-external-volume).

Split out of #2397 per review feedback, alongside the CREATE/DROP (#2475), ALTER (#2474), and SHOW (#2473) PRs.

