### PR TITLE
Databricks: enable query and nested type syntax

### DIFF
--- a/src/dialect/databricks.rs
+++ b/src/dialect/databricks.rs
@@ -113,4 +113,24 @@ impl Dialect for DatabricksDialect {
     fn supports_select_item_multi_column_alias(&self) -> bool {
         true
     }
+
+    fn supports_map_literal_with_angle_brackets(&self) -> bool {
+        true
+    }
+
+    fn supports_string_literal_backslash_escape(&self) -> bool {
+        true
+    }
+
+    fn supports_select_wildcard_replace(&self) -> bool {
+        true
+    }
+
+    fn supports_from_first_select(&self) -> bool {
+        true
+    }
+
+    fn supports_pipe_operator(&self) -> bool {
+        true
+    }
 }

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -17318,7 +17318,7 @@ fn parse_pipeline_operator_negative_tests() {
 
     // Test that CALL with invalid function syntax fails
     assert!(dialects
-        .parse_sql_statements("SELECT * FROM users |> CALL 123invalid")
+        .parse_sql_statements("SELECT * FROM users |> CALL 123 invalid")
         .is_err());
 
     // Test that CALL with malformed arguments fails

--- a/tests/sqlparser_databricks.rs
+++ b/tests/sqlparser_databricks.rs
@@ -737,3 +737,15 @@ fn parse_cte_without_as() {
         .parse_sql_statements("WITH cte (SELECT 1) SELECT * FROM cte")
         .is_err());
 }
+
+#[test]
+fn parse_databricks_query_entry_points() {
+    databricks().verified_stmt("CREATE TABLE t (attrs MAP<STRING, ARRAY<INT>>)");
+    databricks().one_statement_parses_to(r#"SELECT 'it\'s'"#, "SELECT 'it''s'");
+    databricks().verified_stmt("SELECT * REPLACE (upper(name) AS name) FROM source");
+    databricks().verified_stmt(
+        "CREATE VIEW cross_product AS FROM main.raw.left_table, main.raw.right_table",
+    );
+    databricks()
+        .verified_stmt("CREATE VIEW filtered AS FROM main.raw.source |> WHERE id > 0 |> SELECT id");
+}


### PR DESCRIPTION
Enable existing parser capabilities for the Databricks dialect:
- MAP<key, value> nested types
- Backslash-escaped string literals
- SELECT * REPLACE
- FROM-first queries
- Pipe syntax (|>)

The pipeline negative test now uses CALL 123 invalid because Databricks permits numeric-leading identifiers, making the previous 123invalid input valid. The replacement remains invalid for every dialect covered by the test.

References:
- [Databricks pipeline syntax](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-qry-pipeline)
- [SELECT syntax](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-qry-select)
- [MAP type](https://docs.databricks.com/aws/en/sql/language-manual/data-types/map-type)