### PR TITLE
Snowflake: parse ORDER BY ALL

### DIFF
--- a/src/dialect/snowflake.rs
+++ b/src/dialect/snowflake.rs
@@ -153,6 +153,11 @@ impl Dialect for SnowflakeDialect {
         true
     }
 
+    /// See <https://docs.snowflake.com/en/sql-reference/constructs/order-by#syntax>
+    fn supports_order_by_all(&self) -> bool {
+        true
+    }
+
     // Snowflake supports double-dot notation when the schema name is not specified
     // In this case the default PUBLIC schema is used
     //

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -45,6 +45,19 @@ fn test_snowflake_create_table() {
 }
 
 #[test]
+fn parse_order_by_all() {
+    let query = snowflake()
+        .verified_query("SELECT value + 1 AS computed FROM source ORDER BY ALL DESC NULLS FIRST");
+    assert_eq!(
+        query.order_by.expect("ORDER BY expected").kind,
+        OrderByKind::All(OrderByOptions {
+            sort: Some(OrderBySort::Desc),
+            nulls_first: Some(true),
+        })
+    );
+}
+
+#[test]
 fn parse_sf_create_secure_view_and_materialized_view() {
     for sql in [
         "CREATE SECURE VIEW v AS SELECT 1",


### PR DESCRIPTION
`ORDER BY ALL` is supported by Snowflake and is already represented by the shared `OrderByKind::All` AST/parser path. This PR enables that existing capability for `SnowflakeDialect`.

The dialect-specific regression test covers a computed select expression together with `DESC NULLS FIRST`; the shared `parse_select_order_by_all` test also begins exercising Snowflake for every supported option combination.

Reference: https://docs.snowflake.com/en/sql-reference/constructs/order-by

Validation:
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test --test sqlparser_snowflake parse_order_by_all`
- `cargo +1.95.0 test --test sqlparser_common parse_select_order_by_all`
- `cargo +1.95.0 clippy --all-targets -- -D warnings`