### PR TITLE
Postgres: Fix parsing of COLLATE after :: cast

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4178,6 +4178,13 @@ impl<'a> Parser<'a> {
                         self.expected_ref("OF after MEMBER", self.peek_token_ref())
                     }
                 }
+                // Reached when the dialect assigns `COLLATE` a lower precedence than `::`, e.g.
+                // Postgres's `expr::type COLLATE collation`.
+                // See <https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE>
+                Keyword::COLLATE => Ok(Expr::Collate {
+                    expr: Box::new(expr),
+                    collation: self.parse_object_name(false)?,
+                }),
                 // Can only happen if `get_next_precedence` got out of sync with this function
                 _ => parser_err!(
                     format!("No infix parser for token {:?}", tok.token),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -519,6 +519,19 @@ fn parse_cast_in_default_expr() {
     pg().verified_stmt("CREATE TABLE t (c TEXT DEFAULT (foo())::TEXT NOT NULL)");
 }
 
+/// `::` binds tighter than `COLLATE`, so `expr::type COLLATE collation` collates the cast result.
+/// See <https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE>
+#[test]
+fn parse_collate_after_cast() {
+    match pg().verified_expr(r#"contact_name::TEXT COLLATE "POSIX""#) {
+        Expr::Collate { expr, collation } => {
+            assert!(matches!(*expr, Expr::Cast { .. }));
+            assert_eq!(collation.to_string(), "\"POSIX\"");
+        }
+        other => panic!("Expected Expr::Collate, got: {other:?}"),
+    }
+}
+
 #[test]
 fn parse_create_table_from_pg_dump() {
     let sql = "CREATE TABLE public.customer (


### PR DESCRIPTION
Fixes parsing of queries like:
```sql
SELECT contact_name::text COLLATE "POSIX", * FROM customers;
```
which previously failed with `No infix parser for token Word(Word { value: "COLLATE", ... })`.

Per [Postgres operator precedence](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE), `::` binds tighter than `COLLATE`, so `PostgreSqlDialect::get_next_precedence` already assigns `COLLATE` a (lower) precedence relative to `::`. However, `Parser::parse_infix` had no case for the `COLLATE` keyword, so once the precedence-driven loop reached it, parsing failed. This adds the missing `Keyword::COLLATE` arm to build an `Expr::Collate` wrapping the already-parsed (e.g. cast) expression.

Added a unit test (`parse_collate_after_cast`) verifying `contact_name::TEXT COLLATE "POSIX"` parses to `Expr::Collate { expr: Expr::Cast { .. }, .. }`.