### PR TITLE
Redshift: Support APPROXIMATE PERCENTILE_DISC

### DIFF
--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -599,6 +599,7 @@ pub trait Dialect: Debug + Any {
     }
 
     /// Does the dialect support the `APPROXIMATE PERCENTILE_DISC` function syntax?
+    /// See <https://docs.aws.amazon.com/redshift/latest/dg/r_APPROXIMATE_PERCENTILE_DISC.html>
     fn supports_approximate_percentile_disc(&self) -> bool {
         false
     }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -598,6 +598,11 @@ pub trait Dialect: Debug + Any {
         None
     }
 
+    /// Does the dialect support the `APPROXIMATE PERCENTILE_DISC` function syntax?
+    fn supports_approximate_percentile_disc(&self) -> bool {
+        false
+    }
+
     /// Does the dialect support trailing commas around the query?
     fn supports_trailing_commas(&self) -> bool {
         false

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 use crate::ast::Expr;
 use crate::dialect::Dialect;
 use crate::keywords::Keyword;

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -15,8 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::ast::Expr;
 use crate::dialect::Dialect;
 use crate::keywords::Keyword;
+use crate::parser::{Parser, ParserError};
+use crate::tokenizer::Token;
 use core::iter::Peekable;
 use core::str::Chars;
 
@@ -35,6 +38,28 @@ pub struct RedshiftSqlDialect {}
 // in the Postgres dialect, the query will be parsed as an array, while in the Redshift dialect it will
 // be a json path
 impl Dialect for RedshiftSqlDialect {
+    fn parse_prefix(&self, parser: &mut Parser) -> Option<Result<Expr, ParserError>> {
+        if matches!(&parser.peek_token_ref().token, Token::Word(word) if word.value.eq_ignore_ascii_case("approximate"))
+            && matches!(&parser.peek_nth_token_ref(1).token, Token::Word(word) if word.value.eq_ignore_ascii_case("percentile_disc"))
+        {
+            parser.next_token();
+            let function_name = match parser.parse_object_name(false) {
+                Ok(name) => name,
+                Err(error) => return Some(Err(error)),
+            };
+            return Some(
+                parser
+                    .parse_function(function_name)
+                    .map(|function| Expr::Prefixed {
+                        prefix: "APPROXIMATE".into(),
+                        value: Box::new(function),
+                    }),
+            );
+        }
+
+        None
+    }
+
     /// Determine if a character starts a potential nested quoted identifier.
     /// Example: RedShift supports the following quote styles to all mean the same thing:
     /// ```sql

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -128,6 +128,7 @@ impl Dialect for RedshiftSqlDialect {
         true
     }
 
+    /// See <https://docs.aws.amazon.com/redshift/latest/dg/r_APPROXIMATE_PERCENTILE_DISC.html>
     fn supports_approximate_percentile_disc(&self) -> bool {
         true
     }

--- a/src/dialect/redshift.rs
+++ b/src/dialect/redshift.rs
@@ -15,14 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
-
-use crate::ast::Expr;
 use crate::dialect::Dialect;
 use crate::keywords::Keyword;
-use crate::parser::{Parser, ParserError};
-use crate::tokenizer::Token;
 use core::iter::Peekable;
 use core::str::Chars;
 
@@ -41,28 +35,6 @@ pub struct RedshiftSqlDialect {}
 // in the Postgres dialect, the query will be parsed as an array, while in the Redshift dialect it will
 // be a json path
 impl Dialect for RedshiftSqlDialect {
-    fn parse_prefix(&self, parser: &mut Parser) -> Option<Result<Expr, ParserError>> {
-        if matches!(&parser.peek_token_ref().token, Token::Word(word) if word.value.eq_ignore_ascii_case("approximate"))
-            && matches!(&parser.peek_nth_token_ref(1).token, Token::Word(word) if word.value.eq_ignore_ascii_case("percentile_disc"))
-        {
-            parser.next_token();
-            let function_name = match parser.parse_object_name(false) {
-                Ok(name) => name,
-                Err(error) => return Some(Err(error)),
-            };
-            return Some(
-                parser
-                    .parse_function(function_name)
-                    .map(|function| Expr::Prefixed {
-                        prefix: "APPROXIMATE".into(),
-                        value: Box::new(function),
-                    }),
-            );
-        }
-
-        None
-    }
-
     /// Determine if a character starts a potential nested quoted identifier.
     /// Example: RedShift supports the following quote styles to all mean the same thing:
     /// ```sql
@@ -153,6 +125,10 @@ impl Dialect for RedshiftSqlDialect {
     }
 
     fn supports_string_escape_constant(&self) -> bool {
+        true
+    }
+
+    fn supports_approximate_percentile_disc(&self) -> bool {
         true
     }
 

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -121,6 +121,7 @@ define_keywords!(
     APPLICATION,
     APPLY,
     APPLYBUDGET,
+    APPROXIMATE,
     ARCHIVE,
     ARE,
     ARRAY,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1836,6 +1836,20 @@ impl<'a> Parser<'a> {
 
         let dialect = self.dialect;
 
+        if dialect.supports_approximate_percentile_disc()
+            && matches!(&self.peek_token_ref().token, Token::Word(word) if word.value.eq_ignore_ascii_case("approximate"))
+            && matches!(&self.peek_nth_token_ref(1).token, Token::Word(word) if word.value.eq_ignore_ascii_case("percentile_disc"))
+        {
+            self.next_token();
+            let function_name = self.parse_object_name(false)?;
+            return self
+                .parse_function(function_name)
+                .map(|function| Expr::Prefixed {
+                    prefix: "APPROXIMATE".into(),
+                    value: Box::new(function),
+                });
+        }
+
         self.advance_token();
         let next_token_index = self.get_current_index();
         let next_token = self.get_current_token();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1635,6 +1635,18 @@ impl<'a> Parser<'a> {
             Keyword::MAP if *self.peek_token_ref() == Token::LBrace && self.dialect.support_map_literal_syntax() => {
                 Ok(Some(self.parse_duckdb_map_literal()?))
             }
+            Keyword::APPROXIMATE
+                if self.dialect.supports_approximate_percentile_disc()
+                    && self.peek_keyword(Keyword::PERCENTILE_DISC) =>
+            {
+                self.maybe_parse(|parser| {
+                    let function_name = parser.parse_object_name(false)?;
+                    parser.parse_function(function_name).map(|function| Expr::Prefixed {
+                        prefix: w.to_ident(w_span),
+                        value: Box::new(function),
+                    })
+                })
+            }
             Keyword::LAMBDA if self.dialect.supports_lambda_functions() => {
                 Ok(Some(self.parse_lambda_expr()?))
             }
@@ -1835,20 +1847,6 @@ impl<'a> Parser<'a> {
         // next_token reference.
 
         let dialect = self.dialect;
-
-        if dialect.supports_approximate_percentile_disc()
-            && matches!(&self.peek_token_ref().token, Token::Word(word) if word.value.eq_ignore_ascii_case("approximate"))
-            && matches!(&self.peek_nth_token_ref(1).token, Token::Word(word) if word.value.eq_ignore_ascii_case("percentile_disc"))
-        {
-            self.next_token();
-            let function_name = self.parse_object_name(false)?;
-            return self
-                .parse_function(function_name)
-                .map(|function| Expr::Prefixed {
-                    prefix: "APPROXIMATE".into(),
-                    value: Box::new(function),
-                });
-        }
 
         self.advance_token();
         let next_token_index = self.get_current_index();

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -557,3 +557,17 @@ fn parse_unpivot_expression() {
 fn test_interval_as_column_name() {
     redshift().verified_stmt("SELECT * FROM table_name WHERE interval = 78");
 }
+
+#[test]
+fn parse_approximate_percentile_disc() {
+    redshift().one_statement_parses_to(
+        r#"SELECT TOP 10 date.caldate,
+COUNT(totalprice), SUM(totalprice),
+APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY totalprice)
+FROM listing
+JOIN date ON listing.dateid = date.dateid
+GROUP BY date.caldate
+ORDER BY 3 DESC"#,
+        "SELECT TOP 10 date.caldate, COUNT(totalprice), SUM(totalprice), APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY totalprice) FROM listing JOIN date ON listing.dateid = date.dateid GROUP BY date.caldate ORDER BY 3 DESC",
+    );
+}

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -560,18 +560,15 @@ fn test_interval_as_column_name() {
 
 #[test]
 fn parse_approximate_percentile_disc() {
-    let dialects = all_dialects_where(|d| d.supports_approximate_percentile_disc());
-    dialects.verified_stmt(
+    let supporting = all_dialects_where(|d| d.supports_approximate_percentile_disc());
+    supporting.verified_stmt(
         "SELECT APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY totalprice)",
     );
-}
 
-#[test]
-fn parse_approximate_percentile_disc_as_column_alias() {
     // Without dialect support, `APPROXIMATE` is just a column name and
     // `PERCENTILE_DISC` its implicit alias.
-    let dialects = all_dialects_where(|d| !d.supports_approximate_percentile_disc());
-    dialects.one_statement_parses_to(
+    let non_supporting = all_dialects_where(|d| !d.supports_approximate_percentile_disc());
+    non_supporting.one_statement_parses_to(
         "SELECT APPROXIMATE PERCENTILE_DISC FROM t",
         "SELECT APPROXIMATE AS PERCENTILE_DISC FROM t",
     );

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -560,7 +560,19 @@ fn test_interval_as_column_name() {
 
 #[test]
 fn parse_approximate_percentile_disc() {
-    redshift().verified_stmt(
+    let dialects = all_dialects_where(|d| d.supports_approximate_percentile_disc());
+    dialects.verified_stmt(
         "SELECT APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY totalprice)",
+    );
+}
+
+#[test]
+fn parse_approximate_percentile_disc_as_column_alias() {
+    // Without dialect support, `APPROXIMATE` is just a column name and
+    // `PERCENTILE_DISC` its implicit alias.
+    let dialects = all_dialects_where(|d| !d.supports_approximate_percentile_disc());
+    dialects.one_statement_parses_to(
+        "SELECT APPROXIMATE PERCENTILE_DISC FROM t",
+        "SELECT APPROXIMATE AS PERCENTILE_DISC FROM t",
     );
 }

--- a/tests/sqlparser_redshift.rs
+++ b/tests/sqlparser_redshift.rs
@@ -560,14 +560,7 @@ fn test_interval_as_column_name() {
 
 #[test]
 fn parse_approximate_percentile_disc() {
-    redshift().one_statement_parses_to(
-        r#"SELECT TOP 10 date.caldate,
-COUNT(totalprice), SUM(totalprice),
-APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY totalprice)
-FROM listing
-JOIN date ON listing.dateid = date.dateid
-GROUP BY date.caldate
-ORDER BY 3 DESC"#,
-        "SELECT TOP 10 date.caldate, COUNT(totalprice), SUM(totalprice), APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY totalprice) FROM listing JOIN date ON listing.dateid = date.dateid GROUP BY date.caldate ORDER BY 3 DESC",
+    redshift().verified_stmt(
+        "SELECT APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY totalprice)",
     );
 }


### PR DESCRIPTION
Add Redshift support for APPROXIMATE PERCENTILE_DISC with WITHIN GROUP.

Previously, queries such as:

SELECT APPROXIMATE PERCENTILE_DISC(0.5)
WITHIN GROUP (ORDER BY totalprice)

failed to parse. Added a regression test based on the documented Redshift syntax.