### PR TITLE
Snowflake: Add SHOW EXTERNAL VOLUMES

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4558,6 +4558,11 @@ pub enum Statement {
         comment: Option<String>,
     },
     /// ```sql
+    /// SHOW EXTERNAL VOLUMES [LIKE '<pattern>']
+    /// ```
+    /// See <https://docs.snowflake.com/en/sql-reference/sql/show-external-volumes>
+    ShowExternalVolumes(ShowExternalVolumes),
+    /// ```sql
     /// CREATE [ OR REPLACE ] WAREHOUSE [ IF NOT EXISTS ] <name>
     ///   [ [ WITH ] <property> = <value> [ ... ] ]
     /// ```
@@ -6293,6 +6298,7 @@ impl fmt::Display for Statement {
                 }
                 Ok(())
             }
+            Statement::ShowExternalVolumes(s) => write!(f, "{s}"),
             Statement::CreateWarehouse(s) => write!(f, "{s}"),
             Statement::CopyIntoSnowflake {
                 kind,
@@ -11131,6 +11137,28 @@ pub struct ShowObjects {
     pub show_options: ShowStatementOptions,
 }
 
+/// ```sql
+/// SHOW EXTERNAL VOLUMES [LIKE '<pattern>']
+/// ```
+/// See <https://docs.snowflake.com/en/sql-reference/sql/show-external-volumes>
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "visitor", derive(Visit, VisitMut))]
+pub struct ShowExternalVolumes {
+    /// Optional filter (e.g. `LIKE`).
+    pub filter: Option<ShowStatementFilter>,
+}
+
+impl fmt::Display for ShowExternalVolumes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SHOW EXTERNAL VOLUMES")?;
+        if let Some(ref filter) = self.filter {
+            write!(f, " {filter}")?;
+        }
+        Ok(())
+    }
+}
+
 /// MSSQL's json null clause
 ///
 /// ```plaintext
@@ -12623,6 +12651,12 @@ impl From<ExportData> for Statement {
 impl From<CreateUser> for Statement {
     fn from(c: CreateUser) -> Self {
         Self::CreateUser(c)
+    }
+}
+
+impl From<ShowExternalVolumes> for Statement {
+    fn from(s: ShowExternalVolumes) -> Self {
+        Self::ShowExternalVolumes(s)
     }
 }
 

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -523,6 +523,7 @@ impl Spanned for Statement {
             Statement::Vacuum(..) => Span::empty(),
             Statement::AlterUser(..) => Span::empty(),
             Statement::Reset(..) => Span::empty(),
+            Statement::ShowExternalVolumes(..) => Span::empty(),
         }
     }
 }

--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -33,8 +33,9 @@ use crate::ast::{
     IdentityPropertyFormatKind, IdentityPropertyKind, IdentityPropertyOrder, InitializeKind,
     Insert, MultiTableInsertIntoClause, MultiTableInsertType, MultiTableInsertValue,
     MultiTableInsertValues, MultiTableInsertWhenClause, ObjectName, ObjectNamePart,
-    RefreshModeKind, RowAccessPolicy, ShowObjects, SqlOption, Statement, StorageLifecyclePolicy,
-    StorageSerializationPolicy, TableObject, TagsColumnOption, Value, WrappedCollection,
+    RefreshModeKind, RowAccessPolicy, ShowExternalVolumes, ShowObjects, SqlOption, Statement,
+    StorageLifecyclePolicy, StorageSerializationPolicy, TableObject, TagsColumnOption, Value,
+    WrappedCollection,
 };
 use crate::dialect::{Dialect, Precedence};
 use crate::keywords::Keyword;
@@ -368,6 +369,9 @@ impl Dialect for SnowflakeDialect {
         }
 
         if parser.parse_keyword(Keyword::SHOW) {
+            if parser.parse_keywords(&[Keyword::EXTERNAL, Keyword::VOLUMES]) {
+                return Some(parse_show_external_volumes(parser));
+            }
             let terse = parser.parse_keyword(Keyword::TERSE);
             if parser.parse_keyword(Keyword::OBJECTS) {
                 return Some(parse_show_objects(terse, parser));
@@ -1987,4 +1991,10 @@ fn parse_multi_table_insert_when_clauses(
     }
 
     Ok((when_clauses, else_clause))
+}
+
+/// Parse `SHOW EXTERNAL VOLUMES [LIKE '<pattern>']`
+fn parse_show_external_volumes(parser: &mut Parser) -> Result<Statement, ParserError> {
+    let filter = parser.parse_show_statement_filter()?;
+    Ok(ShowExternalVolumes { filter }.into())
 }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -1162,6 +1162,7 @@ define_keywords!(
     VIRTUAL,
     VOLATILE,
     VOLUME,
+    VOLUMES,
     WAITFOR,
     WAREHOUSE,
     WAREHOUSES,

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -4912,3 +4912,25 @@ fn test_select_dollar_column_from_stage() {
     // With table function args, without alias
     snowflake().verified_stmt("SELECT $1, $2 FROM @mystage1(file_format => 'myformat')");
 }
+
+#[test]
+fn test_show_external_volumes() {
+    match snowflake().verified_stmt("SHOW EXTERNAL VOLUMES") {
+        Statement::ShowExternalVolumes(ShowExternalVolumes { filter }) => {
+            assert!(filter.is_none());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_show_external_volumes_like() {
+    match snowflake().verified_stmt("SHOW EXTERNAL VOLUMES LIKE 'my_%'") {
+        Statement::ShowExternalVolumes(ShowExternalVolumes {
+            filter: Some(ShowStatementFilter::Like(pattern)),
+        }) => {
+            assert_eq!("my_%", pattern);
+        }
+        _ => unreachable!(),
+    }
+}


### PR DESCRIPTION
Snowflake's `SHOW EXTERNAL VOLUMES` did not parse:

```sql
SHOW EXTERNAL VOLUMES LIKE 'my_%';
```

This adds a `ShowExternalVolumes` statement to the Snowflake dialect, reusing the existing `ShowStatementFilter` for the optional `LIKE` clause. All statements round-trip.

See the [Snowflake `SHOW EXTERNAL VOLUMES` docs](https://docs.snowflake.com/en/sql-reference/sql/show-external-volumes).

Split out of #2397 per review feedback, alongside the CREATE/DROP (#2475), ALTER (#2474), and DESC (#2472) PRs.

