### PR TITLE
Postgres: Support SUBSTRING SIMILAR/ESCAPE syntax and reversed FOR/FROM order

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1188,12 +1188,16 @@ pub enum Expr {
     /// ```sql
     /// SUBSTRING(<expr>, <expr>, <expr>)
     /// ```
+    /// or
+    /// ```sql
+    /// SUBSTRING(<expr> SIMILAR <expr> ESCAPE <expr>)
+    /// ```
     Substring {
         /// Source expression.
         expr: Box<Expr>,
-        /// Optional `FROM` expression.
+        /// Optional `FROM`/`SIMILAR` expression.
         substring_from: Option<Box<Expr>>,
-        /// Optional `FOR` expression.
+        /// Optional `FOR`/`ESCAPE` expression.
         substring_for: Option<Box<Expr>>,
 
         /// false if the expression is represented using the `SUBSTRING(expr [FROM start] [FOR len])` syntax
@@ -1204,6 +1208,11 @@ pub enum Expr {
         /// true if the expression is represented using the `SUBSTR` shorthand
         /// This flag is used for formatting.
         shorthand: bool,
+
+        /// true if the expression uses the `SUBSTRING(expr SIMILAR pattern ESCAPE escape)` syntax,
+        /// in which case `substring_from` holds the pattern and `substring_for` holds the escape.
+        /// This flag is used for formatting.
+        similar: bool,
     },
     /// ```sql
     /// TRIM([BOTH | LEADING | TRAILING] [<expr> FROM] <expr>)
@@ -2135,6 +2144,7 @@ impl fmt::Display for Expr {
                 substring_for,
                 special,
                 shorthand,
+                similar,
             } => {
                 f.write_str("SUBSTR")?;
                 if !*shorthand {
@@ -2144,6 +2154,8 @@ impl fmt::Display for Expr {
                 if let Some(from_part) = substring_from {
                     if *special {
                         write!(f, ", {from_part}")?;
+                    } else if *similar {
+                        write!(f, " SIMILAR {from_part}")?;
                     } else {
                         write!(f, " FROM {from_part}")?;
                     }
@@ -2151,6 +2163,8 @@ impl fmt::Display for Expr {
                 if let Some(for_part) = substring_for {
                     if *special {
                         write!(f, ", {for_part}")?;
+                    } else if *similar {
+                        write!(f, " ESCAPE {for_part}")?;
                     } else {
                         write!(f, " FOR {for_part}")?;
                     }

--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -1629,6 +1629,7 @@ impl Spanned for Expr {
                 substring_for,
                 special: _,
                 shorthand: _,
+                similar: _,
             } => union_spans(
                 core::iter::once(expr.span())
                     .chain(substring_from.as_ref().map(|i| i.span()))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3031,6 +3031,9 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse `SUBSTRING`/`SUBSTR` expressions: `SUBSTRING(expr FROM start FOR length)` or `SUBSTR(expr, start, length)`.
+    /// Also supports the Postgres `SUBSTRING(expr SIMILAR pattern ESCAPE escape)` syntax and the
+    /// reversed `SUBSTRING(expr FOR length FROM start)` argument order.
+    /// See <https://www.postgresql.org/docs/current/functions-string.html>.
     pub fn parse_substring(&mut self) -> Result<Expr, ParserError> {
         let shorthand = match self.expect_one_of_keywords(&[Keyword::SUBSTR, Keyword::SUBSTRING])? {
             Keyword::SUBSTR => true,
@@ -3041,7 +3044,25 @@ impl<'a> Parser<'a> {
             }
         };
         self.expect_token(&Token::LParen)?;
-        let expr = self.parse_expr()?;
+        // Parse at `LIKE` precedence so a bare `SIMILAR` isn't swallowed as the start of a
+        // `SIMILAR TO` operator, allowing it to be recognized as the substring syntax below.
+        let expr = self.parse_subexpr(self.dialect.prec_value(Precedence::Like))?;
+
+        if self.parse_keyword(Keyword::SIMILAR) {
+            let from_expr = self.parse_expr()?;
+            self.expect_keyword_is(Keyword::ESCAPE)?;
+            let to_expr = self.parse_expr()?;
+            self.expect_token(&Token::RParen)?;
+            return Ok(Expr::Substring {
+                expr: Box::new(expr),
+                substring_from: Some(Box::new(from_expr)),
+                substring_for: Some(Box::new(to_expr)),
+                special: false,
+                shorthand,
+                similar: true,
+            });
+        }
+
         let mut from_expr = None;
         let special = self.consume_token(&Token::Comma);
         if special || self.parse_keyword(Keyword::FROM) {
@@ -3051,6 +3072,10 @@ impl<'a> Parser<'a> {
         let mut to_expr = None;
         if self.parse_keyword(Keyword::FOR) || self.consume_token(&Token::Comma) {
             to_expr = Some(self.parse_expr()?);
+            // Postgres also allows `FOR <count> FROM <start>`, i.e. the reverse order.
+            if from_expr.is_none() && !special && self.parse_keyword(Keyword::FROM) {
+                from_expr = Some(self.parse_expr()?);
+            }
         }
         self.expect_token(&Token::RParen)?;
 
@@ -3060,6 +3085,7 @@ impl<'a> Parser<'a> {
             substring_for: to_expr.map(Box::new),
             special,
             shorthand,
+            similar: false,
         })
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -8425,6 +8425,11 @@ fn parse_substring() {
     verified_stmt("SELECT SUBSTRING('foo' FROM 1 FOR 2) FROM t");
     verified_stmt("SELECT SUBSTR('foo' FROM 1 FOR 2) FROM t");
     verified_stmt("SELECT SUBSTR('foo', 1, 2) FROM t");
+    verified_stmt("SELECT SUBSTRING('1' SIMILAR '_' ESCAPE '#')");
+    one_statement_parses_to(
+        "SELECT SUBSTRING('1' FOR 3 FROM 1)",
+        "SELECT SUBSTRING('1' FROM 1 FOR 3)",
+    );
 }
 
 #[test]

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -1370,6 +1370,7 @@ fn parse_substring_in_select() {
                             ))),
                             special: true,
                             shorthand: false,
+                            similar: false,
                         })],
                         exclude: None,
                         into: None,

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -3369,6 +3369,7 @@ fn parse_substring_in_select() {
                             ))),
                             special: true,
                             shorthand: false,
+                            similar: false,
                         })],
                         exclude: None,
                         into: None,


### PR DESCRIPTION
Fixes parsing of two legal Postgres `SUBSTRING` forms:

- `SUBSTRING('hello world' FOR 5 FROM 1)` (`FOR` before `FROM`)
- `SUBSTRING('hello world' SIMILAR '%#"o w#"%' ESCAPE '#')`

See https://www.postgresql.org/docs/current/functions-string.html

Both previously failed with a parser error. Adds a `similar` flag to `Expr::Substring` to track the `SIMILAR ... ESCAPE` display form, and allows `FOR` to be parsed before `FROM` (normalized to `FROM ... FOR` on output).

Generated with AI assistance (GitHub Copilot).