### PR TITLE
`PostgreSQL`: Support the `VARIADIC` function call argument marker

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -8063,6 +8063,14 @@ pub enum FunctionArg {
     },
     /// An unnamed argument (positional), given by expression or wildcard.
     Unnamed(FunctionArgExpr),
+    /// An argument carrying PostgreSQL's `VARIADIC` marker, e.g.
+    /// `concat(VARIADIC ARRAY['a', 'b'])`. Only the final argument of a call
+    /// may carry it.
+    ///
+    /// Enabled when `Dialect::supports_variadic_function_argument` returns `true`.
+    ///
+    /// [PostgreSQL](https://www.postgresql.org/docs/current/xfunc-sql.html#XFUNC-SQL-VARIADIC-FUNCTIONS)
+    Variadic(Box<FunctionArg>),
 }
 
 impl fmt::Display for FunctionArg {
@@ -8079,6 +8087,7 @@ impl fmt::Display for FunctionArg {
                 operator,
             } => fmt_named_function_arg(f, name, operator, arg),
             FunctionArg::Unnamed(unnamed_arg) => write!(f, "{unnamed_arg}"),
+            FunctionArg::Variadic(arg) => write!(f, "VARIADIC {arg}"),
         }
     }
 }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -2193,6 +2193,7 @@ impl Spanned for FunctionArg {
                 arg,
                 operator: _,
             } => name.span().union(&arg.span()),
+            FunctionArg::Variadic(arg) => arg.span(),
         }
     }
 }

--- a/src/dialect/generic.rs
+++ b/src/dialect/generic.rs
@@ -320,4 +320,8 @@ impl Dialect for GenericDialect {
     fn supports_aliased_function_args(&self) -> bool {
         true
     }
+
+    fn supports_variadic_function_argument(&self) -> bool {
+        true
+    }
 }

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -1815,6 +1815,16 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if the dialect supports the `VARIADIC` marker on the final
+    /// argument of a function call, e.g. `concat(VARIADIC ARRAY['a', 'b'])`.
+    ///
+    /// When this returns false, `VARIADIC` is treated as a regular identifier.
+    ///
+    /// [PostgreSQL](https://www.postgresql.org/docs/current/xfunc-sql.html#XFUNC-SQL-VARIADIC-FUNCTIONS)
+    fn supports_variadic_function_argument(&self) -> bool {
+        false
+    }
+
     /// Returns true if the dialect supports `USING <format>` in `CREATE TABLE`.
     ///
     /// Example:

--- a/src/dialect/postgresql.rs
+++ b/src/dialect/postgresql.rs
@@ -98,10 +98,12 @@ impl Dialect for PostgreSqlDialect {
     }
 
     fn is_reserved_for_identifier(&self, kw: Keyword) -> bool {
-        if matches!(kw, Keyword::INTERVAL) {
-            false
-        } else {
-            RESERVED_FOR_IDENTIFIER.contains(&kw)
+        match kw {
+            Keyword::INTERVAL => false,
+            // PostgreSQL reserves `VARIADIC`, so inside a call it always
+            // introduces the argument marker rather than a column of that name.
+            Keyword::VARIADIC => true,
+            _ => RESERVED_FOR_IDENTIFIER.contains(&kw),
         }
     }
 
@@ -358,6 +360,10 @@ impl Dialect for PostgreSqlDialect {
     }
 
     fn supports_aliased_function_args(&self) -> bool {
+        true
+    }
+
+    fn supports_variadic_function_argument(&self) -> bool {
         true
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18830,8 +18830,100 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse a single function argument, handling named and unnamed variants.
+    /// Parse a single function argument, handling the `VARIADIC` marker as well
+    /// as named and unnamed variants.
+    ///
+    /// Dialects that reserve `VARIADIC`, such as PostgreSQL, always mean the
+    /// marker. Where the keyword is unreserved, `f(variadic)` passes a column
+    /// of that name instead, so the ordinary reading is parsed first and kept
+    /// whenever it stands as an argument on its own; `f(VARIADIC a)` is left as
+    /// the only reading that takes the marker.
     pub fn parse_function_args(&mut self) -> Result<FunctionArg, ParserError> {
+        if self.dialect.supports_variadic_function_argument()
+            && self.peek_keyword(Keyword::VARIADIC)
+        {
+            if !self.dialect.is_reserved_for_identifier(Keyword::VARIADIC) {
+                let plain = self.maybe_parse(|p| {
+                    let arg = p.parse_plain_function_args()?;
+                    if p.peek_ends_function_arg() {
+                        Ok(arg)
+                    } else {
+                        p.expected_ref("end of the function argument", p.peek_token_ref())
+                    }
+                })?;
+                if let Some(arg) = plain {
+                    return Ok(arg);
+                }
+            }
+
+            let loc = self.peek_token_ref().span.start;
+            self.expect_keyword(Keyword::VARIADIC)?;
+            let arg = self.parse_plain_function_args()?;
+            // PostgreSQL's VARIADIC productions require expression operands,
+            // so no wildcard argument form is valid.
+            let carries_wildcard = match &arg {
+                FunctionArg::Unnamed(arg)
+                | FunctionArg::Named { arg, .. }
+                | FunctionArg::ExprNamed { arg, .. } => !matches!(arg, FunctionArgExpr::Expr(_)),
+                FunctionArg::Variadic(_) => false,
+            };
+            if carries_wildcard {
+                return parser_err!("A VARIADIC argument cannot be a wildcard", loc);
+            }
+            return Ok(FunctionArg::Variadic(Box::new(arg)));
+        }
+        self.parse_plain_function_args()
+    }
+
+    /// Returns true when the next token can follow a complete function
+    /// argument: the argument separator, the end of the list, or a complete
+    /// clause that [`Parser::parse_function_argument_list`] accepts after the
+    /// arguments. A clause keyword whose own syntax does not follow is an
+    /// operand instead, as in `f(VARIADIC separator)`.
+    fn peek_ends_function_arg(&self) -> bool {
+        let word = match &self.peek_token_ref().token {
+            Token::Comma | Token::RParen => return true,
+            Token::Word(word) => word,
+            _ => return false,
+        };
+        let next = &self.peek_nth_token_ref(1).token;
+        let next_is = |keyword| matches!(next, Token::Word(next) if next.keyword == keyword);
+        match word.keyword {
+            Keyword::ORDER => next_is(Keyword::BY),
+            Keyword::IGNORE | Keyword::RESPECT => next_is(Keyword::NULLS),
+            // `ON OVERFLOW`, and the `ABSENT ON NULL` / `NULL ON NULL` clauses.
+            Keyword::ON => next_is(Keyword::OVERFLOW),
+            Keyword::ABSENT | Keyword::NULL => next_is(Keyword::ON),
+            Keyword::HAVING => next_is(Keyword::MIN) || next_is(Keyword::MAX),
+            // These take an expression, a value or a type of their own.
+            Keyword::LIMIT | Keyword::RETURNING | Keyword::SEPARATOR | Keyword::WHERE => {
+                !matches!(next, Token::Comma | Token::RParen)
+            }
+            _ => false,
+        }
+    }
+
+    /// Rejects a `VARIADIC` marker on any but the final argument, as
+    /// PostgreSQL's grammar carries it on the last one only.
+    fn verify_variadic_argument_is_last(args: &[FunctionArg]) -> Result<(), ParserError> {
+        let Some((_, preceding)) = args.split_last() else {
+            return Ok(());
+        };
+        match preceding
+            .iter()
+            .find(|arg| matches!(arg, FunctionArg::Variadic(_)))
+        {
+            Some(arg) => parser_err!(
+                "A VARIADIC argument must be the last function argument",
+                arg.span().start
+            ),
+            None => Ok(()),
+        }
+    }
+
+    /// Parse a single function argument carrying no `VARIADIC` marker,
+    /// handling named and unnamed variants.
+    fn parse_plain_function_args(&mut self) -> Result<FunctionArg, ParserError> {
         // Parse the argument expression once, then check for a named-arg
         // operator. Parsing it speculatively and re-parsing on the unnamed
         // path is O(2^depth) on nested calls like `CAST(CASE (CAST(CASE (…`.
@@ -18956,6 +19048,7 @@ impl<'a> Parser<'a> {
             Ok(vec![])
         } else {
             let args = self.parse_comma_separated(Parser::parse_function_args)?;
+            Self::verify_variadic_argument_is_last(&args)?;
             self.expect_token(&Token::RParen)?;
             Ok(args)
         }
@@ -18978,6 +19071,7 @@ impl<'a> Parser<'a> {
                 break None;
             }
         };
+        Self::verify_variadic_argument_is_last(&args)?;
         self.expect_token(&Token::RParen)?;
         Ok(TableFunctionArgs { args, settings })
     }
@@ -19013,8 +19107,18 @@ impl<'a> Parser<'a> {
             });
         }
 
+        let loc = self.peek_token_ref().span.start;
         let duplicate_treatment = self.parse_duplicate_treatment()?;
         let args = self.parse_comma_separated(Parser::parse_function_args)?;
+        Self::verify_variadic_argument_is_last(&args)?;
+
+        // PostgreSQL pairs the marker with neither `DISTINCT` nor `ALL`.
+        if duplicate_treatment.is_some() && matches!(args.last(), Some(FunctionArg::Variadic(_))) {
+            return parser_err!(
+                "A VARIADIC argument cannot be combined with DISTINCT or ALL",
+                loc
+            );
+        }
 
         if self.parse_keyword(Keyword::WHERE) {
             clauses.push(FunctionArgumentClause::Where(self.parse_expr()?));

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -25,6 +25,7 @@ mod test_utils;
 use helpers::attached_token::AttachedToken;
 use sqlparser::ast::*;
 use sqlparser::dialect::{Dialect, GenericDialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect};
+use sqlparser::keywords::Keyword;
 use sqlparser::parser::{Parser, ParserError};
 use sqlparser::tokenizer::{Location, Span};
 use test_utils::*;
@@ -9917,4 +9918,215 @@ fn parse_non_reserved_keywords_as_table_alias() {
             "SELECT * FROM tbl_name {kw} JOIN tbl_name_2 ON {kw}.id = tbl_name_2.id"
         ));
     }
+}
+
+#[test]
+fn parse_variadic_function_argument() {
+    pg().verified_stmt("SELECT concat(VARIADIC ARRAY[1, 2])");
+    pg().verified_stmt("SELECT concat_ws('-', VARIADIC ARRAY['a'])");
+    pg().verified_stmt(
+        "SELECT * FROM pg_get_publication_tables(VARIADIC ARRAY['pub'::TEXT]) AS gpt",
+    );
+
+    // PostgreSQL accepts the marker on a named final argument too.
+    let select = pg().verified_only_select("SELECT f(VARIADIC a => ARRAY[1])");
+    match expr_from_projection(only(&select.projection)) {
+        Expr::Function(Function {
+            args: FunctionArguments::List(FunctionArgumentList { args, .. }),
+            ..
+        }) => assert_eq!(
+            &vec![FunctionArg::Variadic(Box::new(FunctionArg::ExprNamed {
+                name: Expr::Identifier(Ident::new("a")),
+                arg: FunctionArgExpr::Expr(Expr::Array(Array {
+                    elem: vec![Expr::value(number("1"))],
+                    named: true,
+                })),
+                operator: FunctionArgOperator::RightArrow,
+            }))],
+            args
+        ),
+        other => panic!("Expected a function call, found {other:?}"),
+    }
+
+    // PostgreSQL reserves the keyword, so the marker holds even where an
+    // unreserved dialect would read `variadic - a` as an expression.
+    let select = pg().verified_only_select("SELECT concat(VARIADIC -a)");
+    match expr_from_projection(only(&select.projection)) {
+        Expr::Function(Function {
+            args: FunctionArguments::List(FunctionArgumentList { args, .. }),
+            ..
+        }) => assert_eq!(
+            &vec![FunctionArg::Variadic(Box::new(FunctionArg::Unnamed(
+                FunctionArgExpr::Expr(Expr::UnaryOp {
+                    op: UnaryOperator::Minus,
+                    expr: Box::new(Expr::Identifier(Ident::new("a"))),
+                })
+            )))],
+            args
+        ),
+        other => panic!("Expected a function call, found {other:?}"),
+    }
+
+    // Since the keyword is reserved, it never passes a column of that name,
+    // matching PostgreSQL's own rejection of `SELECT f(variadic)`.
+    assert_eq!(
+        ParserError::ParserError("Expected: an expression, found: )".to_string()),
+        pg().parse_sql_statements("SELECT f(variadic)").unwrap_err()
+    );
+
+    // The marker only applies to the final argument.
+    let dialects = all_dialects_where(|d| d.supports_variadic_function_argument());
+    assert_eq!(
+        ParserError::ParserError(
+            "A VARIADIC argument must be the last function argument".to_string()
+        ),
+        dialects
+            .parse_sql_statements("SELECT concat(VARIADIC a, b)")
+            .unwrap_err()
+    );
+
+    // A comma introducing the table-function `SETTINGS` clause is no argument.
+    all_dialects_where(|d| d.supports_variadic_function_argument() && d.supports_settings())
+        .verified_stmt("SELECT * FROM f(VARIADIC a, SETTINGS x = 1)");
+
+    // A bare clause keyword is an operand, not the start of that clause.
+    dialects.verified_stmt("SELECT f(VARIADIC separator)");
+    dialects.verified_stmt("SELECT f(VARIADIC returning)");
+
+    // PostgreSQL's VARIADIC productions require expression operands, so no
+    // wildcard argument form is valid.
+    for sql in ["SELECT f(VARIADIC *)", "SELECT f(VARIADIC a => *)"] {
+        assert_eq!(
+            ParserError::ParserError("A VARIADIC argument cannot be a wildcard".to_string()),
+            dialects.parse_sql_statements(sql).unwrap_err(),
+            "{sql}"
+        );
+    }
+    dialects.verified_stmt("SELECT f(*)");
+
+    // Dialects without the marker read `VARIADIC` as an identifier, so the
+    // argument that follows it has nowhere to go.
+    let unsupported = all_dialects_except(|d| d.supports_variadic_function_argument());
+    assert_eq!(
+        ParserError::ParserError("Expected: ), found: a".to_string()),
+        unsupported
+            .parse_sql_statements("SELECT concat(VARIADIC a)")
+            .unwrap_err()
+    );
+
+    // PostgreSQL has no production pairing the marker with a duplicate
+    // treatment: `count(DISTINCT VARIADIC ARRAY[1])` is a syntax error there.
+    for sql in [
+        "SELECT count(DISTINCT VARIADIC ARRAY[1])",
+        "SELECT count(ALL VARIADIC ARRAY[1])",
+    ] {
+        assert_eq!(
+            ParserError::ParserError(
+                "A VARIADIC argument cannot be combined with DISTINCT or ALL".to_string()
+            ),
+            dialects.parse_sql_statements(sql).unwrap_err(),
+            "{sql}"
+        );
+    }
+
+    // The rejection points at the duplicate treatment it names, even when
+    // earlier arguments precede the marker.
+    assert_eq!(
+        ParserError::ParserError(
+            "A VARIADIC argument cannot be combined with DISTINCT or ALL at Line: 1, Column: 14"
+                .to_string()
+        ),
+        Parser::parse_sql(
+            &PostgreSqlDialect {},
+            "SELECT count(DISTINCT a, VARIADIC b)"
+        )
+        .unwrap_err()
+    );
+
+    // A column of that name still may, where the keyword is unreserved.
+    all_dialects_where(|d| {
+        d.supports_variadic_function_argument() && !d.is_reserved_for_identifier(Keyword::VARIADIC)
+    })
+    .verified_stmt("SELECT count(DISTINCT variadic)");
+}
+
+/// Dialects that accept the marker without reserving `VARIADIC`, such as
+/// `GenericDialect`, must still read `variadic` as an ordinary identifier
+/// wherever it stands as an argument on its own.
+#[test]
+fn parse_variadic_as_identifier_function_argument() {
+    let dialects = all_dialects_where(|d| {
+        d.supports_variadic_function_argument() && !d.is_reserved_for_identifier(Keyword::VARIADIC)
+    });
+    for sql in [
+        "SELECT f(variadic)",
+        "SELECT f(variadic, x)",
+        "SELECT f(x, variadic)",
+        "SELECT f(variadic + 1)",
+        "SELECT f(variadic.x)",
+        "SELECT f(variadic[1])",
+        "SELECT f(variadic(1))",
+        "SELECT f(variadic AS x)",
+        "SELECT f(variadic WHERE x)",
+        "SELECT f(variadic LIMIT 1)",
+        "SELECT array_agg(variadic ORDER BY x)",
+        "SELECT count(variadic) FROM t WHERE variadic IS NULL",
+    ] {
+        dialects.verified_stmt(sql);
+    }
+
+    // Display alone cannot tell `Unnamed(variadic + 1)` from
+    // `Variadic(Unnamed(+1))` apart from spelling, so assert the shape.
+    for (sql, expected) in [
+        (
+            "SELECT f(variadic)",
+            FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Identifier(Ident::new(
+                "variadic",
+            )))),
+        ),
+        (
+            "SELECT f(variadic + 1)",
+            FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("variadic"))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expr::value(number("1"))),
+            })),
+        ),
+    ] {
+        let select = dialects.verified_only_select(sql);
+        match expr_from_projection(only(&select.projection)) {
+            Expr::Function(Function {
+                args: FunctionArguments::List(FunctionArgumentList { args, .. }),
+                ..
+            }) => assert_eq!(&vec![expected], args),
+            other => panic!("Expected a function call, found {other:?}"),
+        }
+    }
+
+    // The marker still applies when the ordinary reading cannot stand alone.
+    dialects.verified_stmt("SELECT f(VARIADIC a)");
+}
+
+#[test]
+fn parse_pg_publication_tables_view_definition() {
+    // `pg_get_viewdef('pg_publication_tables'::regclass, true)` on PostgreSQL 18.
+    let sql = r#"
+SELECT p.pubname,
+    n.nspname AS schemaname,
+    c.relname AS tablename,
+    ( SELECT array_agg(a.attname ORDER BY a.attnum) AS array_agg
+           FROM pg_attribute a
+          WHERE a.attrelid = gpt.relid AND (a.attnum = ANY (gpt.attrs::smallint[]))) AS attnames,
+    pg_get_expr(gpt.qual, gpt.relid) AS rowfilter
+   FROM pg_publication p,
+    LATERAL pg_get_publication_tables(VARIADIC ARRAY[p.pubname::text]) gpt(pubid, relid, attrs, qual),
+    pg_class c
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.oid = gpt.relid
+"#;
+    let mut statements = pg().parse_sql_statements(sql).unwrap();
+    assert_eq!(1, statements.len());
+    let statement = statements.pop().unwrap();
+    let reparsed = pg().parse_sql_statements(&statement.to_string()).unwrap();
+    assert_eq!(vec![statement], reparsed);
 }


### PR DESCRIPTION
`PostgreSqlDialect` could not parse the `VARIADIC` argument marker in a function call, in any position:

```rust
Parser::parse_sql(&PostgreSqlDialect {}, "SELECT concat(VARIADIC a)");
// Err: sql parser error: Expected: ), found: a at Line: 1, Column: 24
```

The marker is added as `FunctionArg::Variadic`. Parsing is gated on `Dialect::supports_variadic_function_argument`, enabled for `PostgreSQL` and the generic dialect.

As in `PostgreSQL`, the marker is rejected on a wildcard operand, in combination with `DISTINCT` or `ALL`, and on any but the final argument.