### PR TITLE
Add NOTICE file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ include = [
     "src/**/*.rs",
     "Cargo.toml",
     "LICENSE.TXT",
+    "NOTICE.TXT",
 ]
 edition = "2021"
 

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -1,0 +1,5 @@
+Apache DataFusion sqlparser-rs
+Copyright 2024-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Adds the `NOTICE.TXT` file required for ASF source releases, and includes it in the crates.io package.

- Part of #2495