### PR TITLE
Postgres: Support aliases for JOIN USING

### DIFF
--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -2701,6 +2701,9 @@ impl fmt::Display for Join {
                         JoinConstraint::Using(attrs) => {
                             write!(f, " USING({})", display_comma_separated(attrs))
                         }
+                        JoinConstraint::UsingAlias(columns, alias) => {
+                            write!(f, " USING({}) AS {alias}", display_comma_separated(columns))
+                        }
                         _ => Ok(()),
                     }
                 }
@@ -2890,6 +2893,8 @@ pub enum JoinConstraint {
     On(Expr),
     /// `USING(...)` list of column names.
     Using(Vec<ObjectName>),
+    /// `USING(...) AS alias` list of column names with an alias for the joined columns.
+    UsingAlias(Vec<ObjectName>, Ident),
     /// `NATURAL` join (columns matched automatically).
     Natural,
     /// No constraint specified (e.g. `CROSS JOIN`).

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -2304,6 +2304,12 @@ impl Spanned for JoinConstraint {
         match self {
             JoinConstraint::On(expr) => expr.span(),
             JoinConstraint::Using(vec) => union_spans(vec.iter().map(|i| i.span())),
+            JoinConstraint::UsingAlias(columns, alias) => union_spans(
+                columns
+                    .iter()
+                    .map(|i| i.span())
+                    .chain(iter::once(alias.span)),
+            ),
             JoinConstraint::Natural => Span::empty(),
             JoinConstraint::None => Span::empty(),
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17738,7 +17738,14 @@ impl<'a> Parser<'a> {
             Ok(JoinConstraint::On(constraint))
         } else if self.parse_keyword(Keyword::USING) {
             let columns = self.parse_parenthesized_qualified_column_list(Mandatory, false)?;
-            Ok(JoinConstraint::Using(columns))
+            if self.parse_keyword(Keyword::AS) {
+                Ok(JoinConstraint::UsingAlias(
+                    columns,
+                    self.parse_identifier()?,
+                ))
+            } else {
+                Ok(JoinConstraint::Using(columns))
+            }
         } else {
             Ok(JoinConstraint::None)
             //self.expected_ref("ON, or USING after JOIN", self.peek_token_ref())

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -9918,3 +9918,11 @@ fn parse_non_reserved_keywords_as_table_alias() {
         ));
     }
 }
+
+#[test]
+fn parse_join_using_alias() {
+    pg().one_statement_parses_to(
+        "SELECT * FROM t1 JOIN t2 USING (id) AS joined_cols",
+        "SELECT * FROM t1 JOIN t2 USING(id) AS joined_cols",
+    );
+}


### PR DESCRIPTION
Support PostgreSQL's optional alias on JOIN USING columns, e.g. `JOIN t2 USING (id) AS joined_cols`.

PostgreSQL documents this as `USING ( join_column [, ...] ) [ AS join_using_alias ]`: https://www.postgresql.org/docs/current/sql-select.html

Implementation notes:
- Preserve the existing `JoinConstraint::Using(Vec<ObjectName>)` variant for joins without aliases.
- Add `JoinConstraint::UsingAlias(Vec<ObjectName>, Ident)` for the alias form.
- Add a minimal PostgreSQL regression test.

AI assistance was used to prepare this change.
