### PR TITLE
Update sqlparser_derive to syn 3.0

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -39,6 +39,6 @@ proc-macro = true
 unsafe_code = "forbid"
 
 [dependencies]
-syn = { version = "2.0", default-features = false, features = ["full", "printing", "parsing", "derive", "proc-macro", "clone-impls"] }
+syn = { version = "3.0", default-features = false, features = ["full", "printing", "parsing", "derive", "proc-macro", "clone-impls"] }
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/derive/src/dialect.rs
+++ b/derive/src/dialect.rs
@@ -23,7 +23,8 @@ use std::collections::HashSet;
 use syn::{
     braced,
     parse::{Parse, ParseStream},
-    Error, File, FnArg, Ident, Item, LitBool, LitChar, Pat, ReturnType, Signature, Token,
+    Error, File, FnArg, Ident, Item, LitBool, LitChar, Pat, ReceiverKind, ReturnType, Signature,
+    Token,
     TraitItem, Type,
 };
 
@@ -343,7 +344,7 @@ fn is_bool_method(sig: &Signature) -> bool {
     sig.inputs.len() == 1
         && matches!(
             sig.inputs.first(),
-            Some(FnArg::Receiver(r)) if r.reference.is_some() && r.mutability.is_none()
+            Some(FnArg::Receiver(r)) if matches!(&r.kind, ReceiverKind::Reference(_, _, None))
         )
         && matches!(
             &sig.output,

--- a/derive/src/dialect.rs
+++ b/derive/src/dialect.rs
@@ -24,8 +24,7 @@ use syn::{
     braced,
     parse::{Parse, ParseStream},
     Error, File, FnArg, Ident, Item, LitBool, LitChar, Pat, ReceiverKind, ReturnType, Signature,
-    Token,
-    TraitItem, Type,
+    Token, TraitItem, Type,
 };
 
 /// Override value types supported by the macro


### PR DESCRIPTION
## Which issue does this PR close?

N/A — dependency maintenance.

## Rationale for this change

Keep dependencies current. 

## What changes are included in this PR?

- Bump `syn` from `2.0` to `3.0` in `derive/Cargo.toml`
- Adapt to the one breaking change that affects us

## Is this a breaking API change?

**No — `syn` does not appear in the public API.** `sqlparser_derive` is a proc-macro crate 

## Are these changes tested?

By CI

## Are there any user-facing changes?

No user-facing API changes. Downstream crates that enable the `visitor` or `derive-dialect` features will build `syn` 3.0 instead of 2.0 once a new `sqlparser_derive` is published.