### PR TITLE
chore: Bump version to 0.63.0 and add changelog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "sqlparser"
 description = "Extensible SQL Lexer and Parser with support for ANSI SQL:2011"
-version = "0.62.0"
+version = "0.63.0"
 authors = ["Apache DataFusion <dev@datafusion.apache.org>"]
 homepage = "https://github.com/apache/datafusion-sqlparser-rs"
 documentation = "https://docs.rs/sqlparser/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 # of dev-dependencies because of
 # https://github.com/rust-lang/cargo/issues/1596
 serde_json = { version = "1.0", optional = true }
-sqlparser_derive = { version = "0.5.0", path = "derive", optional = true }
+sqlparser_derive = { version = "0.6.0", path = "derive", optional = true }
 
 [dev-dependencies]
 simple_logger = "5.0"

--- a/changelog/0.63.0.md
+++ b/changelog/0.63.0.md
@@ -1,0 +1,137 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# sqlparser-rs 0.63.0 Changelog
+
+This release consists of 71 commits from 28 contributors. See credits at the end of this changelog for more information.
+
+**Implemented enhancements:**
+
+- feat: add PostgreSQL EXCLUDE constraint parsing [#2307](https://github.com/apache/datafusion-sqlparser-rs/pull/2307) (fmguerreiro)
+
+**Other:**
+
+- Databricks: Add support for `UPDATE SET *` and `INSERT *` in MERGE statements [#2325](https://github.com/apache/datafusion-sqlparser-rs/pull/2325) (finchxxia)
+- Snowflake: Fix COPY INTO transformation parsing for cast expressions [#2328](https://github.com/apache/datafusion-sqlparser-rs/pull/2328) (97nitt)
+- Snowflake: Accept COPY GRANTS after CREATE VIEW column list [#2327](https://github.com/apache/datafusion-sqlparser-rs/pull/2327) (97nitt)
+- Fix panic in EscapeQuotedString and parse_flush, clean up a few unwraps [#2330](https://github.com/apache/datafusion-sqlparser-rs/pull/2330) (Mrmaxmeier)
+- Teradata: Add `CREATE TABLE` options [#2329](https://github.com/apache/datafusion-sqlparser-rs/pull/2329) (iffyio)
+- Add support for PostgreSQL's ORDER BY ... USING <operator> clause [#2246](https://github.com/apache/datafusion-sqlparser-rs/pull/2246) (LucaCappelletti94)
+- BigQuery: Parse WITH CONNECTION on CREATE EXTERNAL TABLE [#2326](https://github.com/apache/datafusion-sqlparser-rs/pull/2326) (97nitt)
+- Add ASYNC keyword support for CREATE INDEX [#2302](https://github.com/apache/datafusion-sqlparser-rs/pull/2302) (amaksimo)
+- PostgreSQL: add support for `ABORT TRANSACTION` [#2332](https://github.com/apache/datafusion-sqlparser-rs/pull/2332) (sunng87)
+- Snowflake: Add support for PUT [#2341](https://github.com/apache/datafusion-sqlparser-rs/pull/2341) (ramnes)
+- Make `visitor` feature `no_std`-compatible [#2343](https://github.com/apache/datafusion-sqlparser-rs/pull/2343) (LucaCappelletti94)
+- Parser: fix exponential parse time on compound chains [#2344](https://github.com/apache/datafusion-sqlparser-rs/pull/2344) (LucaCappelletti94)
+- MySQL: Add support for group by with rollup [#2347](https://github.com/apache/datafusion-sqlparser-rs/pull/2347) (yoavcloud)
+- Hive: Support MAP<K, V> column types [#2346](https://github.com/apache/datafusion-sqlparser-rs/pull/2346) (wugeer)
+- Snowflake: Add support for CREATE FILE FORMAT [#2336](https://github.com/apache/datafusion-sqlparser-rs/pull/2336) (ramnes)
+- Expose Parser::into_comments [#2354](https://github.com/apache/datafusion-sqlparser-rs/pull/2354) (xitep)
+- Improve accuracy of supports_string_literal_concatenation_with_newline [#2348](https://github.com/apache/datafusion-sqlparser-rs/pull/2348) (yoavcloud)
+- Spark: enable SQL pipe operator (`|>`) [#2358](https://github.com/apache/datafusion-sqlparser-rs/pull/2358) (moshap-firebolt)
+- Support multiple targets for `SELECT INTO` [#2360](https://github.com/apache/datafusion-sqlparser-rs/pull/2360) (iffyio)
+- Fix issue #2353: Incorrect canonicalization of `NATURAL JOIN` [#2355](https://github.com/apache/datafusion-sqlparser-rs/pull/2355) (revitalkr)
+- Microsoft sql server: Escape quotes in national string display [#2365](https://github.com/apache/datafusion-sqlparser-rs/pull/2365) (lovasoa)
+- Parser: fix exponential parse time on compound keyword chains [#2350](https://github.com/apache/datafusion-sqlparser-rs/pull/2350) (LucaCappelletti94)
+- Parser: fix exponential parse time on speculative prefix parsing [#2352](https://github.com/apache/datafusion-sqlparser-rs/pull/2352) (LucaCappelletti94)
+- Support aliased function arguments (expr AS name) [#2368](https://github.com/apache/datafusion-sqlparser-rs/pull/2368) (LucaCappelletti94)
+- Forbid unsafe code [#2369](https://github.com/apache/datafusion-sqlparser-rs/pull/2369) (LucaCappelletti94)
+- sqlite: Support `GLOB` operator [#2362](https://github.com/apache/datafusion-sqlparser-rs/pull/2362) (connyay)
+- Parser: fix exponential parse time on table-factor paren chains [#2372](https://github.com/apache/datafusion-sqlparser-rs/pull/2372) (moshap-firebolt)
+- Disable `supports_left_associative_joins_without_parens` for MySQL and Redshift [#2357](https://github.com/apache/datafusion-sqlparser-rs/pull/2357) (revitalkr)
+- Add PostgreSQL `CREATE/ALTER TEXT SEARCH` DDL Parsing [#2250](https://github.com/apache/datafusion-sqlparser-rs/pull/2250) (LucaCappelletti94)
+- Do not consume statement terminator in unparenthesized option lists [#2376](https://github.com/apache/datafusion-sqlparser-rs/pull/2376) (LucaCappelletti94)
+- Parse `ALTER USER` as a synonym for `ALTER ROLE` [#2374](https://github.com/apache/datafusion-sqlparser-rs/pull/2374) (LucaCappelletti94)
+- Add pre_visit_ident / post_visit_ident hooks to the Visitor trait [#2370](https://github.com/apache/datafusion-sqlparser-rs/pull/2370) (sabir-akhadov-localstack)
+- Handle nested parentheses in INSERT subquery detection [#2387](https://github.com/apache/datafusion-sqlparser-rs/pull/2387) (sabir-akhadov-localstack)
+- PostgreSQL `UNLOGGED` Table Support and `ALTER TABLE ... SET LOGGED|UNLOGGED` [#2251](https://github.com/apache/datafusion-sqlparser-rs/pull/2251) (LucaCappelletti94)
+- ClickHouse: Support unparenthesized IN right-hand side [#2385](https://github.com/apache/datafusion-sqlparser-rs/pull/2385) (dinmukhamedm)
+- Parser: fix exponential parse time on expression-named function arguments [#2392](https://github.com/apache/datafusion-sqlparser-rs/pull/2392) (moshap-firebolt)
+- CI: Add cargo audit security workflow [#2373](https://github.com/apache/datafusion-sqlparser-rs/pull/2373) (LucaCappelletti94)
+- Postgres: parse LIMIT after the row-locking clause [#2391](https://github.com/apache/datafusion-sqlparser-rs/pull/2391) (truffle-dev)
+- Fix clippy lints for Rust 1.97 [#2402](https://github.com/apache/datafusion-sqlparser-rs/pull/2402) (takaebato)
+- PostgreSQL: support right-deep join chains (deferred ON clauses) [#2377](https://github.com/apache/datafusion-sqlparser-rs/pull/2377) (moshap-firebolt)
+- Dialects: implement identifier_quote_style for remaining dialect [#2401](https://github.com/apache/datafusion-sqlparser-rs/pull/2401) (takaebato)
+- Support inline aggregate WHERE filter (`AGG(expr WHERE cond)`) [#2404](https://github.com/apache/datafusion-sqlparser-rs/pull/2404) (moshap-firebolt)
+- Snowflake: parse CREATE WAREHOUSE [#2388](https://github.com/apache/datafusion-sqlparser-rs/pull/2388) (sabir-akhadov-localstack)
+- PostgreSQL: Support SQL standard `ARRAY` keyword in type declarations [#2356](https://github.com/apache/datafusion-sqlparser-rs/pull/2356) (LucaCappelletti94)
+- Accept CREATE OR REPLACE SCHEMA [#2396](https://github.com/apache/datafusion-sqlparser-rs/pull/2396) (sabir-akhadov-localstack)
+- ClickHouse: Fix MATERIALIZED column option docs typo [#2410](https://github.com/apache/datafusion-sqlparser-rs/pull/2410) (Hashim1999164)
+- Adding support for `IS JSON` & `IS NOT JSON` [#2256](https://github.com/apache/datafusion-sqlparser-rs/pull/2256) (LucaCappelletti94)
+- Support numeric underscore separators for DuckDB and SQLite [#2412](https://github.com/apache/datafusion-sqlparser-rs/pull/2412) (nuno-faria)
+- Add visitors for ORDER BY and GROUP BY [#2406](https://github.com/apache/datafusion-sqlparser-rs/pull/2406) (rs-sac)
+- PostgreSQL: support INCLUDE on PRIMARY KEY / UNIQUE table constraints [#2366](https://github.com/apache/datafusion-sqlparser-rs/pull/2366) (amaksimo)
+- Honour operator precedence in SQLite `REGEXP`, `MATCH` and `GLOB` [#2419](https://github.com/apache/datafusion-sqlparser-rs/pull/2419) (LucaCappelletti94)
+- Add recursion checks for parse_interval [#2422](https://github.com/apache/datafusion-sqlparser-rs/pull/2422) (shuvamk)
+- Added support for unpivot in Redshift with expression and bracketsless [#2375](https://github.com/apache/datafusion-sqlparser-rs/pull/2375) (kfirSatori)
+- Add XMLPARSE expression [#2371](https://github.com/apache/datafusion-sqlparser-rs/pull/2371) (LucaCappelletti94)
+- BigQuery: enable FROM-first SELECT [#2439](https://github.com/apache/datafusion-sqlparser-rs/pull/2439) (moshap-firebolt)
+- Reject invalid numeric underscore separators [#2426](https://github.com/apache/datafusion-sqlparser-rs/pull/2426) (fyrsta7)
+- Keep the quoting and span of a function argument name [#2447](https://github.com/apache/datafusion-sqlparser-rs/pull/2447) (LucaCappelletti94)
+- Improved AGENTS.md to address the problematics of slop PRs & reviews [#2444](https://github.com/apache/datafusion-sqlparser-rs/pull/2444) (LucaCappelletti94)
+- Support PostgreSQL's `RESET SESSION AUTHORIZATION` [#2413](https://github.com/apache/datafusion-sqlparser-rs/pull/2413) (LucaCappelletti94)
+- Support `NO INHERIT` modifier on `CHECK` constraints [#2435](https://github.com/apache/datafusion-sqlparser-rs/pull/2435) (LucaCappelletti94)
+- Print `GRANT` clauses in the order the parser reads them [#2415](https://github.com/apache/datafusion-sqlparser-rs/pull/2415) (LucaCappelletti94)
+- Inline Word::to_ident [#2427](https://github.com/apache/datafusion-sqlparser-rs/pull/2427) (fyrsta7)
+- Parse `REVOKE GRANT OPTION FOR` [#2431](https://github.com/apache/datafusion-sqlparser-rs/pull/2431) (LucaCappelletti94)
+- Redshift: allow INTERVAL as a column name [#2456](https://github.com/apache/datafusion-sqlparser-rs/pull/2456) (BenSatori)
+- Honour operator precedence in `IS [NOT] DISTINCT FROM` [#2436](https://github.com/apache/datafusion-sqlparser-rs/pull/2436) (zvonimir-dd)
+- Stop printing a trailing space after `PUBLIC` in `GRANT` and `REVOKE` [#2416](https://github.com/apache/datafusion-sqlparser-rs/pull/2416) (LucaCappelletti94)
+- PostgreSQL: Allow non-reserved keywords as table aliases [#2479](https://github.com/apache/datafusion-sqlparser-rs/pull/2479) (BenSatori)
+- Honour operator precedence in MySQL and Spark `DIV` [#2471](https://github.com/apache/datafusion-sqlparser-rs/pull/2471) (zvonimir-dd)
+- MySQL: print a space before PARTITION when displaying a table factor [#2423](https://github.com/apache/datafusion-sqlparser-rs/pull/2423) (shuvamk)
+- Preserve numeric compound field access display [#2463](https://github.com/apache/datafusion-sqlparser-rs/pull/2463) (LucaCappelletti94)
+
+## Credits
+
+Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
+
+```
+    24	Luca Cappelletti
+     6	Mosha Pasumansky
+     4	sabir-akhadov-localstack
+     3	Corey Fritz
+     2	Aleksandar Maksimovic
+     2	Ben Herzberg
+     2	Guillaume Gelin
+     2	Ifeanyi Ubah
+     2	Shuvam Kumar
+     2	Takahiro Ebato
+     2	Yoav Cohen
+     2	Yuwei Zhao
+     2	Zvonimir
+     2	revitalkr
+     1	Connor Hindley
+     1	Dinmukhamed Mailibay
+     1	Filipe Guerreiro
+     1	Hashim Khan
+     1	Mrmaxmeier
+     1	Ning Sun
+     1	Nuno Faria
+     1	Ophir LOJKINE
+     1	Sidney Cammeresi
+     1	Truffle
+     1	finchxxia
+     1	kfirSatori
+     1	wugeer
+     1	xitep
+```
+
+Thank you also to everyone who contributed in other ways such as filing issues, reviewing PRs, and providing feedback on this release.
+

--- a/changelog/0.63.0.md
+++ b/changelog/0.63.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # sqlparser-rs 0.63.0 Changelog
 
-This release consists of 71 commits from 28 contributors. See credits at the end of this changelog for more information.
+This release consists of 80 commits from 30 contributors. See credits at the end of this changelog for more information.
 
 **Implemented enhancements:**
 
@@ -97,20 +97,28 @@ This release consists of 71 commits from 28 contributors. See credits at the end
 - Honour operator precedence in MySQL and Spark `DIV` [#2471](https://github.com/apache/datafusion-sqlparser-rs/pull/2471) (zvonimir-dd)
 - MySQL: print a space before PARTITION when displaying a table factor [#2423](https://github.com/apache/datafusion-sqlparser-rs/pull/2423) (shuvamk)
 - Preserve numeric compound field access display [#2463](https://github.com/apache/datafusion-sqlparser-rs/pull/2463) (LucaCappelletti94)
+- Visit CreateView name as a relation [#2442](https://github.com/apache/datafusion-sqlparser-rs/pull/2442) (sabir-akhadov-localstack)
+- Apply recursion limit without std [#2465](https://github.com/apache/datafusion-sqlparser-rs/pull/2465) (LucaCappelletti94)
+- Parse PostgreSQL MERGE DO NOTHING actions [#2468](https://github.com/apache/datafusion-sqlparser-rs/pull/2468) (LucaCappelletti94)
+- Add recursion checks for parse_data_type [#2411](https://github.com/apache/datafusion-sqlparser-rs/pull/2411) (iffyio)
+- Parse expression-valued LIKE ESCAPE clauses [#2476](https://github.com/apache/datafusion-sqlparser-rs/pull/2476) (lovasoa)
+- Databricks: enable query and nested type syntax [#2478](https://github.com/apache/datafusion-sqlparser-rs/pull/2478) (EthanVieira)
 
 ## Credits
 
 Thank you to everyone who contributed to this release. Here is a breakdown of commits (PRs merged) per contributor.
 
 ```
-    24	Luca Cappelletti
+    26	Luca Cappelletti
      6	Mosha Pasumansky
-     4	sabir-akhadov-localstack
+     5	sabir-akhadov-localstack
+     3	Andrew Lamb
      3	Corey Fritz
+     3	Ifeanyi Ubah
      2	Aleksandar Maksimovic
      2	Ben Herzberg
      2	Guillaume Gelin
-     2	Ifeanyi Ubah
+     2	Ophir LOJKINE
      2	Shuvam Kumar
      2	Takahiro Ebato
      2	Yoav Cohen
@@ -119,12 +127,12 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
      2	revitalkr
      1	Connor Hindley
      1	Dinmukhamed Mailibay
+     1	Ethan Vieira
      1	Filipe Guerreiro
      1	Hashim Khan
      1	Mrmaxmeier
      1	Ning Sun
      1	Nuno Faria
-     1	Ophir LOJKINE
      1	Sidney Cammeresi
      1	Truffle
      1	finchxxia

--- a/changelog/0.63.0.md
+++ b/changelog/0.63.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # sqlparser-rs 0.63.0 Changelog
 
-This release consists of 80 commits from 30 contributors. See credits at the end of this changelog for more information.
+This release consists of 83 commits from 30 contributors. See credits at the end of this changelog for more information.
 
 **Implemented enhancements:**
 
@@ -103,6 +103,7 @@ This release consists of 80 commits from 30 contributors. See credits at the end
 - Add recursion checks for parse_data_type [#2411](https://github.com/apache/datafusion-sqlparser-rs/pull/2411) (iffyio)
 - Parse expression-valued LIKE ESCAPE clauses [#2476](https://github.com/apache/datafusion-sqlparser-rs/pull/2476) (lovasoa)
 - Databricks: enable query and nested type syntax [#2478](https://github.com/apache/datafusion-sqlparser-rs/pull/2478) (EthanVieira)
+- Visit function clauses in source order [#2477](https://github.com/apache/datafusion-sqlparser-rs/pull/2477) (lovasoa)
 
 ## Credits
 
@@ -111,14 +112,14 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
 ```
     26	Luca Cappelletti
      6	Mosha Pasumansky
+     5	Andrew Lamb
      5	sabir-akhadov-localstack
-     3	Andrew Lamb
      3	Corey Fritz
      3	Ifeanyi Ubah
+     3	Ophir LOJKINE
      2	Aleksandar Maksimovic
      2	Ben Herzberg
      2	Guillaume Gelin
-     2	Ophir LOJKINE
      2	Shuvam Kumar
      2	Takahiro Ebato
      2	Yoav Cohen

--- a/changelog/0.63.0.md
+++ b/changelog/0.63.0.md
@@ -19,7 +19,7 @@ under the License.
 
 # sqlparser-rs 0.63.0 Changelog
 
-This release consists of 83 commits from 30 contributors. See credits at the end of this changelog for more information.
+This release consists of 87 commits from 30 contributors. See credits at the end of this changelog for more information.
 
 **Implemented enhancements:**
 
@@ -104,6 +104,7 @@ This release consists of 83 commits from 30 contributors. See credits at the end
 - Parse expression-valued LIKE ESCAPE clauses [#2476](https://github.com/apache/datafusion-sqlparser-rs/pull/2476) (lovasoa)
 - Databricks: enable query and nested type syntax [#2478](https://github.com/apache/datafusion-sqlparser-rs/pull/2478) (EthanVieira)
 - Visit function clauses in source order [#2477](https://github.com/apache/datafusion-sqlparser-rs/pull/2477) (lovasoa)
+- Update sqlparser_derive to syn 3.0 [#2483](https://github.com/apache/datafusion-sqlparser-rs/pull/2483) (alamb)
 
 ## Credits
 
@@ -111,8 +112,8 @@ Thank you to everyone who contributed to this release. Here is a breakdown of co
 
 ```
     26	Luca Cappelletti
+     9	Andrew Lamb
      6	Mosha Pasumansky
-     5	Andrew Lamb
      5	sabir-akhadov-localstack
      3	Corey Fritz
      3	Ifeanyi Ubah

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "sqlparser_derive"
 description = "Procedural (proc) macros for sqlparser"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["sqlparser-rs authors"]
 homepage = "https://github.com/sqlparser-rs/sqlparser-rs"
 documentation = "https://docs.rs/sqlparser_derive/"

--- a/dev/release/create-tarball.sh
+++ b/dev/release/create-tarball.sh
@@ -107,7 +107,7 @@ Here is my vote:
 
 [1]: https://github.com/apache/datafusion-sqlparser-rs/tree/${release_hash}
 [2]: ${url}
-[3]: https://github.com/apache/datafusion-sqlparser-rs/blob/${release_hash}/CHANGELOG.md
+[3]: https://github.com/apache/datafusion-sqlparser-rs/blob/${release_hash}/changelog/${version}.md
 MAIL
 echo "---------------------------------------------------------"
 


### PR DESCRIPTION
- Part of #2453

This PR prepares the 0.63.0 release, following the process in [dev/release/README.md](https://github.com/apache/datafusion-sqlparser-rs/blob/main/dev/release/README.md):

- Bumps the version in `Cargo.toml` from `0.62.0` to `0.63.0`
- Adds `changelog/0.63.0.md` -- See rendered preview: https://github.com/alamb/sqlparser-rs/blob/release-0.63.0/changelog/0.63.0.md
- Fixes the changelog link in the vote email template in `create-tarball.sh` to point at `changelog/<version>.md` rather than the `CHANGELOG.md` stub
- Bumps `sqlparser_derive` from `0.5.0` to `0.6.0` so it can be released alongside `sqlparser` (it has unreleased changes: #2219, #2343, #2369, #2483) -- see #2386